### PR TITLE
Rename host and port cli arguments

### DIFF
--- a/server/bleep/src/lib.rs
+++ b/server/bleep/src/lib.rs
@@ -149,15 +149,15 @@ pub struct Configuration {
     /// Maximum number of parallel background threads
     pub max_threads: usize,
 
-    #[clap(short, long, default_value_t = default_host())]
+    #[clap(long, default_value_t = default_host())]
     #[serde(default = "default_host")]
     /// Bind the webserver to `<port>`
-    pub webserver_host: String,
+    pub host: String,
 
-    #[clap(short, long, default_value_t = default_port())]
+    #[clap(long, default_value_t = default_port())]
     #[serde(default = "default_port")]
     /// Bind the webserver to `<host>`
-    pub webserver_port: u16,
+    pub port: u16,
 
     #[clap(long)]
     #[serde(serialize_with = "state::serialize_secret_opt_str", default)]

--- a/server/bleep/src/webserver.rs
+++ b/server/bleep/src/webserver.rs
@@ -29,10 +29,7 @@ pub(in crate::webserver) mod prelude {
 }
 
 pub async fn start(app: Application) -> Result<()> {
-    let bind = SocketAddr::new(
-        app.config.webserver_host.parse()?,
-        app.config.webserver_port,
-    );
+    let bind = SocketAddr::new(app.config.host.parse()?, app.config.port);
 
     let mut router = Router::new()
         // querying


### PR DESCRIPTION
Rename from `webserver-host` and `webserver-port` to `host` and `port`. Remove short argument names to stop conflict.