### PR TITLE
Start with telemetry popup

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -7,6 +7,7 @@ import { homeDir } from '@tauri-apps/api/path';
 import { open as openDialog } from '@tauri-apps/api/dialog';
 import { listen } from '@tauri-apps/api/event';
 import * as tauriOs from '@tauri-apps/api/os';
+import { getVersion } from '@tauri-apps/api/app';
 
 function App() {
   const [homeDirectory, setHomeDir] = useState('');
@@ -18,6 +19,7 @@ function App() {
     platform: '',
     version: '',
   });
+  const [release, setRelease] = useState('');
 
   useEffect(() => {
     homeDir().then(setHomeDir);
@@ -33,8 +35,10 @@ function App() {
       tauriOs.type(),
       tauriOs.platform(),
       tauriOs.version(),
-    ]).then(([arch, type, platform, version]) => {
+      getVersion(),
+    ]).then(([arch, type, platform, version, appVersion]) => {
       setOs({ arch, type, platform, version });
+      setRelease(appVersion);
     });
   }, []);
 
@@ -54,8 +58,9 @@ function App() {
       listen,
       os,
       invokeTauriCommand: invoke,
+      release,
     }),
-    [homeDirectory, indexFolder, deviceId, os],
+    [homeDirectory, indexFolder, deviceId, os, release],
   );
   return <ClientApp deviceContextValue={deviceContextValue} />;
 }

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -1,9 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import { initializeSentry } from '@bloop/client/src/utils/services';
 import App from './App';
-
-initializeSentry();
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>

--- a/client/package.json
+++ b/client/package.json
@@ -1,11 +1,10 @@
 {
   "name": "@bloop/client",
   "private": true,
-  "version": "0.0.0",
+  "version": "0.1.0",
   "exports": {
     "./src/App": "./src/App.tsx",
     "./src/index.css": "./src/index.css",
-    "./src/utils/services": "./src/utils/services.ts",
     "./postcss": "./postcss.config.cjs",
     "./tailwind.config": "./tailwind.config.cjs"
   },

--- a/client/src/context/deviceContext.ts
+++ b/client/src/context/deviceContext.ts
@@ -21,6 +21,7 @@ export type DeviceContextType = {
     version: string;
   };
   invokeTauriCommand: (c: string, payload?: any) => void;
+  release: string;
 };
 
 export const DeviceContext = createContext<DeviceContextType>({
@@ -37,4 +38,5 @@ export const DeviceContext = createContext<DeviceContextType>({
     version: '',
   },
   invokeTauriCommand: () => {},
+  release: '0.0.0',
 });

--- a/client/src/context/providers/DeviceContextProvider.tsx
+++ b/client/src/context/providers/DeviceContextProvider.tsx
@@ -1,7 +1,8 @@
 import { PropsWithChildren, useContext, useEffect } from 'react';
+import * as Sentry from '@sentry/react';
 import { DeviceContext, DeviceContextType } from '../deviceContext';
 import { AnalyticsContext } from '../analyticsContext';
-import { telemetryAllowed } from '../../utils/services';
+import { initializeSentry } from '../../utils/services';
 
 type Props = {
   deviceContextValue: DeviceContextType;
@@ -17,7 +18,14 @@ export const DeviceContextProvider = ({
     deviceContextValue.invokeTauriCommand(
       isAnalyticsAllowed ? 'enable_telemetry' : 'disable_telemetry',
     );
-    telemetryAllowed.value = isAnalyticsAllowed;
+    if (isAnalyticsAllowed) {
+      initializeSentry(deviceContextValue.release);
+    } else {
+      const client = Sentry.getCurrentHub().getClient();
+      if (client) {
+        client.close();
+      }
+    }
   }, [isAnalyticsAllowed, deviceContextValue.invokeTauriCommand]);
 
   return (

--- a/client/src/hooks/useGitHubAuth.ts
+++ b/client/src/hooks/useGitHubAuth.ts
@@ -30,9 +30,6 @@ export const useGitHubAuth = (
         }
         setLoginUrl(data.authentication_needed.url);
         setCode(data.authentication_needed.code);
-        copyToClipboard(data.authentication_needed.code);
-        setCodeCopied(true);
-        setTimeout(() => setCodeCopied(false), 2000);
       });
     }
   }, [disabled]);

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -1,9 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import packageJson from '../package.json';
 import App from './App';
