### PR TITLE
Increase `open:` query performance on large repositories

### DIFF
--- a/server/bleep/benches/indexes.rs
+++ b/server/bleep/benches/indexes.rs
@@ -71,7 +71,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         b.iter_batched(
             || {
                 doc! {
-                    file.file_disk_path => "js-sample-big-symbols.js",
+                    file.entry_disk_path => "js-sample-big-symbols.js",
                     file.repo_ref => "local//bloop",
                     file.repo_name => "bloop",
                     file.relative_path => "js-sample-big-symbols.js",

--- a/server/bleep/src/indexes/file.rs
+++ b/server/bleep/src/indexes/file.rs
@@ -250,24 +250,21 @@ impl Indexable for File {
         let start = std::time::Instant::now();
 
         use rayon::prelude::*;
-        walker
-            .into_par_iter()
-            .chain(Some(repo.disk_path.clone()))
-            .for_each(|entry_disk_path| {
-                let workload = Workload {
-                    entry_disk_path: entry_disk_path.clone(),
-                    repo_disk_path: &repo.disk_path,
-                    repo_ref: reporef.to_string(),
-                    repo_name: &repo_name,
-                    cache: &file_cache,
-                    repo_info,
-                };
+        walker.into_par_iter().for_each(|entry_disk_path| {
+            let workload = Workload {
+                entry_disk_path: entry_disk_path.clone(),
+                repo_disk_path: &repo.disk_path,
+                repo_ref: reporef.to_string(),
+                repo_name: &repo_name,
+                cache: &file_cache,
+                repo_info,
+            };
 
-                debug!(?entry_disk_path, "queueing entry");
-                if let Err(err) = self.worker(workload, writer) {
-                    warn!(%err, ?entry_disk_path, "indexing failed; skipping");
-                }
-            });
+            debug!(?entry_disk_path, "queueing entry");
+            if let Err(err) = self.worker(workload, writer) {
+                warn!(%err, ?entry_disk_path, "indexing failed; skipping");
+            }
+        });
 
         info!(?repo.disk_path, "file indexing finished, took {:?}", start.elapsed());
 


### PR DESCRIPTION
With the `tensorflow` repository, this takes `open:` query time down from ~1 second to ~20 milliseconds, a 50x speedup.

The central idea behind this change involves introducing dummy documents into the file index, representing directories. This allows us to search for folders, without having to infer their existence due to other documents.

Before, 1.028 seconds:
```
curl -v 'localhost:7878/q?q=open:true%20repo:tensorflow'  0.00s user 0.00s system 10% cpu 1.028 total
```

After, 19 milliseconds:
```
curl -v 'localhost:7878/q?q=open:true%20repo:tensorflow'  0.00s user 0.00s system 47% cpu 0.019 total
```

Additionally, a bug with open queries of the form `some/valid/file/with/trailing/slash.txt/` resulting in panics was fixed.