### PR TITLE
tune token count for completions

### DIFF
--- a/server/bleep/src/webserver/answer.rs
+++ b/server/bleep/src/webserver/answer.rs
@@ -281,9 +281,7 @@ impl AnswerAPIClient {
             snippets.len(),
             self.query,
         );
-        let tokens_used = token_count_estimate(&prompt);
-        let max_tokens = 4097 - tokens_used;
-        self.send(prompt, max_tokens).await
+        self.send(prompt, 1).await
     }
 
     async fn explain_snippet(
@@ -299,8 +297,7 @@ impl AnswerAPIClient {
             #####
 
             Above is a code snippet.\
-            Your job is to respond as a friendly customer support agent,\
-            answering the user's question with a detailed response.\
+            Answer the user's question with a detailed response.\
             Separate each function out and explain why it is relevant.\
             Format your response in GitHub markdown with code blocks annotated\
             with programming language. Include the path of the file.
@@ -310,7 +307,7 @@ impl AnswerAPIClient {
             snippet.relative_path, snippet.text, self.query
         );
         let tokens_used = token_count_estimate(&prompt);
-        let max_tokens = 4097 - tokens_used;
+        let max_tokens = 1500_u32.saturating_sub(tokens_used);
         self.send(prompt, max_tokens).await
     }
 }


### PR DESCRIPTION
this helps the app produce some truly impressive completions. the performance takes a hit however, it could take upwards of 20s to produce an answer.

some example queries: 
- with an index of `bloop`: `auth flow frontend`
- with an index of `bloop`: `how are scope graphs built`

a sample response for the second query:

---


Scope graphs are used to represent lexical scopes and names in a single syntax tree.The function `ScopeGraph::new` is used to construct a scope graph given a `TextRange` and language index `lang_id`:

```rust 
pub fn new(range: TextRange, lang_id: usize) -> Self {
    let mut graph = Graph::new();
    let root_idx = graph.add_node(NodeKind::scope(range));
    Self {
        graph,
        root_idx,
        lang_id,
    }
}
```
This function creates an empty graph, inserts a root scope as a node, and annotates it with the given `range` and `lang_id`. 

The `insert_local_scope` and `insert_local_def` functions can be used to insert a local scope and definition respectively into the scope graph. 

`insert_local_scope` takes `LocalScope` and inserts it into the scope graph under the parent scope, or the scope that encompasses that `LocalScope`. 

`insert_local_def` takes `LocalDef` and inserts it into the scope graph under the scope where it is defined. 

`insert_hoisted_def` takes a `LocalDef` and can insert it into the parent scope of the defining scope, or the scope where the `LocalDef` is defined. 

`insert_ref` is used to insert a `Reference` into the scope graph. It will traverse all the scopes from the current scope to the root scope and find candidate definitions with the same name as the `Reference`. In addition, if both the `Reference` and definition have a `symbol_id`, it will only form an edge if the namespaces of the two match. 

Finally, `scope_by_range` and `parent_scope` are helper functions for finding scopes in the scope graph.
`scope_by_range` takes a `TextRange` and a `start` node index and will return the smallest scope encompassing that `TextRange`, starting from the `start` node specified. 
`parant_scope` takes a node index of a scope and will return the parent scope of that node, or `None` if there is none. 

File: server/bleep/src/intelligence/scope_resolution.rs

---

which is highly accurate if i say so myself.
