### PR TITLE
Remove redundant norm calculation

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -3,7 +3,5 @@ PCRE2_SYS_STATIC = "1"
 
 [target.aarch64-apple-darwin]
 rustflags = [
-    "-C", "link-arg=-L/opt/homebrew/opt/openblas/lib",
-    "-C", "link-arg=-I/opt/homebrew/opt/openblas/include", 
     "-C", "link-args=-Wl,-rpath,/opt/homebrew/opt/onnxruntime/lib"
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,15 +83,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2cb2f989d18dd141ab8ae82f64d1a8cdd37e0840f73a406896cf5e99502fab61"
 
 [[package]]
-name = "approx"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f2a05fd1bd10b2527e20a2cd32d8873d115b8b39fe219ee25f42a8aca6ba278"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "arc-swap"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -332,7 +323,6 @@ dependencies = [
  "ignore",
  "maplit",
  "ndarray",
- "ndarray-linalg",
  "notify-debouncer-mini",
  "octocrab",
  "once_cell",
@@ -567,27 +557,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a17ed5635fc8536268e5d4de1e22e81ac34419e5f052d4d51f4e01dcc263fcc"
 dependencies = [
  "rustversion",
-]
-
-[[package]]
-name = "cauchy"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ff11ddd2af3b5e80dd0297fee6e56ac038d9bdc549573cdb51bd6d2efe7f05e"
-dependencies = [
- "num-complex",
- "num-traits",
- "rand 0.8.5",
- "serde",
-]
-
-[[package]]
-name = "cblas-sys"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6feecd82cce51b0204cf063f0041d69f24ce83f680d87514b004248e7b0fa65"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -2627,17 +2596,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "katexit"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb1304c448ce2c207c2298a34bc476ce7ae47f63c23fa2b498583b26be9bc88c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "kqueue"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2667,29 +2625,6 @@ dependencies = [
  "html5ever",
  "matches",
  "selectors",
-]
-
-[[package]]
-name = "lapack-sys"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "447f56c85fb410a7a3d36701b2153c1018b1d2b908c5fbaf01c1b04fac33bcbe"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "lax"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f96a229d9557112e574164f8024ce703625ad9f88a90964c1780809358e53da"
-dependencies = [
- "cauchy",
- "katexit",
- "lapack-sys",
- "num-traits",
- "openblas-src",
- "thiserror",
 ]
 
 [[package]]
@@ -3047,30 +2982,11 @@ version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb12d4e967ec485a5f71c6311fe28158e9d6f4bc4a447b474184d0f91a8fa32"
 dependencies = [
- "approx",
- "cblas-sys",
- "libc",
  "matrixmultiply",
  "num-complex",
  "num-integer",
  "num-traits",
  "rawpointer",
-]
-
-[[package]]
-name = "ndarray-linalg"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b0e8dda0c941b64a85c5deb2b3e0144aca87aced64678adfc23eacea6d2cc42"
-dependencies = [
- "cauchy",
- "katexit",
- "lax",
- "ndarray",
- "num-complex",
- "num-traits",
- "rand 0.8.5",
- "thiserror",
 ]
 
 [[package]]
@@ -3190,8 +3106,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ae39348c8bc5fbd7f40c727a9925f03517afd2ab27d46702108b6a7e5414c19"
 dependencies = [
  "num-traits",
- "rand 0.8.5",
- "serde",
 ]
 
 [[package]]
@@ -3389,27 +3303,6 @@ checksum = "b4a3100141f1733ea40b53381b0ae3117330735ef22309a190ac57b9576ea716"
 dependencies = [
  "pathdiff",
  "windows-sys 0.36.1",
-]
-
-[[package]]
-name = "openblas-build"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2796ae60e2d04434936195a8be9f4ae248dd140e78f222caed0961034c2932ba"
-dependencies = [
- "thiserror",
- "walkdir",
-]
-
-[[package]]
-name = "openblas-src"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9016355894bd1c6e2e52dd6ea37866a7c062929743f33abc96fddaf31a18d67"
-dependencies = [
- "dirs",
- "openblas-build",
- "vcpkg",
 ]
 
 [[package]]

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -8,7 +8,6 @@ To build the Tauri app you need the following dependencies:
 - `pnpm`
 - `rustup`
 - `clang` `cmake` `wget`
-- `openBLAS`
 - `protobuf`
 - `onnxruntime`
 

--- a/apps/desktop/src-tauri/src/qdrant.rs
+++ b/apps/desktop/src-tauri/src/qdrant.rs
@@ -204,6 +204,7 @@ where
 fn run_command(command: &Path, qdrant_dir: &Path) -> Child {
     use nix::sys::resource::{getrlimit, setrlimit, Resource};
     use tracing::{error, info};
+    error!("BIG CAPITALS I AM HERE");
     match getrlimit(Resource::RLIMIT_NOFILE) {
         Ok((current_soft, current_hard)) if current_hard < 2048 => {
             if let Err(err) = setrlimit(Resource::RLIMIT_NOFILE, 1024, 2048) {

--- a/apps/desktop/src-tauri/src/qdrant.rs
+++ b/apps/desktop/src-tauri/src/qdrant.rs
@@ -204,7 +204,6 @@ where
 fn run_command(command: &Path, qdrant_dir: &Path) -> Child {
     use nix::sys::resource::{getrlimit, setrlimit, Resource};
     use tracing::{error, info};
-    error!("BIG CAPITALS I AM HERE");
     match getrlimit(Resource::RLIMIT_NOFILE) {
         Ok((current_soft, current_hard)) if current_hard < 2048 => {
             if let Err(err) = setrlimit(Resource::RLIMIT_NOFILE, 1024, 2048) {

--- a/flake.nix
+++ b/flake.nix
@@ -30,7 +30,6 @@
               openssl
               glib.dev
               cmake
-              openblas
               protobuf
             ] ++ lib.optionals pkgs.stdenv.isLinux [
               dbus.dev

--- a/server/bleep/Cargo.toml
+++ b/server/bleep/Cargo.toml
@@ -102,7 +102,6 @@ qdrant-client = "0.11.5"
 tokenizers = "0.13.2"
 ort = { git = "https://github.com/rsdy/ort", branch = "arm64-convert-fix" }
 ndarray = "0.15"
-ndarray-linalg = { version = "0.16.0", features = ["openblas-system"] }
 maplit = "1.0.2"
 uuid = "1.2.2"
 

--- a/server/bleep/src/semantic.rs
+++ b/server/bleep/src/semantic.rs
@@ -3,7 +3,6 @@ use std::{collections::HashMap, ops::Not, path::Path, sync::Arc};
 use anyhow::Result;
 use maplit::hashmap;
 use ndarray::s;
-use ndarray_linalg::Norm;
 use ort::{
     tensor::{FromArray, InputTensor, OrtOwnedTensor},
     Environment, ExecutionProvider, GraphOptimizationLevel, LoggingLevel, SessionBuilder,
@@ -118,9 +117,8 @@ impl Semantic {
         let output_tensor: OrtOwnedTensor<f32, _> = outputs[0].try_extract().unwrap();
         let logits = &*output_tensor.view();
         let pooled = logits.slice(s![.., 0, ..]);
-        let norm = pooled.norm();
 
-        Ok((pooled.to_owned() / norm).as_slice().unwrap().to_vec())
+        Ok(pooled.to_owned().as_slice().unwrap().to_vec())
     }
 
     pub async fn search(&self, query: &str, limit: u64) -> Result<Vec<HashMap<String, Value>>> {


### PR DESCRIPTION
Removes a redundant norm calculation, and the `ndarray_linalg` crate that is depends on.