### PR TITLE
Quicker reporting of repo statuses

### DIFF
--- a/server/bleep/src/remotes.rs
+++ b/server/bleep/src/remotes.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use anyhow::{Context, Result};
+use anyhow::{bail, Context, Result};
 use dashmap::mapref::one::Ref;
 use git2::{Cred, RemoteCallbacks};
 use ignore::WalkBuilder;
@@ -147,6 +147,8 @@ impl BackendCredential {
 
             let existing = app.repo_pool.get_mut(&repo_ref);
             let synced = match existing {
+                // if there's a parallel process already syncing, just return
+                Some(repo) if repo.sync_status == SyncStatus::Syncing => bail!("sync in progress"),
                 Some(mut repo) => {
                     repo.value_mut().sync_status = SyncStatus::Syncing;
                     let repo = repo.downgrade();


### PR DESCRIPTION
This moves syncing outside of the global write lock of tantivy indexes, meaning we can start getting repositories into the pool quicker.

Since the lock is gone, we're required to check the status of the repo and make sure we skip syncing if there's a sync in progress, otherwise chaos would erupt.