-import { initializeSentry } from './utils/services';
-
-initializeSentry();
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
@@ -22,6 +20,7 @@ ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
           version: '',
         },
         invokeTauriCommand: () => {},
+        release: packageJson.version,
       }}
     />
   </React.StrictMode>,

--- a/client/src/pages/Home/Onboarding/index.tsx
+++ b/client/src/pages/Home/Onboarding/index.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useContext, useEffect, useState } from 'react';
 import { UIContext } from '../../../context/uiContext';
+import TelemetryPopup from '../TelemetryPopup';
 import Step0 from './Step0';
 import Step1 from './Step1';
 import Step2 from './Step2';
@@ -13,6 +14,11 @@ type Props = {
 const Onboarding = ({ onFinish }: Props) => {
   const [step, setStep] = useState(0);
   const { onBoardingState } = useContext(UIContext);
+  const [shouldShowTelemetry, setShouldShowTelemetry] = useState(true);
+
+  const closeTelemetry = useCallback(() => {
+    setShouldShowTelemetry(false);
+  }, []);
 
   useEffect(() => {
     if (step === 5) {
@@ -31,31 +37,37 @@ const Onboarding = ({ onFinish }: Props) => {
   return (
     <div className="fixed top-0 bottom-0 left-0 right-0 my-16 bg-[url('/onboarding-background.png')] bg-cover">
       <div className="absolute top-0 bottom-0 left-0 right-0 flex justify-center items-start overflow-auto bg-gray-900 bg-opacity-75">
-        <div className="flex flex-col items-center">
-          <div className="mt-8 bg-gray-900 border border-gray-800 rounded-lg shadow-big p-6 flex flex-col gap-8 max-w-md2 w-full relative max-h-[calc(100vh-12rem)]">
-            {step === 0 ? (
-              <Step0 handleNext={handleNext} />
-            ) : step === 1 ? (
-              <Step1 handleNext={handleNext} handleBack={handlePrev} />
-            ) : step === 2 ? (
-              <Step2 handleNext={handleNext} handleBack={handlePrev} />
-            ) : step === 3 ? (
-              <Step3
-                handleNext={handleNext}
-                handleBack={(e) =>
-                  handlePrev(e, onBoardingState.indexFolder ? 1 : 2)
-                }
-              />
-            ) : step === 4 ? (
-              <Step4
-                handleNext={handleNext}
-                handleBack={(e) =>
-                  handlePrev(e, onBoardingState.indexFolder ? 2 : 3)
-                }
-              />
-            ) : null}
+        <TelemetryPopup
+          onClose={closeTelemetry}
+          visible={shouldShowTelemetry}
+        />
+        {!shouldShowTelemetry && (
+          <div className="flex flex-col items-center">
+            <div className="mt-8 bg-gray-900 border border-gray-800 rounded-lg shadow-big p-6 flex flex-col gap-8 max-w-md2 w-full relative max-h-[calc(100vh-12rem)]">
+              {step === 0 ? (
+                <Step0 handleNext={handleNext} />
+              ) : step === 1 ? (
+                <Step1 handleNext={handleNext} handleBack={handlePrev} />
+              ) : step === 2 ? (
+                <Step2 handleNext={handleNext} handleBack={handlePrev} />
+              ) : step === 3 ? (
+                <Step3
+                  handleNext={handleNext}
+                  handleBack={(e) =>
+                    handlePrev(e, onBoardingState.indexFolder ? 1 : 2)
+                  }
+                />
+              ) : step === 4 ? (
+                <Step4
+                  handleNext={handleNext}
+                  handleBack={(e) =>
+                    handlePrev(e, onBoardingState.indexFolder ? 2 : 3)
+                  }
+                />
+              ) : null}
+            </div>
           </div>
-        </div>
+        )}
       </div>
     </div>
   );

--- a/client/src/pages/Home/index.tsx
+++ b/client/src/pages/Home/index.tsx
@@ -34,13 +34,8 @@ const HomePage = ({ emptyRepos }: Props) => {
   const [shouldShowWelcome, setShouldShowWelcome] = useState(
     !getPlainFromStorage(ONBOARDING_DONE_KEY),
   );
-  const [shouldShowTelemetry, setShouldShowTelemetry] = useState(false);
   const [filter, setFilter] = useState(0);
   const { setInputValue } = useContext(SearchContext);
-
-  const closeTelemetry = useCallback(() => {
-    setShouldShowTelemetry(false);
-  }, []);
 
   useEffect(() => {
     if (import.meta.env.VITE_ONBOARDING) {
@@ -60,7 +55,6 @@ const HomePage = ({ emptyRepos }: Props) => {
     setShouldShowWelcome(false);
     onboardingFinished = true; // to avoid showing onboarding twice per session when using VITE_ONBOARDING=true
     savePlainToStorage(ONBOARDING_DONE_KEY, 'true');
-    setTimeout(() => setShouldShowTelemetry(true), 2000);
   }, []);
 
   return (
@@ -76,10 +70,6 @@ const HomePage = ({ emptyRepos }: Props) => {
           <Onboarding onFinish={closeOnboarding} />
         ) : (
           <>
-            <TelemetryPopup
-              onClose={closeTelemetry}
-              visible={shouldShowTelemetry}
-            />
             <div className="w-90 text-gray-300 border-r border-gray-800 flex-shrink-0 h-full">
               <ListNavigation
                 title=" "

--- a/client/src/utils/services.ts
+++ b/client/src/utils/services.ts
@@ -7,18 +7,8 @@ import {
   useLocation,
   useNavigationType,
 } from 'react-router-dom';
-import {
-  getPlainFromStorage,
-  IS_ANALYTICS_ALLOWED_KEY,
-} from '../services/storage';
 
-export const telemetryAllowed = {
-  value: getPlainFromStorage(IS_ANALYTICS_ALLOWED_KEY) === 'true',
-};
-
-const getIsTelemetryAllowed = () => telemetryAllowed.value;
-
-export const initializeSentry = () => {
+export const initializeSentry = (release: string) => {
   Sentry.init({
     dsn: 'https://79266c6b7c1e4fbca430019e2acaf941@o4504254520426496.ingest.sentry.io/4504275760775168',
     integrations: [
@@ -33,23 +23,7 @@ export const initializeSentry = () => {
       }),
     ],
     environment: import.meta.env.MODE,
-    release: '0.0.0',
-    beforeSend: (event, hint) => {
-      if (!getIsTelemetryAllowed()) {
-        return null;
-      }
-      return event;
-    },
-    beforeSendTransaction: (event, hint) => {
-      if (!getIsTelemetryAllowed()) {
-        return null;
-      }
-      return event;
-    },
-    tracesSampleRate: !getIsTelemetryAllowed()
-      ? 0
-      : import.meta.env.MODE === 'development'
-      ? 1.0
-      : 0.1,
+    release,
+    tracesSampleRate: import.meta.env.MODE === 'development' ? 1.0 : 0.1,
   });
 };


### PR DESCRIPTION
When being initialized Sentry makes an API request to the Sentry server which is unwanted before the user gives their consent. Solution: Before showing the onboarding flow show the Telemetry popup and ask the user for their consent; when the user changes permissions close the current Sentry client or reinitialize it depending on the choice. Also, pass the release version to Sentry when initializing it.
Minor bug fix: copying text to the clipboard doesn't work if the user doesn't click on a button, so this function call is removed now and shouldn't throw an error in the console.