### PR TITLE
Path navigation fix

### DIFF
--- a/client/src/components/CodeBlock/SearchFile/index.tsx
+++ b/client/src/components/CodeBlock/SearchFile/index.tsx
@@ -61,7 +61,12 @@ const SearchFile = ({
         e.preventDefault();
         onFileClick(
           repoName,
-          breadcrumbsItemPath(pathParts, pathIndex, isWindowsPath(filePath)),
+          breadcrumbsItemPath(
+            pathParts,
+            pathIndex,
+            isWindowsPath(filePath),
+            pathIndex === pathParts.length - 1,
+          ),
         );
       };
       pp.push(pathPart);


### PR DESCRIPTION
when clicking on the filename the path contained trailing '/' because the last argument 'isFile' was not provided