### PR TITLE
Increase `TopDoc` limit for `open:` queries

### DIFF
--- a/server/bleep/src/webserver/query.rs
+++ b/server/bleep/src/webserver/query.rs
@@ -599,7 +599,7 @@ impl ExecuteQuery for OpenReader {
         queries: &[parser::Query<'_>],
         _q: &ApiQuery,
     ) -> Result<QueryResponse> {
-        let top_docs = TopDocs::with_limit(1000);
+        let top_docs = TopDocs::with_limit(50000);
         let empty_collector = MultiCollector::new();
         let results = indexer
             .query(queries.iter(), self, (top_docs, empty_collector))


### PR DESCRIPTION
If the `TopDoc` limit is less than the total number of files in a repository `open:` queries may miss files. For example, if this repo had 5,000 files, the query `open:true repo:bloop` internally only process 1,000 of them and that set might not include all of the top level files in the repo.

This change increases the `TopDoc` limit to cover most repos. This is a temporary solution as `open:true repo:foo` queries for very large repos are slow. We should implement a more efficient strategy for `open:` queries in a future PR.