### PR TITLE
Better recovery after shutdown

### DIFF
--- a/server/bleep/src/state.rs
+++ b/server/bleep/src/state.rs
@@ -440,6 +440,11 @@ impl StateSource {
                             elem.value_mut().delete();
                         }
                     }
+
+                    // in case the app terminated during indexing, make sure to re-queue it
+                    if elem.sync_status == SyncStatus::Indexing {
+                        elem.value_mut().sync_status = SyncStatus::Queued;
+                    }
                 }
 
                 // then add anything new that's appeared


### PR DESCRIPTION
Previously shutdowns would occasionally cause invalid JSON structures for the state files. In this PR we fix this by making these writes atomic from the FS perspective by first writing to a new file, then moving it into place.

Also, since we dump the raw memory structure into the state JSONs, we need to reset the `sync_status` on repos that were being indexed when the shutdown happened, and queue them again.