### PR TITLE
add `lang` and `repo` filters to NL search

### DIFF
--- a/server/bleep/src/query/grammar.pest
+++ b/server/bleep/src/query/grammar.pest
@@ -50,3 +50,6 @@ group_end = _{ ")" }
 group = !{ group_start ~ intersection ~ group_end }
 
 WHITESPACE = _{ " " }
+
+// natural language queries
+nl_query = _{ SOI ~ (label | literal)* ~ EOI }

--- a/server/bleep/src/query/parser.rs
+++ b/server/bleep/src/query/parser.rs
@@ -22,6 +22,27 @@ pub enum Target<'a> {
     Content(Literal<'a>),
 }
 
+#[derive(Default, Clone, Debug, PartialEq, Eq)]
+pub struct NLQuery<'a> {
+    pub repo: Option<Literal<'a>>,
+    pub lang: Option<Cow<'a, str>>,
+    pub target: Option<Literal<'a>>,
+}
+
+impl<'a> NLQuery<'a> {
+    pub fn repo(&self) -> Option<&Cow<'_, str>> {
+        self.repo.as_ref().and_then(|t| t.as_plain())
+    }
+
+    pub fn lang(&self) -> Option<&Cow<'_, str>> {
+        self.lang.as_ref()
+    }
+
+    pub fn target(&self) -> Option<&Cow<'_, str>> {
+        self.target.as_ref().and_then(|t| t.as_plain())
+    }
+}
+
 impl<'a> Query<'a> {
     /// Merge this query with another, overwriting current terms by terms in the new query, if they
     /// exist.
@@ -158,6 +179,12 @@ impl Literal<'_> {
         let lhs = self.regex_str();
         let rhs = rhs.regex_str();
         Self::Regex(Cow::Owned(format!("{lhs}\\s+{rhs}")))
+    }
+
+    fn join_as_plain(self, rhs: Self) -> Option<Self> {
+        let lhs = self.as_plain()?;
+        let rhs = rhs.as_plain()?;
+        Some(Self::Plain(Cow::Owned(format!("{lhs} {rhs}"))))
     }
 
     /// Convert this literal into a regex string.
@@ -373,6 +400,37 @@ pub fn parse(query: &str) -> Result<Vec<Query<'_>>, ParseError> {
     }
 
     Ok(qs.into_vec())
