### PR TITLE
Add histogram-based logging for long-running files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -342,6 +342,7 @@ dependencies = [
  "flume",
  "futures",
  "git2",
+ "histogram",
  "hyperpolyglot",
  "ignore",
  "notify-debouncer-mini",
@@ -1915,6 +1916,12 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "histogram"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12cb882ccb290b8646e554b157ab0b71e64e8d5bef775cd66b6531e52d302669"
 
 [[package]]
 name = "hostname"

--- a/server/bleep/Cargo.toml
+++ b/server/bleep/Cargo.toml
@@ -25,35 +25,26 @@ name = "queries"
 harness = false
 
 [dependencies]
+
+# core
 tantivy = { version = "0.18.1", features = ["mmap"] }
 tokio = { version = "1.21.2", features = ["macros", "process", "rt", "rt-multi-thread", "io-std", "io-util", "sync", "fs"] }
+futures = "0.3.25"
 rayon = "1.6.0"
 clap = { version = "4.0.26", features = ["derive"] }
-tower-http = {version = "0.3.4", features = ["cors", "catch-panic"]}
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.16", features = ["env-filter", "registry"] }
 color-eyre = "0.6.2"
 
-# for debugging tokio
+# for debugging
 console-subscriber = { version = "0.1.8", optional = true }
+histogram = { version = "0.6.9", optional = true }
 
+# error handling
 anyhow = "1.0.66"
 thiserror = "1.0.37"
 
-ignore = "0.4.18"
-flume = "0.10.14"
-serde_json = "1.0.87"
-blake3 = "1.3.1"
-futures = "0.3.25"
-axum = { version = "0.5.17", features = ["http2"] }
-serde = "1.0.147"
-regex = "1.7.0"
-regex-syntax = "0.6.28"
-smallvec = { version = "1.10.0", features = ["serde"]}
-hyperpolyglot = "0.1.7"
-async-trait = "0.1.58"
-utoipa = { version = "2.3.0", features = ["axum_extras", "yaml"] }
-
+# query parsing
 pest = "2.4.1"
 pest_derive = "2.4.1"
 
@@ -70,10 +61,32 @@ tree-sitter-java = { git = "https://github.com/tree-sitter/tree-sitter-java", ta
 tree-sitter-cpp = { git = "https://github.com/tree-sitter/tree-sitter-cpp", rev = "5ead1e2" }
 petgraph = { version = "0.6.2", default-features = false, features = ["serde-1"] }
 
-dashmap = { version = "5.4.0", features = ["serde"] }
+# webserver
+serde_json = "1.0.87"
+utoipa = { version = "2.3.0", features = ["axum_extras", "yaml"] }
+axum = { version = "0.5.17", features = ["http2"] }
+tower-http = {version = "0.3.4", features = ["cors", "catch-panic"]}
+
+# api integrations
 octocrab = { git = "https://github.com/bloopai/octocrab", features = ["rustls"] }
 reqwest = { version = "0.11.13", features = ["rustls-tls", "rustls"], default-features = false }
 secrecy = { version = "0.8.0", features = ["serde"] }
+
+# file processing
+ignore = "0.4.18"
+hyperpolyglot = "0.1.7"
+blake3 = "1.3.1"
+notify-debouncer-mini = { version = "0.2.1", default-features = false }
+
+# misc
+git2 = "0.15.0"
+serde = "1.0.147"
+regex = "1.7.0"
+regex-syntax = "0.6.28"
+smallvec = { version = "1.10.0", features = ["serde"]}
+async-trait = "0.1.58"
+flume = "0.10.14"
+dashmap = { version = "5.4.0", features = ["serde"] }
 either = "1.8.0"
 compact_str = "0.6.1"
 bincode = "1.3.3"
@@ -82,12 +95,9 @@ chrono = { version = "0.4.23", features = ["serde"], default-features = false }
 phf = "0.11.1"
 rand = "0.8.5"
 once_cell = "1.16.0"
-notify-debouncer-mini = { version = "0.2.1", default-features = false }
 replace_with = "0.1.7"
 relative-path = "1.7.2"
-git2 = "0.15.0"
 dunce = "1.0.3"
-histogram = { version = "0.6.9", optional = true }
 
 [dev-dependencies]
 criterion = { version = "0.4.0", features = ["async_tokio"] }

--- a/server/bleep/Cargo.toml
+++ b/server/bleep/Cargo.toml
@@ -7,7 +7,7 @@ build = "build.rs"
 
 [features]
 default = []
-debug = ["console-subscriber"]
+debug = ["console-subscriber", "histogram"]
 
 [[bin]]
 name = "bleep"
@@ -30,8 +30,6 @@ tokio = { version = "1.21.2", features = ["macros", "process", "rt", "rt-multi-t
 rayon = "1.6.0"
 clap = { version = "4.0.26", features = ["derive"] }
 tower-http = {version = "0.3.4", features = ["cors", "catch-panic"]}
-
-# logging
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.16", features = ["env-filter", "registry"] }
 color-eyre = "0.6.2"
@@ -89,6 +87,7 @@ replace_with = "0.1.7"
 relative-path = "1.7.2"
 git2 = "0.15.0"
 dunce = "1.0.3"
+histogram = { version = "0.6.9", optional = true }
 
 [dev-dependencies]
 criterion = { version = "0.4.0", features = ["async_tokio"] }

--- a/server/bleep/src/indexes/file.rs
+++ b/server/bleep/src/indexes/file.rs
@@ -456,6 +456,7 @@ impl File {
 
         trace!("writing document");
 
+        #[cfg(feature = "debug")]
         let buf_size = buffer.len();
         writer.add_document(doc!(
             self.repo_disk_path => repo_disk_path.to_string_lossy().as_ref(),

--- a/server/bleep/src/lib.rs
+++ b/server/bleep/src/lib.rs
@@ -14,6 +14,9 @@
 #[cfg(any(bench, test))]
 use criterion as _;
 
+#[cfg(all(feature = "debug", not(tokio_unstable)))]
+use console_subscriber as _;
+
 use crate::{
     indexes::Indexes,
     state::{Credentials, RepositoryPool, StateSource},
@@ -301,7 +304,7 @@ impl Application {
     }
 }
 
-#[cfg(feature = "debug")]
+#[cfg(all(tokio_unstable, feature = "debug"))]
 fn tracing_subscribe() -> bool {
     use tracing_subscriber::{fmt, prelude::*};
     let env_filter = fmt::layer().with_filter(EnvFilter::from_env(LOG_ENV_VAR));
@@ -312,7 +315,7 @@ fn tracing_subscribe() -> bool {
         .is_ok()
 }
 
-#[cfg(not(feature = "debug"))]
+#[cfg(not(all(tokio_unstable, feature = "debug")))]
 fn tracing_subscribe() -> bool {
     use tracing_subscriber::{fmt, prelude::*};
     let env_filter = fmt::layer().with_filter(EnvFilter::from_env(LOG_ENV_VAR));


### PR DESCRIPTION
Add behind the `debug` feature flag an option to log severe outliers during analytics, including file size.

This is useful, because it seems like large files are hogging 1 thread, and can take up to 40s to complete (e.g. Kubernetes has a lot of generated `.go` files of several MiB in size). Identifying outliers will be helpful in addressing the issue.

If this seems useful, we may want to convert this into a default feature, as the runtime impact should be fairly lightweight.