### PR TITLE
Fix applying filters on page other than 1

### DIFF
--- a/client/src/pages/Results/index.tsx
+++ b/client/src/pages/Results/index.tsx
@@ -72,7 +72,7 @@ const ResultsPage = () => {
   useEffect(() => {
     if (queryString) {
       setInputValue(queryString);
-      searchQuery(queryString, page, globalRegex);
+      searchQuery(queryString, 0, globalRegex);
       setPage(0);
     }
   }, [queryString]);


### PR DESCRIPTION
When applying a filter while viewing other than the first page, the search is made using the previous page number which leads to erroneous results. Solution: reset pagination when queryString changes (new search was made)