### PR TITLE
Error when semantic search returns no snippets

### DIFF
--- a/server/bleep/src/webserver/answer.rs
+++ b/server/bleep/src/webserver/answer.rs
@@ -78,6 +78,10 @@ pub async fn handle(
         })
         .collect::<Vec<_>>();
 
+    if snippets.len() < 1 {
+        super::error(ErrorKind::Internal, "semantic search returned no snippets");
+    }
+
     let res = reqwest::Client::new()
         .post(format!("{}/q", app.config.answer_api_base))
         .json(&api::Request {


### PR DESCRIPTION
Throw an error when semantic search returns no results, rather than passing an empty `Vec` to the OpenAI API. We should display a standard message on the client in this case.