### PR TITLE
Quantized embedding model

### DIFF
--- a/model/model.onnx
+++ b/model/model.onnx
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0523ac5fd110ba5d7ebda0dd055e0ef05dbc1dcd72de4916e2842276c829b034
-size 90983731
+oid sha256:712cda19c5e4803e4d2f1d5ae972083537ffc2531759b67641622251c8ec3caf
+size 22998413


### PR DESCRIPTION
Replace model with quantized version. This is 4x smaller and runs faster than the full-precision version.