### PR TITLE
Interpret escape characters, and remove triple quoted literals

### DIFF
--- a/server/bleep/src/query/grammar.pest
+++ b/server/bleep/src/query/grammar.pest
@@ -5,7 +5,6 @@ element = ${ label | mode | literal | group }
 literal = _{ !(or ~ terminator) ~ (
                  (quote ~ quoted_literal ~ quote)
                | (single_quote ~ single_quoted_literal ~ single_quote)
-               | (triple_quote ~ triple_quoted_literal ~ triple_quote)
                | (regex_quote ~ regex_quoted_literal ~ regex_quote)
                | unquoted_literal
              )
@@ -13,14 +12,12 @@ literal = _{ !(or ~ terminator) ~ (
 
 quote = _{ "\"" }
 single_quote = _{ "'" }
-triple_quote = _{ "'''" }
 regex_quote = _{ "/" }
 terminator = @{ group_start | group_end | WHITESPACE }
 
 unquoted_literal = @{ (!terminator ~ ANY)+ ~ (escape ~ unquoted_literal)? }
 quoted_literal   = @{ (!(quote | "\\") ~ ANY)* ~ (escape ~ quoted_literal)? }
 single_quoted_literal = @{ (!(single_quote | "\\") ~ ANY)* ~ (escape ~ single_quoted_literal)? }
-triple_quoted_literal = @{ (!(triple_quote | "\\") ~ ANY)* ~ (escape ~ triple_quoted_literal)? }
 regex_quoted_literal  = @{ (!(regex_quote | "\\") ~ ANY)* ~ (escape ~ regex_quoted_literal)? }
 
 escape  = @{ "\\" ~ ANY }


### PR DESCRIPTION
There are three escape characters interpreted per literal type: newlines, tabs, and the closing delimiter. This fixes regex queries containing a `/` character, and plain text queries containing single or double quotes respectively.

Triple quoted strings were also removed.