### PR TITLE
Fix highlight ranges

### DIFF
--- a/client/src/components/CodeBlock/Code/index.tsx
+++ b/client/src/components/CodeBlock/Code/index.tsx
@@ -80,8 +80,9 @@ const Code = ({
     }
     const highlightMap: HighlightMap[] = [];
 
-    token.content.split('').forEach((char, index) => {
-      const pos = token.byteRange.start + index;
+    let byteIndex = 0;
+    token.content.split('').forEach((char) => {
+      const pos = token.byteRange.start + byteIndex;
       const existing = highlightMap[highlightMap.length - 1];
 
       if (hlRangesMap.has(pos)) {
@@ -109,6 +110,7 @@ const Code = ({
           existing.token.content += char;
         }
       }
+      byteIndex += new TextEncoder().encode(char).length;
     });
 
     return highlightMap;

--- a/client/src/utils/prism.ts
+++ b/client/src/utils/prism.ts
@@ -106,9 +106,10 @@ const appendRanges = (tokens: Token[][], lineEndings: 'CRLF' | 'LF') => {
   let b = 0;
   return tokens.map((line) => {
     const lt = line.map((token) => {
-      const currRange = { start: b, end: b + token.content.length };
-      if (!token.empty) {
-        b += token.content.length;
+      const tokenLengthInBytes = new TextEncoder().encode(token.content).length;
+      const currRange = { start: b, end: b + tokenLengthInBytes };
+      if (!token.empty && tokenLengthInBytes) {
+        b += tokenLengthInBytes;
       }
       return { ...token, byteRange: currRange };
     });


### PR DESCRIPTION
When code contains non-UTF8 characters (e.g. Unicode left-single-quotation mark) the highlights can get off. Solution: always calculate byte sizes instead of character length by using TextEncoder.