### PR TITLE
Add dummy build-client job to server workflow

### DIFF
--- a/.github/workflows/client-test.yml
+++ b/.github/workflows/client-test.yml
@@ -25,7 +25,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: 'echo "No checks required" '
-  build:
+
+  build-client:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/tauri-test.yml
+++ b/.github/workflows/tauri-test.yml
@@ -16,6 +16,11 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  build-client:
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "No checks required" '
+
   checks:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Allow required `build-client` job to pass on server workflows.