+}
+
+pub fn parse_nl(query: &str) -> Result<NLQuery<'_>, ParseError> {
+    let pairs = PestParser::parse(Rule::nl_query, query).map_err(Box::new)?;
+
+    let mut repo = None;
+    let mut lang = None;
+    let mut target: Option<Literal> = None;
+    for pair in pairs {
+        match pair.as_rule() {
+            Rule::repo => repo = Some(Literal::from(pair.into_inner().next().unwrap())),
+            Rule::lang => {
+                lang = Some(super::languages::parse_alias(
+                    pair.into_inner().as_str().into(),
+                ))
+            }
+            Rule::unquoted_literal | Rule::quoted_literal | Rule::single_quoted_literal => {
+                let rhs = Literal::from(pair);
+                if let Some(t) = target {
+                    target = t.join_as_plain(rhs);
+                } else {
+                    target = Some(rhs);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    let qs = NLQuery { repo, lang, target };
+
+    Ok(qs)
 }
 
 fn flatten(root: Expr<'_>) -> SmallVec<[Query<'_>; 1]> {
@@ -890,6 +948,18 @@ mod tests {
             .unwrap()
             .regex()
             .unwrap();
+    }
+
+    #[test]
+    fn test_nl_parse() {
+        assert_eq!(
+            parse_nl("what is background color? lang:tsx repo:bloop").unwrap(),
+            NLQuery {
+                target: Some(Literal::Plain("what is background color?".into())),
+                lang: Some("tsx".into()),
+                repo: Some(Literal::Plain("bloop".into())),
+            },
+        );
     }
 
     #[test]

--- a/server/bleep/src/semantic.rs
+++ b/server/bleep/src/semantic.rs
@@ -146,7 +146,7 @@ impl Semantic {
 
         let repo_filter = nl_query
             .repo()
-            .map(|r| make_kv_filter("repo".to_string(), r.to_string()));
+            .map(|r| make_kv_filter("repo_name".to_string(), r.to_string()));
 
         let lang_filter = nl_query
             .lang()

--- a/server/bleep/src/semantic.rs
+++ b/server/bleep/src/semantic.rs
@@ -1,5 +1,7 @@
 use std::{collections::HashMap, ops::Not, path::Path, sync::Arc};
 
+use crate::query::parser::NLQuery;
+
 use anyhow::Result;
 use maplit::hashmap;
 use ndarray::s;
@@ -10,9 +12,10 @@ use ort::{
 use qdrant_client::{
     prelude::{QdrantClient, QdrantClientConfig},
     qdrant::{
-        vectors_config, with_payload_selector::SelectorOptions, CollectionOperationResponse,
-        CreateCollection, Distance, PointId, PointStruct, SearchPoints, Value, VectorParams,
-        VectorsConfig, WithPayloadSelector,
+        r#match::MatchValue, vectors_config, with_payload_selector::SelectorOptions,
+        CollectionOperationResponse, CreateCollection, Distance, FieldCondition, Filter, Match,
+        PointId, PointStruct, SearchPoints, Value, VectorParams, VectorsConfig,
+        WithPayloadSelector,
     },
 };
 use rayon::prelude::*;
@@ -121,7 +124,39 @@ impl Semantic {
         Ok(pooled.to_owned().as_slice().unwrap().to_vec())
     }
 
-    pub async fn search(&self, query: &str, limit: u64) -> Result<Vec<HashMap<String, Value>>> {
+    pub async fn search<'a>(
+        &self,
+        nl_query: &NLQuery<'a>,
+        limit: u64,
+    ) -> Result<Vec<HashMap<String, Value>>> {
+        let Some(query) = nl_query.target() else {
+            anyhow::bail!("no search target for query");
+        };
+
+        let make_kv_filter = |key, value| {
+            FieldCondition {
+                key,
+                r#match: Some(Match {
+                    match_value: MatchValue::Text(value).into(),
+                }),
+                ..Default::default()
+            }
+            .into()
+        };
+
+        let repo_filter = nl_query
+            .repo()
+            .map(|r| make_kv_filter("repo".to_string(), r.to_string()));
+
+        let lang_filter = nl_query
+            .lang()
+            .map(|l| make_kv_filter("lang".to_string(), l.to_string()));
+
+        let filters = [repo_filter, lang_filter]
+            .into_iter()
+            .flatten()
+            .collect::<Vec<_>>();
+
         let response = self
             .qdrant
             .search_points(&SearchPoints {
@@ -130,6 +165,10 @@ impl Semantic {
                 vector: self.embed(query)?,
                 with_payload: Some(WithPayloadSelector {
                     selector_options: Some(SelectorOptions::Enable(true)),
+                }),
+                filter: Some(Filter {
+                    must: filters,
+                    ..Default::default()
                 }),
                 ..Default::default()
             })

--- a/server/bleep/src/webserver/answer.rs
+++ b/server/bleep/src/webserver/answer.rs
@@ -1,3 +1,4 @@
+use crate::query::parser;
 use axum::{extract::Query, response::IntoResponse, Extension, Json};
 use utoipa::ToSchema;
 
@@ -59,9 +60,11 @@ pub async fn handle(
     Query(params): Query<Params>,
     Extension(app): Extension<Application>,
 ) -> Result<impl IntoResponse, impl IntoResponse> {
+    let query =
+        parser::parse_nl(&params.q).map_err(|e| super::error(ErrorKind::User, e.to_string()))?;
     let mut snippets = app
         .semantic
-        .search(&params.q, params.limit)
+        .search(&query, params.limit)
         .await
         .map_err(|e| super::error(ErrorKind::Internal, e.to_string()))?
         .into_iter()

--- a/server/bleep/src/webserver/semantic.rs
+++ b/server/bleep/src/webserver/semantic.rs
@@ -1,5 +1,5 @@
 use super::prelude::*;
-use crate::semantic::Semantic;
+use crate::{query::parser, semantic::Semantic};
 use tracing::error;
 
 use qdrant_client::qdrant::value::Kind;
@@ -31,7 +31,8 @@ pub(super) async fn raw_chunks(
 ) -> impl IntoResponse {
     let Args { ref query, limit } = args;
 
-    let result = semantic.search(query, limit).await.and_then(|raw| {
+    let query = parser::parse_nl(query).unwrap();
+    let result = semantic.search(&query, limit).await.and_then(|raw| {
         raw.into_iter()
             .map(|v| {
                 v.into_iter()


### PR DESCRIPTION
this enables the `lang` and `repo` filters for natural language search. note that this currently does not work with regex filters such as `repo:/blo.*/`, if a regex filter is encountered, it is ignored and no filter is applied.

the NL search query grammar is very lenient; a query of the form:

```
lang:tsx background repo:bloop color
```` 
is interpreted as:

```
background color (lang:tsx) (repo:bloop)
```
instead of raising a syntax error.