### PR TITLE
Add segment logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -342,6 +342,7 @@ dependencies = [
  "replace_with",
  "reqwest",
  "secrecy",
+ "segment",
  "serde",
  "serde_json",
  "serde_yaml 0.9.16",
@@ -4524,6 +4525,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "segment"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bb93f3f738322ce8f33c4e80c251fb1560ca81f3a241355271fcb912eeb48e3"
+dependencies = [
+ "async-trait",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "time 0.3.17",
+]
+
+[[package]]
 name = "selectors"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6195,6 +6210,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "422ee0de9031b5b948b97a8fc04e3aa35230001a722ddd27943e0be31564ce4c"
 dependencies = [
  "getrandom 0.2.8",
+ "rand 0.8.5",
  "serde",
 ]
 

--- a/server/bleep/Cargo.toml
+++ b/server/bleep/Cargo.toml
@@ -103,7 +103,8 @@ tokenizers = "0.13.2"
 ort = { git = "https://github.com/rsdy/ort", branch = "arm64-convert-fix" }
 ndarray = "0.15"
 maplit = "1.0.2"
-uuid = "1.2.2"
+segment = "0.2.1"
+uuid = { version = "1.2.2", features = ["v4", "fast-rng"] }
 
 [dev-dependencies]
 criterion = { version = "0.4.0", features = ["async_tokio"] }

--- a/server/bleep/src/indexes/file.rs
+++ b/server/bleep/src/indexes/file.rs
@@ -474,7 +474,7 @@ impl File {
 
         tokio::task::block_in_place(|| {
             Handle::current().block_on(self.semantic.insert_points_for_buffer(
-                &repo_name,
+                repo_name,
                 &relative_path.to_string_lossy(),
                 &buffer,
                 lang_str,

--- a/server/bleep/src/lib.rs
+++ b/server/bleep/src/lib.rs
@@ -268,7 +268,7 @@ impl Application {
         }
 
         // configure segment
-        let segment = config.segment_key.clone().map(Segment::new);
+        let segment = Arc::new(config.segment_key.clone().map(Segment::new));
 
         let config = Arc::new(config);
         let semantic = Semantic::new(&config.model_dir, &config.qdrant_url).await?;

--- a/server/bleep/src/lib.rs
+++ b/server/bleep/src/lib.rs
@@ -280,7 +280,7 @@ impl Application {
             background: BackgroundExecutor::start(config.clone()),
             semantic,
             config,
-            segment: Arc::new(segment),
+            segment,
         })
     }
 

--- a/server/bleep/src/segment.rs
+++ b/server/bleep/src/segment.rs
@@ -19,8 +19,6 @@ impl Segment {
     }
 
     pub async fn track_query(&self, user_id: &str, query: &str, snippet: &str, response: &str) {
-        let id = uuid::Uuid::new_v4().to_string();
-
         self.client
             .send(
                 self.key.expose_secret().clone(),
@@ -33,7 +31,7 @@ impl Segment {
                         "query": query.to_owned(),
                         "relevant_snippet": snippet.to_owned(),
                         "response": response.to_owned(),
-                        "id": id.to_string()
+                        "id": uuid::Uuid::new_v4()
                     }),
                     ..Default::default()
                 }),

--- a/server/bleep/src/segment.rs
+++ b/server/bleep/src/segment.rs
@@ -31,7 +31,7 @@ impl Segment {
                         "query": query.to_owned(),
                         "relevant_snippet": snippet.to_owned(),
                         "response": response.to_owned(),
-                        "id": uuid::Uuid::new_v4()
+                        "id": uuid::Uuid::new_v4().to_string()
                     }),
                     ..Default::default()
                 }),

--- a/server/bleep/src/segment.rs
+++ b/server/bleep/src/segment.rs
@@ -1,0 +1,44 @@
+use secrecy::{ExposeSecret, Secret};
+use segment::{
+    message::{Track, User},
+    Client, Message,
+};
+use serde_json::json;
+
+pub struct Segment {
+    pub key: Secret<String>,
+    pub client: segment::HttpClient,
+}
+
+impl Segment {
+    pub fn new(segment_key: Secret<String>) -> Segment {
+        Self {
+            key: segment_key,
+            client: segment::HttpClient::default(),
+        }
+    }
+
+    pub async fn track_query(&self, user_id: &str, query: &str, snippet: &str, response: &str) {
+        let id = uuid::Uuid::new_v4().to_string();
+
+        self.client
+            .send(
+                self.key.expose_secret().clone(),
+                Message::from(Track {
+                    user: User::UserId {
+                        user_id: user_id.to_owned(),
+                    },
+                    event: "openai query".to_owned(),
+                    properties: json!({
+                        "query": query.to_owned(),
+                        "relevant_snippet": snippet.to_owned(),
+                        "response": response.to_owned(),
+                        "id": id.to_string()
+                    }),
+                    ..Default::default()
+                }),
+            )
+            .await
+            .expect("Could not send to Segment");
+    }
+}

--- a/server/bleep/src/webserver/answer.rs
+++ b/server/bleep/src/webserver/answer.rs
@@ -163,7 +163,7 @@ pub async fn handle(
         snippets,
         selection: api::Response {
             data: api::DecodedResponse {
-                index: 0_u32, // the relevant snippet is always placed at 0
+                index: 0u32, // the relevant snippet is always placed at 0
                 answer: snippet_explaination,
             },
             id: params.user_id,

--- a/server/bleep/src/webserver/answer.rs
+++ b/server/bleep/src/webserver/answer.rs
@@ -147,6 +147,7 @@ pub async fn handle(
                     },
                     event: "openai query".to_owned(),
                     properties: json!({
+                        "query": params.q,
                         "relevant_snippet": &snippets[0],
                         "response": snippet_explaination,
                         "id": id.to_string()


### PR DESCRIPTION
Adds Segment. If configured, for each call to the `/answer` endpoint will track the query, the snippet deemed most relevant and the LLM response.