### PR TITLE
Stability improvements

### DIFF
--- a/.github/workflows/tauri-release.yml
+++ b/.github/workflows/tauri-release.yml
@@ -29,11 +29,11 @@ jobs:
 
       - name: Check Formatting
         run: |
-          cargo fmt -p app -- --check
+          cargo fmt -p bloop -- --check
 
       - name: Run tests
         run: |
-          cargo test -p app --verbose
+          cargo test -p bloop --verbose
 
   build-mac-linux-ctags:
     strategy:

--- a/.github/workflows/tauri-test.yml
+++ b/.github/workflows/tauri-test.yml
@@ -49,11 +49,11 @@ jobs:
 
       - name: Check Formatting
         run: |
-          cargo fmt -p app -- --check
+          cargo fmt -p bloop -- --check
 
       - name: Run tests
         run: |
-          cargo test -p app --verbose
+          cargo test -p bloop --verbose
 
       - uses: actions-rs/clippy-check@v1
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,25 +89,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d301b3b94cb4b2f23d7917810addbbaff90738e0ca2be692bd027e70d7e0330c"
 
 [[package]]
-name = "app"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "bleep",
- "color-eyre",
- "once_cell",
- "qdrant-client",
- "sentry",
- "serde",
- "serde_json",
- "tauri",
- "tauri-build",
- "tokio",
- "tracing",
- "tracing-subscriber",
-]
-
-[[package]]
 name = "approx"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -430,6 +411,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "bloop"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "bleep",
+ "color-eyre",
+ "once_cell",
+ "qdrant-client",
+ "sentry",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-build",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 [profile.release]
 debug = false
 strip = "debuginfo"
-lto = true
+#lto = true
 
 [profile.profiler]
 inherits = "release"

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
-name = "app"
+name = "bloop"
 version = "0.1.0"
-description = "A Tauri App"
-authors = ["you"]
+description = "Search code. Fast."
+authors = ["Bloop AI Developers"]
 license = ""
 repository = ""
-default-run = "app"
+default-run = "bloop"
 edition = "2021"
 rust-version = "1.57"
 

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -101,6 +101,8 @@ async fn main() {
         ])
         .run(tauri::generate_context!())
         .expect("error running tauri application");
+
+    qdrant::shutdown();
 }
 
 #[tauri::command]

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -92,6 +92,10 @@ async fn main() {
 
             Ok(())
         })
+        .on_window_event(|window_event| match window_event.event() {
+            tauri::WindowEvent::CloseRequested { .. } => qdrant::shutdown(),
+            _ => {}
+        })
         .invoke_handler(tauri::generate_handler![
             show_folder_in_finder,
             get_device_id,
@@ -101,8 +105,6 @@ async fn main() {
         ])
         .run(tauri::generate_context!())
         .expect("error running tauri application");
-
-    qdrant::shutdown();
 }
 
 #[tauri::command]

--- a/apps/desktop/src-tauri/src/qdrant.rs
+++ b/apps/desktop/src-tauri/src/qdrant.rs
@@ -33,7 +33,7 @@ storage:
 
   performance:
     # Number of parallel threads used for search operations. If 0 - auto selection.
-    max_search_threads: 0
+    max_search_threads: 4
 
   optimizers:
     # The minimal fraction of deleted vectors in a segment, required to perform segment optimization
@@ -50,7 +50,7 @@ storage:
     # It is recommended to select default number of segments as a factor of the number of search threads,
     # so that each segment would be handled evenly by one of the threads.
     # If `default_segment_number = 0`, will be automatically selected by the number of available CPUs
-    default_segment_number: 0
+    default_segment_number: 2
 
     # Do not create segments larger this size (in KiloBytes).
     # Large segments might require disproportionately long indexation times,
@@ -111,9 +111,8 @@ service:
 
   # gRPC port to bind the service on.
   # If `null` - gRPC is disabled. Default: null
-  grpc_port: 6334
   # Uncomment to enable gRPC:
-  # grpc_port: 6334
+  grpc_port: 6334
 
   # Enable CORS headers in REST API.
   # If enabled, browsers would be allowed to query REST endpoints regardless of query origin.

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -52,7 +52,7 @@
         "icons/icon.icns",
         "icons/icon.ico"
       ],
-      "identifier": "ai.bloop.app",
+      "identifier": "ai.bloop.bloop",
       "longDescription": "Helping developers find code faster",
       "macOS": {
         "entitlements": null,

--- a/server/bleep/src/bin/bleep.rs
+++ b/server/bleep/src/bin/bleep.rs
@@ -3,6 +3,7 @@ use bleep::{Application, Configuration, Environment};
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    Application::install_logging();
     let app = Application::initialize(Environment::Server, Configuration::from_cli()?).await?;
     app.run().await
 }

--- a/server/bleep/src/indexes/file.rs
+++ b/server/bleep/src/indexes/file.rs
@@ -474,7 +474,6 @@ impl File {
 
         tokio::task::block_in_place(|| {
             Handle::current().block_on(self.semantic.insert_points_for_buffer(
-                &file_disk_path,
                 &repo_name,
                 &relative_path.to_string_lossy(),
                 &buffer,

--- a/server/bleep/src/semantic.rs
+++ b/server/bleep/src/semantic.rs
@@ -140,10 +140,7 @@ impl Semantic {
         buffer: &str,
         lang_str: &str,
     ) {
-        let chunks = chunk::tree_sitter(buffer, lang_str).unwrap_or_else(|e| {
-            debug!(?e, %lang_str, "failed to chunk, falling back to trivial chunker");
-            chunk::trivial(buffer, 15) // line-wise chunking, 15 lines per chunk
-        });
+        let chunks = chunk::trivial(buffer, 15); // line-wise chunking, 15 lines per chunk
 
         debug!(chunk_count = chunks.len(), "found chunks");
         let datapoints = chunks


### PR DESCRIPTION
This changes the app name to `ai.bloop.bloop`, so `ai.bloop.app` should be gone.

Also, the tauri app attempts to shut down `qdrant`. This needs more testing.

Additionally, creating and verifying collections is now stricter, to avoid starting the app in a weird state.