### PR TITLE
omit hidden files from ctags calculations

### DIFF
--- a/server/bleep/src/ctags.rs
+++ b/server/bleep/src/ctags.rs
@@ -40,7 +40,6 @@ fn find_files(path: &Path) -> Vec<String> {
     WalkBuilder::new(path)
         .ignore(true)
         .git_ignore(true)
-        .hidden(false)
         .build()
         .filter_map(|res| match res {
             Ok(de) => Some(de),


### PR DESCRIPTION
files such as `.eslint.rc` and `.gitignore` were being omitted from the index.