### PR TITLE
Don't report indexing as "done" before Tantivy commit is over

### DIFF
--- a/server/bleep/src/background.rs
+++ b/server/bleep/src/background.rs
@@ -139,44 +139,40 @@ impl IndexWriter {
             (key, repo)
         };
 
-        let indexed = match repo.sync_status {
+        let (state, indexed) = match repo.sync_status {
             Uninitialized | Syncing | Indexing => return Ok(()),
-            Removed => self.delete_repo(&repo, &writers),
+            Removed => (None, self.delete_repo(&repo, &writers)),
             _ => {
                 repo_pool.get_mut(reporef).unwrap().value_mut().sync_status = Indexing;
-
                 let indexed = repo.index(&key, &writers).await;
-                let mut repo = repo_pool.get_mut(reporef).unwrap();
+                let state = match &indexed {
+                    Ok(state) => Some(state.clone()),
+                    _ => None,
+                };
 
-                match indexed {
-                    Ok(state) => {
-                        repo.value_mut().sync_done_with(state);
-                        Ok(())
-                    }
-                    Err(err) => {
-                        repo.value_mut().sync_status = Error {
-                            message: err.to_string(),
-                        };
-                        Err(err.into())
-                    }
-                }
+                (state, indexed.map(|_| ()).map_err(|e| e.into()))
             }
         };
-
-        if let Err(err) = indexed {
-            error!(?err, ?reporef, "failed to index repository");
-        }
 
         // self is a separate sweep so we don't await while holding locks
         repo_pool.retain(|_k, v| v.sync_status != Removed);
 
         writers.commit().await?;
-
-        // update tantivy pointer to latest commit
-        info!("commit complete; indexing done");
-
         config.source.save_pool(repo_pool.clone())?;
-        info!("sync state saved");
+
+        let mut repo = repo_pool.get_mut(reporef).unwrap();
+        match indexed {
+            Ok(()) => {
+                repo.value_mut().sync_done_with(state.unwrap());
+                info!("commit complete; indexing done");
+            }
+            Err(err) => {
+                repo.value_mut().sync_status = Error {
+                    message: err.to_string(),
+                };
+                error!(?err, ?reporef, "failed to index repository");
+            }
+        }
 
         Ok(())
     }

--- a/server/bleep/src/indexes.rs
+++ b/server/bleep/src/indexes.rs
@@ -39,6 +39,13 @@ impl<'a> Deref for GlobalWriteHandle<'a> {
 }
 
 impl<'a> GlobalWriteHandle<'a> {
+    pub fn rollback(self) -> Result<()> {
+        for mut handle in self.handles {
+            handle.rollback()?
+        }
+
+        Ok(())
+    }
     pub async fn commit(self) -> Result<()> {
         for mut handle in self.handles {
             handle.commit().await?
@@ -156,6 +163,11 @@ impl<'a> IndexWriteHandle<'a> {
         self.writer.commit()?;
         self.refresh_reader().await?;
 
+        Ok(())
+    }
+
+    pub fn rollback(&mut self) -> Result<()> {
+        self.writer.rollback()?;
         Ok(())
     }
 }


### PR DESCRIPTION
Additionally, deleting logic a bit more robust here, as it doesn't neeed to be aware of multiple repositories in this function.