### PR TITLE
chunk by number of tokens instead of lines

### DIFF
--- a/server/bleep/src/semantic.rs
+++ b/server/bleep/src/semantic.rs
@@ -146,7 +146,8 @@ impl Semantic {
         buffer: &str,
         lang_str: &str,
     ) {
-        let chunks = chunk::trivial(buffer, 15); // line-wise chunking, 15 lines per chunk
+        let chunks = //chunk::trivial(buffer, 15); // line-wise chunking, 15 lines per chunk
+            chunk::by_tokens(buffer, &*self.tokenizer, self.session.inputs.len(), 15);
 
         debug!(chunk_count = chunks.len(), "found chunks");
         let datapoints = chunks

--- a/server/bleep/src/semantic/chunk.rs
+++ b/server/bleep/src/semantic/chunk.rs
@@ -86,7 +86,10 @@ pub fn tree_sitter<'a, 'l>(src: &'a str, lang_id: &'l str) -> Result<Vec<Chunk<'
 }
 
 fn point(src: &str, byte: usize) -> Point {
-    let line = src.as_bytes()[..byte].iter().filter(|&&b| b == b'\n').count();
+    let line = src.as_bytes()[..byte]
+        .iter()
+        .filter(|&&b| b == b'\n')
+        .count() + 1; // we count from line 1
     let column = if let Some(last_nl) = src[..byte].rfind('\n') {
         byte - last_nl
     } else {
@@ -95,13 +98,38 @@ fn point(src: &str, byte: usize) -> Point {
     Point { byte, column, line }
 }
 
-fn add_chunks<'s>(results: &mut Vec<Chunk<'s>>, src: &'s str, offsets: &[(usize, usize)], start: usize, end: usize, _max_tokens: usize) {
-    //TODO: split if more than _max_tokens
+fn add_chunk<'s>(
+    results: &mut Vec<Chunk<'s>>,
+    src: &'s str,
+    offsets: &[(usize, usize)],
+    start: usize,
+    end: usize,
+) {
     let startpoint = point(src, offsets[start].0);
     let endpoint = point(src, offsets[end].1);
-    if endpoint.byte > startpoint.byte { 
-        results.push(Chunk::new(&src[startpoint.byte .. endpoint.byte], startpoint, endpoint));        
+    if endpoint.byte > startpoint.byte {
+        results.push(Chunk::new(
+            &src[startpoint.byte..endpoint.byte],
+            startpoint,
+            endpoint,
+        ));
     }
+}
+
+fn add_chunks<'s>(
+    results: &mut Vec<Chunk<'s>>,
+    src: &'s str,
+    offsets: &[(usize, usize)],
+    mut start: usize,
+    end: usize,
+    max_tokens: usize,
+) {
+    while end - start > max_tokens {
+        let Some(mid) = (start..(start + max_tokens - 1)).rfind(|&i| offsets[i].1 < offsets[i + 1].0) else { return };
+        add_chunk(results, src, offsets, start, mid);
+        start = mid;
+    }
+    add_chunk(results, src, offsets, start, end);
 }
 
 /// This tries to split the code by lines and add as much tokens as possible until reaching
@@ -128,15 +156,31 @@ pub fn by_tokens<'s>(
     let mut first_newline = 0;
     let mut last_newline = 0;
     let mut result = Vec::new();
-    for newline in (0..(offset_len - 1)).filter(|&i| src[offsets[i].1 .. offsets[i + 1].0].contains('\n')) {
+    for newline in
+        (0..(offset_len - 1)).filter(|&i| src[offsets[i].1..offsets[i + 1].0].contains('\n'))
+    {
         if newline - first_newline > max_tokens {
-            add_chunks(&mut result, src, offsets, first_newline, last_newline, max_tokens);
+            add_chunks(
+                &mut result,
+                src,
+                offsets,
+                first_newline,
+                last_newline,
+                max_tokens,
+            );
             first_newline = (last_newline + 1).min(offset_len);
         }
         last_newline = newline;
     }
     if first_newline < offset_len {
-        add_chunks(&mut result, src, offsets, first_newline, offset_len - 1, max_tokens);
+        add_chunks(
+            &mut result,
+            src,
+            offsets,
+            first_newline,
+            offset_len - 1,
+            max_tokens,
+        );
     }
     result
 }
@@ -179,8 +223,7 @@ mod tests {
     #[test]
     pub fn test_by_tokens() {
         let src = include_str!("chunk.rs"); // tokenize yourself!
-        let tokenizer = tokenizers::Tokenizer::from_file("../../model/tokenizer.json")
-        .unwrap();
+        let tokenizer = tokenizers::Tokenizer::from_file("../../model/tokenizer.json").unwrap();
         let max_tokens = 128;
         let max_lines = 15;
         dbg!(super::by_tokens(src, &tokenizer, max_tokens, max_lines));

--- a/server/bleep/src/semantic/chunk.rs
+++ b/server/bleep/src/semantic/chunk.rs
@@ -3,6 +3,8 @@ use crate::{
     text_range::{Point, TextRange},
 };
 
+use tokenizers::Tokenizer;
+use tracing::warn;
 use tree_sitter::{Parser, QueryCursor};
 
 #[derive(Debug)]
@@ -18,6 +20,13 @@ pub struct Chunk<'a> {
 }
 
 impl<'a> Chunk<'a> {
+    pub fn new(data: &'a str, start: Point, end: Point) -> Self {
+        Self {
+            data,
+            range: TextRange { start, end },
+        }
+    }
+
     pub fn len(&self) -> usize {
         self.data.len()
     }
@@ -76,6 +85,62 @@ pub fn tree_sitter<'a, 'l>(src: &'a str, lang_id: &'l str) -> Result<Vec<Chunk<'
     Ok(chunks)
 }
 
+fn point(src: &str, byte: usize) -> Point {
+    let line = src.as_bytes()[..byte].iter().filter(|&&b| b == b'\n').count();
+    let column = if let Some(last_nl) = src[..byte].rfind('\n') {
+        byte - last_nl
+    } else {
+        byte
+    };
+    Point { byte, column, line }
+}
+
+fn add_chunks<'s>(results: &mut Vec<Chunk<'s>>, src: &'s str, offsets: &[(usize, usize)], start: usize, end: usize, _max_tokens: usize) {
+    //TODO: split if more than _max_tokens
+    let startpoint = point(src, offsets[start].0);
+    let endpoint = point(src, offsets[end].1);
+    if endpoint.byte > startpoint.byte { 
+        results.push(Chunk::new(&src[startpoint.byte .. endpoint.byte], startpoint, endpoint));        
+    }
+}
+
+/// This tries to split the code by lines and add as much tokens as possible until reaching
+/// `max_tokens`. Then it'll reduce to the last newline.
+pub fn by_tokens<'s>(
+    src: &'s str,
+    tokenizer: &Tokenizer,
+    max_tokens: usize,
+    max_lines: usize,
+) -> Vec<Chunk<'s>> {
+    if src.is_empty() {
+        return Vec::new();
+    }
+    let Ok(encoding) = tokenizer.encode(src, false)
+    else {
+        warn!("Could not encode \"{}\"", src);
+        return trivial(src, max_lines);
+    };
+    // FIXME: This unfortunately is the char offset, not the byte offset!
+    // We need to take care of non-ascii unicode at some point
+    // another reason for aleph-alpha-tokenizer...
+    let offsets = encoding.get_offsets();
+    let offset_len = offsets.len();
+    let mut first_newline = 0;
+    let mut last_newline = 0;
+    let mut result = Vec::new();
+    for newline in (0..(offset_len - 1)).filter(|&i| src[offsets[i].1 .. offsets[i + 1].0].contains('\n')) {
+        if newline - first_newline > max_tokens {
+            add_chunks(&mut result, src, offsets, first_newline, last_newline, max_tokens);
+            first_newline = (last_newline + 1).min(offset_len);
+        }
+        last_newline = newline;
+    }
+    if first_newline < offset_len {
+        add_chunks(&mut result, src, offsets, first_newline, offset_len - 1, max_tokens);
+    }
+    result
+}
+
 pub fn trivial(src: &str, size: usize) -> Vec<Chunk<'_>> {
     let ends = std::iter::once(0)
         .chain(src.match_indices('\n').map(|(i, _)| i))
@@ -107,4 +172,17 @@ pub fn trivial(src: &str, size: usize) -> Vec<Chunk<'_>> {
             },
         })
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    pub fn test_by_tokens() {
+        let src = include_str!("chunk.rs"); // tokenize yourself!
+        let tokenizer = tokenizers::Tokenizer::from_file("../../model/tokenizer.json")
+        .unwrap();
+        let max_tokens = 128;
+        let max_lines = 15;
+        dbg!(super::by_tokens(src, &tokenizer, max_tokens, max_lines));
+    }
 }


### PR DESCRIPTION
This tries to maximize the number of tokens per chunk while still splitting at newlines. Overlap is not yet implemented and lines that are longer than the maximum number of chunks will still silently be put into one single chunk (and likely truncated by the model). Next step will be splitting overlong lines by white space and then implementing overlap.