### PR TITLE
[RFC] Interruptable scope_graph generation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,4 @@ RUN cargo build --release -p bleep
 FROM debian
 RUN apt-get update && apt-get -y install universal-ctags openssl ca-certificates
 COPY --from=builder /build/target/release/bleep /
-ENTRYPOINT ["/bleep", "--webserver-host=0.0.0.0"]
+ENTRYPOINT ["/bleep", "--host=0.0.0.0"]

--- a/server/bleep/src/indexes/file.rs
+++ b/server/bleep/src/indexes/file.rs
@@ -438,11 +438,12 @@ impl File {
                 }
             }
         };
-
+        use rayon::iter::IntoParallelRefIterator;
+        use rayon::iter::ParallelIterator;
         // flatten the list of symbols into a string with just text
         let symbols = symbol_locations
             .list()
-            .iter()
+            .par_iter()
             .map(|sym| buffer[sym.range.start.byte..sym.range.end.byte].to_owned())
             .collect::<HashSet<_>>()
             .into_iter()

--- a/server/bleep/src/intelligence.rs
+++ b/server/bleep/src/intelligence.rs
@@ -66,7 +66,7 @@ impl<'a> TreeSitterFile<'a> {
     }
 
     /// Produce a lexical scope-graph for this TreeSitterFile.
-    pub fn scope_graph(self) -> Result<ScopeGraph, TreeSitterFileError> {
+    pub async fn scope_graph(self) -> Result<ScopeGraph, TreeSitterFileError> {
         let query = self
             .language
             .scope_query
@@ -74,6 +74,8 @@ impl<'a> TreeSitterFile<'a> {
             .map_err(TreeSitterFileError::QueryError)?;
         let root_node = self.tree.root_node();
 
-        Ok(ResolutionMethod::Generic.build_scope(query, root_node, self.src, self.language))
+        Ok(ResolutionMethod::Generic
+            .build_scope(query, root_node, self.src, self.language)
+            .await)
     }
 }

--- a/server/bleep/src/intelligence.rs
+++ b/server/bleep/src/intelligence.rs
@@ -52,7 +52,7 @@ impl<'a> TreeSitterFile<'a> {
             .map_err(|_| TreeSitterFileError::LanguageMismatch)?;
 
         // do not permit files that take >1s to parse
-        parser.set_timeout_micros(10u64.pow(6));
+        parser.set_timeout_micros(10u64.pow(5));
 
         let tree = parser
             .parse(src, None)

--- a/server/bleep/src/intelligence.rs
+++ b/server/bleep/src/intelligence.rs
@@ -51,7 +51,7 @@ impl<'a> TreeSitterFile<'a> {
             .set_language((language.grammar)())
             .map_err(|_| TreeSitterFileError::LanguageMismatch)?;
 
-        // do not permit files that take >1s to parse
+        // do not permit files that take >100ms to parse
         parser.set_timeout_micros(10u64.pow(5));
 
         let tree = parser

--- a/server/bleep/src/intelligence.rs
+++ b/server/bleep/src/intelligence.rs
@@ -36,11 +36,6 @@ pub enum TreeSitterFileError {
 impl<'a> TreeSitterFile<'a> {
     /// Create a TreeSitterFile out of a sourcefile
     pub fn try_build(src: &'a [u8], lang_id: &str) -> Result<Self, TreeSitterFileError> {
-        // no scope-res for files larger than 500kb
-        if src.len() > 500 * 10usize.pow(3) {
-            return Err(TreeSitterFileError::FileTooLarge);
-        }
-
         let language = match TSLanguage::from_id(lang_id) {
             Language::Supported(language) => Ok(language),
             Language::Unsupported => Err(TreeSitterFileError::UnsupportedLanguage),
@@ -51,9 +46,7 @@ impl<'a> TreeSitterFile<'a> {
             .set_language((language.grammar)())
             .map_err(|_| TreeSitterFileError::LanguageMismatch)?;
 
-        // do not permit files that take >100ms to parse
         parser.set_timeout_micros(10u64.pow(5));
-
         let tree = parser
             .parse(src, None)
             .ok_or(TreeSitterFileError::ParseTimeout)?;

--- a/server/bleep/src/intelligence/scope_resolution.rs
+++ b/server/bleep/src/intelligence/scope_resolution.rs
@@ -36,7 +36,7 @@ impl ResolutionMethod {
     /// Build a lexical scope-graph with a scope query and a tree-sitter tree. The `src`
     /// parameter is required by tree-sitter to resolve certain kinds of query predicates
     /// such as #match? and #eq?.
-    pub fn build_scope(
+    pub async fn build_scope(
         &self,
         query: &Query,
         root_node: Node<'_>,
@@ -44,7 +44,7 @@ impl ResolutionMethod {
         language: &TSLanguageConfig,
     ) -> ScopeGraph {
         match self {
-            ResolutionMethod::Generic => scope_res_generic(query, root_node, src, language),
+            ResolutionMethod::Generic => scope_res_generic(query, root_node, src, language).await,
         }
     }
 }
@@ -337,7 +337,7 @@ impl ScopeGraph {
     }
 }
 
-fn scope_res_generic(
+async fn scope_res_generic(
     query: &Query,
     root_node: Node<'_>,
     src: &[u8],
@@ -371,6 +371,8 @@ fn scope_res_generic(
 
     // determine indices of every capture group in the query file
     for (i, name) in query.capture_names().iter().enumerate() {
+        tokio::task::yield_now().await;
+
         let i = i as u32;
         let parts: Vec<_> = name.split('.').collect();
 
@@ -453,6 +455,8 @@ fn scope_res_generic(
         is_hoisted,
     } in local_def_captures
     {
+        tokio::task::yield_now().await;
+
         if let Some(ranges) = capture_map.get(&index) {
             for range in ranges {
                 // if the symbol is present, is it one of the supported symbols for this language?
@@ -470,6 +474,8 @@ fn scope_res_generic(
 
     // and then refs
     for LocalRefCapture { index, symbol } in local_ref_captures {
+        tokio::task::yield_now().await;
+
         if let Some(ranges) = capture_map.get(&index) {
             for range in ranges {
                 // if the symbol is present, is it one of the supported symbols for this language?

--- a/server/bleep/src/state.rs
+++ b/server/bleep/src/state.rs
@@ -299,7 +299,6 @@ impl Repository {
             // misc languages
             "json",
             "markdown",
-            "rmarkdown",
             "iniconf",
             "man",
             "protobuf",


### PR DESCRIPTION
Reduce the parsing time to 0.1s. For some reason the previous 1s limit causes weird runaway loops parsing highly complex files. We might want to escalate this to upstream with a test suite.

# Verifying results

[983d36c](https://github.com/BloopAI/bloop/pull/27/commits/983d36c3caf965396bbcfb4a7077988c2dac9604) reduces the parsing timeout to 0.1s on paper. This somehow avoids choking the indexing process, and extreme outliers for the entire worker function. Ultimately it cuts total processing from 7m40s to 3m20s for the testset.