### PR TITLE
Fix empty lines for symbol search

### DIFF
--- a/client/src/components/CodeBlock/Code/CodeLine.tsx
+++ b/client/src/components/CodeBlock/Code/CodeLine.tsx
@@ -138,7 +138,7 @@ const CodeLine = ({
           className={`text-gray-500 min-w-6 text-right select-none pr-0 leading-5 ${getBlameStyle()} ${
             lineHidden ? 'p-0' : ''
           } ${hoverEffect ? 'group-hover:text-gray-300' : ''}
-          before:content-[attr(data-line)]
+           ${lineHidden ? '' : 'before:content-[attr(data-line)]'}
           `}
         ></td>
       )}


### PR DESCRIPTION
Having a ':before' element with line numbers creates an un-collapsable table row, which causes empty lines for symbol search. Solution: add content to before elements only when the line is not hidden.