### PR TITLE
Allow permission management through authenticating users

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,9 +84,9 @@ checksum = "2cb2f989d18dd141ab8ae82f64d1a8cdd37e0840f73a406896cf5e99502fab61"
 
 [[package]]
 name = "arc-swap"
-version = "1.6.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6"
+checksum = "983cd8b9d4b02a6dc6ffa557262eb5858a27a0038ffffe21a0f133eaa819a164"
 
 [[package]]
 name = "arrayref"
@@ -123,9 +123,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.61"
+version = "0.1.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "705339e0e4a9690e2908d2b3d049d85682cf19fbd5782494498fbf7003a6a282"
+checksum = "677d1d8ab452a3936018a687b20e6f7cf5363d713b732b8884001317b0e48aa3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -203,7 +203,7 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
- "itoa 1.0.5",
+ "itoa 1.0.4",
  "matchit",
  "memchr",
  "mime",
@@ -240,6 +240,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum-extra"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9a320103719de37b7b4da4c8eb629d4573f6bcfd3dfe80d3208806895ccf81d"
+dependencies = [
+ "axum",
+ "bytes",
+ "cookie",
+ "futures-util",
+ "http",
+ "mime",
+ "pin-project-lite",
+ "tokio",
+ "tower",
+ "tower-http",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -261,18 +281,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
-name = "base64"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
-
-[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "biscuit-auth"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "610aa5ab70f4c4be5819ec27314e254d71a7ef992829005f85fd84467499db44"
+dependencies = [
+ "base64",
+ "ed25519-dalek",
+ "getrandom 0.1.16",
+ "hex",
+ "nom",
+ "prost 0.9.0",
+ "prost-types 0.9.0",
+ "quote",
+ "rand 0.7.3",
+ "rand_core 0.5.1",
+ "regex",
+ "sha2 0.9.9",
+ "thiserror",
+ "time 0.3.17",
+ "zeroize",
 ]
 
 [[package]]
@@ -301,7 +338,7 @@ dependencies = [
  "cc",
  "cfg-if",
  "constant_time_eq",
- "digest",
+ "digest 0.10.6",
 ]
 
 [[package]]
@@ -311,10 +348,12 @@ dependencies = [
  "anyhow",
  "async-trait",
  "axum",
+ "axum-extra",
  "bincode",
+ "biscuit-auth",
  "blake3",
  "chrono",
- "clap 4.0.32",
+ "clap 4.0.29",
  "color-eyre",
  "compact_str",
  "console-subscriber",
@@ -386,6 +425,15 @@ checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
 
 [[package]]
 name = "block-buffer"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
@@ -436,12 +484,11 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.1.0"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b45ea9b00a7b3f2988e9a65ad3917e62123c38dba709b666506207be96d1790b"
+checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
 dependencies = [
  "memchr",
- "serde",
 ]
 
 [[package]]
@@ -470,9 +517,9 @@ checksum = "dfb24e866b15a1af2a1b663f10c6b6b8f397a84aadb828f12e5b289ec23a3a3c"
 
 [[package]]
 name = "bzip2"
-version = "0.4.4"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
+checksum = "6afcd980b5f3a45017c57e57a2fcccbb351cc43a356ce117ef760ef8052b89b0"
 dependencies = [
  "bzip2-sys",
  "libc",
@@ -504,7 +551,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.6",
  "tar",
  "tempfile",
  "thiserror",
@@ -538,9 +585,9 @@ dependencies = [
 
 [[package]]
 name = "cargo_toml"
-version = "0.13.3"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497049e9477329f8f6a559972ee42e117487d01d1e8c2cc9f836ea6fa23a9e1a"
+checksum = "aa0e3586af56b3bfa51fca452bd56e8dbbbd5d8d81cbf0b7e4e35b695b537eb8"
 dependencies = [
  "serde",
  "toml",
@@ -639,6 +686,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "chunked_transfer"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fff857943da45f546682664a79488be82e69e43c1a7a2307679ab9afb3a66d2e"
+
+[[package]]
 name = "ciborium"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -703,9 +756,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.0.32"
+version = "4.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7db700bc935f9e43e88d00b0850dae18a63773cfbec6d8e070fccf7fef89a39"
+checksum = "4d63b9e9c07271b9957ad22c173bae2a4d9a81127680962039296abcd2f8251d"
 dependencies = [
  "bitflags",
  "clap_derive",
@@ -838,21 +891,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5138945395949e7dfba09646dc9e766b548ff48e23deb5246890e6b64ae9e1b9"
 dependencies = [
  "castaway",
- "itoa 1.0.5",
+ "itoa 1.0.4",
  "ryu",
 ]
 
 [[package]]
 name = "console"
-version = "0.15.5"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d79fbe8970a77e3e34151cc13d3b3e248aa0faaecb9f6091fa07ebefe5ad60"
+checksum = "c050367d967ced717c04b65d8c619d863ef9292ce0c5760028655a2fb298718c"
 dependencies = [
  "encode_unicode",
  "lazy_static",
  "libc",
+ "terminal_size",
  "unicode-width",
- "windows-sys",
+ "winapi",
 ]
 
 [[package]]
@@ -861,8 +915,8 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e57ff02e8ad8e06ab9731d5dc72dc23bef9200778eae1a89d555d8c42e5d4a86"
 dependencies = [
- "prost",
- "prost-types",
+ "prost 0.11.6",
+ "prost-types 0.11.6",
  "tonic",
  "tracing-core",
 ]
@@ -879,7 +933,7 @@ dependencies = [
  "futures",
  "hdrhistogram",
  "humantime",
- "prost-types",
+ "prost-types 0.11.6",
  "serde",
  "serde_json",
  "thread_local",
@@ -902,6 +956,17 @@ name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
+name = "cookie"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e859cd57d0710d9e06c381b550c06e76992472a8c6d527aecd2fc673dcc231fb"
+dependencies = [
+ "percent-encoding",
+ "time 0.3.17",
+ "version_check",
+]
 
 [[package]]
 name = "core-foundation"
@@ -1103,10 +1168,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b365fabc795046672053e29c954733ec3b05e4be654ab130fe8f1f94d7051f35"
 
 [[package]]
-name = "cxx"
-version = "1.0.86"
+name = "curve25519-dalek"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d1075c37807dcf850c379432f0df05ba52cc30f279c5cfc43cc221ce7f8579"
+checksum = "0b9fdf9972b2bd6af2d913799d9ebc165ea4d2e65878e329d9c6b372c4491b61"
+dependencies = [
+ "byteorder",
+ "digest 0.9.0",
+ "rand_core 0.5.1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "cxx"
+version = "1.0.82"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4a41a86530d0fe7f5d9ea779916b7cadd2d4f9add748b99c2c029cbbdfaf453"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -1116,9 +1194,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.86"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5044281f61b27bc598f2f6647d480aed48d2bf52d6eb0b627d84c0361b17aa70"
+checksum = "06416d667ff3e3ad2df1cd8cd8afae5da26cf9cec4d0825040f88b5ca659a2f0"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -1131,15 +1209,15 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.86"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61b50bc93ba22c27b0d31128d2d130a0a6b3d267ae27ef7e4fae2167dfe8781c"
+checksum = "820a9a2af1669deeef27cb271f476ffd196a2c4b6731336011e0ba63e2c7cf71"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.86"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39e61fda7e62115119469c7b3591fd913ecca96fb766cfd3f2e2502ab7bc87a5"
+checksum = "a08a6e2fcc370a089ad3b4aaf54db3b1b4cee38ddabce5896b33eb693275f470"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1286,11 +1364,20 @@ checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "digest"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "digest"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.10.3",
  "crypto-common",
  "subtle",
 ]
@@ -1353,9 +1440,9 @@ checksum = "bd0c93bb4b0c6d9b77f4435b0ae98c24d17f1c45b2ff844c6151a07256ca923b"
 
 [[package]]
 name = "dissimilar"
-version = "1.0.5"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd5f0c7e4bd266b8ab2550e6238d2e74977c23c15536ac7be45e9c95e2e3fbbb"
+checksum = "8c97b9233581d84b8e1e689cdd3a47b6f69770084fc246e86a7f78b0d9c1d4a5"
 
 [[package]]
 name = "doc-comment"
@@ -1395,6 +1482,29 @@ name = "dunce"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bd4b30a6560bbd9b4620f4de34c3f14f60848e58a9b7216801afcb4c7b31c3c"
+
+[[package]]
+name = "ed25519"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e9c280362032ea4203659fc489832d0204ef09f247a0506f170dafcac08c369"
+dependencies = [
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "rand 0.7.3",
+ "serde",
+ "sha2 0.9.9",
+ "zeroize",
+]
 
 [[package]]
 name = "either"
@@ -1521,14 +1631,14 @@ dependencies = [
 
 [[package]]
 name = "filetime"
-version = "0.2.19"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e884668cd0c7480504233e951174ddc3b382f7c2666e3b7310b5c4e7b0c37f9"
+checksum = "4b9663d381d07ae25dc88dbdf27df458faa83a9b25336bcac83d5e452b5fc9d3"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -1797,15 +1907,15 @@ dependencies = [
 
 [[package]]
 name = "generator"
-version = "0.7.2"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d266041a359dfa931b370ef684cceb84b166beb14f7f0421f4a6a3d0c446d12e"
+checksum = "cc184cace1cea8335047a471cc1da80f18acf8a76f3bab2028d499e328948ec7"
 dependencies = [
  "cc",
  "libc",
  "log",
  "rustversion",
- "windows 0.39.0",
+ "windows 0.32.0",
 ]
 
 [[package]]
@@ -1940,15 +2050,15 @@ dependencies = [
 
 [[package]]
 name = "glob"
-version = "0.3.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "globset"
-version = "0.4.10"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "029d74589adefde59de1a0c4f4732695c32805624aec7b68d91503d4dba79afc"
+checksum = "0a1e17342619edbc21a964c2afbeb6c820c6a2560032872f397bb97ea127bd0a"
 dependencies = [
  "aho-corasick",
  "bstr",
@@ -2050,9 +2160,9 @@ checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 
 [[package]]
 name = "half"
-version = "2.2.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b4af3693f1b705df946e9fe5631932443781d0aabb423b62fcd4d73f6d2fd0"
+checksum = "ad6a9459c9c30b177b925162351f97e7d967c7ea8bab3b8352805327daf45554"
 dependencies = [
  "crunchy",
 ]
@@ -2072,7 +2182,7 @@ version = "7.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f19b9f54f7c7f55e31401bb647626ce0cf0f67b0004982ce815b3ee72a02aa8"
 dependencies = [
- "base64 0.13.1",
+ "base64",
  "byteorder",
  "flate2",
  "nom",
@@ -2163,7 +2273,7 @@ checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
 dependencies = [
  "bytes",
  "fnv",
- "itoa 1.0.5",
+ "itoa 1.0.4",
 ]
 
 [[package]]
@@ -2222,7 +2332,7 @@ dependencies = [
  "http-body",
  "httparse",
  "httpdate",
- "itoa 1.0.5",
+ "itoa 1.0.4",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -2233,9 +2343,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.23.2"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1788965e61b367cd03a62950836d5cd41560c3577d90e40e0819373194d1661c"
+checksum = "59df7c4e19c950e6e0e868dcc0a300b09a9b88e9ec55bd879ca819087a77355d"
 dependencies = [
  "http",
  "hyper",
@@ -2339,10 +2449,11 @@ dependencies = [
 
 [[package]]
 name = "ignore"
-version = "0.4.19"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a05705bc64e0b66a806c3740bd6578ea66051b157ec42dc219c785cbf185aef3"
+checksum = "713f1b139373f96a2e0ce3ac931cd01ee973c3c5dd7c40c0c2efe96ad2b6751d"
 dependencies = [
+ "crossbeam-utils",
  "globset",
  "lazy_static",
  "log",
@@ -2451,30 +2562,30 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "1.0.4"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7d6c6f8c91b4b9ed43484ad1a938e393caf35960fce7f82a040497207bd8e9e"
+checksum = "46112a93252b123d31a119a8d1a1ac19deac4fac6e0e8b0df58f0d4e5870e63c"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
 name = "ipnet"
-version = "2.7.1"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30e22bd8629359895450b59ea7a776c850561b96a3b1d31321c1949d9e6c9146"
+checksum = "ec947b7a4ce12e3b87e353abae7ce124d025b6c7d6c5aea5cc0bcf92e9510ded"
 
 [[package]]
 name = "is-terminal"
-version = "0.4.2"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dfb6c8100ccc63462345b67d1bbc3679177c75ee4bf59bf29c8b1d110b8189"
+checksum = "927609f78c2913a6f6ac3c27a4fe87f43e2a35367c0c4b0f8265e8f49a104330"
 dependencies = [
  "hermit-abi 0.2.6",
  "io-lifetimes",
  "rustix",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -2512,9 +2623,9 @@ checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "itoa"
-version = "1.0.5"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
+checksum = "4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc"
 
 [[package]]
 name = "javascriptcore-rs"
@@ -2590,11 +2701,11 @@ dependencies = [
 
 [[package]]
 name = "jsonwebtoken"
-version = "8.2.0"
+version = "8.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09f4f04699947111ec1733e71778d763555737579e44b85844cae8e1940a1828"
+checksum = "1aa4b4af834c6cfd35d8763d359661b90f2e45d8f750a0849156c7f4671af09c"
 dependencies = [
- "base64 0.13.1",
+ "base64",
  "pem",
  "ring",
  "serde",
@@ -2648,15 +2759,15 @@ checksum = "0c2cdeb66e45e9f36bfad5bbdb4d2384e70936afbee843c6f6543f0c551ebb25"
 
 [[package]]
 name = "libc"
-version = "0.2.139"
+version = "0.2.138"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
+checksum = "db6d7e329c562c5dfab7a46a2afabc8b987ab9a4834c9d1ca04dc54c1546cef8"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.14.1+1.5.0"
+version = "0.14.0+1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a07fb2692bc3593bda59de45a502bb3071659f2c515e28c71e728306b038e17"
+checksum = "47a00859c70c8a4f7218e6d1cc32875c4b55f6799445b842b0d8ed5e4c3d959b"
 dependencies = [
  "cc",
  "libc",
@@ -2703,9 +2814,9 @@ dependencies = [
 
 [[package]]
 name = "link-cplusplus"
-version = "1.0.8"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecd207c9c713c34f95a097a5b029ac2ce6010530c7b49d7fea24d977dede04f5"
+checksum = "9272ab7b96c9046fbc5bc56c06c117cb639fe2d509df0c421cad82d2915cf369"
 dependencies = [
  "cc",
 ]
@@ -2932,7 +3043,7 @@ dependencies = [
  "libc",
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -3044,9 +3155,9 @@ checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 
 [[package]]
 name = "nom"
-version = "7.1.2"
+version = "7.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5507769c4919c998e69e49c839d9dc6e693ede4cc4290d6ad8b41d4f09c548c"
+checksum = "a8903e5a29a317527874d0402f867152a3d21c908bb0b933e416c65e301d4c36"
 dependencies = [
  "memchr",
  "minimal-lexical",
@@ -3141,11 +3252,11 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.15.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
+checksum = "f6058e64324c71e02bc2b150e4f3bc8286db6c83092132ffa3f6b1eab0f9def5"
 dependencies = [
- "hermit-abi 0.2.6",
+ "hermit-abi 0.1.19",
  "libc",
 ]
 
@@ -3223,9 +3334,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.30.2"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b8c786513eb403643f2a88c244c2aaa270ef2153f55094587d0c48a3cf22a83"
+checksum = "239da7f290cfa979f43f85a8efeee9a8a76d0827c356d37f9d3d7254d6b537fb"
 dependencies = [
  "memchr",
 ]
@@ -3237,7 +3348,7 @@ source = "git+https://github.com/bloopai/octocrab#eecfe95aa2593452856aef3309a439
 dependencies = [
  "arc-swap",
  "async-trait",
- "base64 0.13.1",
+ "base64",
  "bytes",
  "cfg-if",
  "chrono",
@@ -3255,9 +3366,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.17.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
+checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
 
 [[package]]
 name = "oneshot"
@@ -3297,20 +3408,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
-name = "open"
-version = "3.2.0"
+name = "opaque-debug"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2078c0039e6a54a0c42c28faa984e115fb4c2d5bf2208f77d1961002df8576f8"
+checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+
+[[package]]
+name = "open"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4a3100141f1733ea40b53381b0ae3117330735ef22309a190ac57b9576ea716"
 dependencies = [
  "pathdiff",
- "windows-sys",
+ "windows-sys 0.36.1",
 ]
 
 [[package]]
 name = "openssl"
-version = "0.10.45"
+version = "0.10.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b102428fd03bc5edf97f62620f7298614c45cedf287c271e7ed450bbaf83f2e1"
+checksum = "12fc0523e3bd51a692c8850d075d74dc062ccf251c0110668cbd921917118a13"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -3349,9 +3466,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.80"
+version = "0.9.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23bbbf7854cd45b83958ebe919f0e8e516793727652e27fda10a8384cfc790b7"
+checksum = "5454462c0eced1e97f2ec09036abc8da362e66802f66fd20f86854d9d8cbcbc4"
 dependencies = [
  "autocfg",
  "cc",
@@ -3368,7 +3485,7 @@ source = "git+https://github.com/bloopai/ort?branch=arm64-convert-fix#153f45d872
 dependencies = [
  "casey",
  "flate2",
- "half 2.2.1",
+ "half 2.1.0",
  "lazy_static",
  "libc",
  "ndarray",
@@ -3401,7 +3518,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6a252f1f8c11e84b3ab59d7a488e48e4478a93937e027076638c49536204639"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -3477,22 +3594,22 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.6"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba1ef8814b5c993410bb3adfad7a5ed269563e4a2f90c41f5d85be7fb47133bf"
+checksum = "7ff9f3fef3968a3ec5945535ed654cb38ff72d7495a25619e2247fb15a2ed9ba"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
 name = "paste"
-version = "1.0.11"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d01a5bd0424d00070b0098dd17ebca6f961a959dead1dbcbbbc1d1cd8d3deeba"
+checksum = "b1de2e551fb905ac83f73f7aedf2f0cb4a0da7e35efa24a202a936269f1f18e1"
 
 [[package]]
 name = "pathdiff"
@@ -3502,11 +3619,11 @@ checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
 
 [[package]]
 name = "pem"
-version = "1.1.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8835c273a76a90455d7344889b0964598e3316e2a79ede8e36f16bdcf2228b8"
+checksum = "03c64931a1a212348ec4f3b4362585eca7159d0d09cbdf4a7f74f02173596fd4"
 dependencies = [
- "base64 0.13.1",
+ "base64",
 ]
 
 [[package]]
@@ -3517,9 +3634,9 @@ checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "pest"
-version = "2.5.3"
+version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4257b4a04d91f7e9e6290be5d3da4804dd5784fafde3a497d73eb2b4a158c30a"
+checksum = "cc8bed3549e0f9b0a2a78bf7c0018237a2cdf085eecbbc048e52612438e4e9d0"
 dependencies = [
  "thiserror",
  "ucd-trie",
@@ -3527,9 +3644,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.5.3"
+version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "241cda393b0cdd65e62e07e12454f1f25d57017dcc514b1514cd3c4645e3a0a6"
+checksum = "cdc078600d06ff90d4ed238f0119d84ab5d43dbaad278b0e33a8820293b32344"
 dependencies = [
  "pest",
  "pest_generator",
@@ -3537,9 +3654,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.5.3"
+version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46b53634d8c8196302953c74d5352f33d0c512a9499bd2ce468fc9f4128fa27c"
+checksum = "28a1af60b1c4148bb269006a750cff8e2ea36aff34d2d96cf7be0b14d1bed23c"
 dependencies = [
  "pest",
  "pest_meta",
@@ -3550,13 +3667,13 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.5.3"
+version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ef4f1332a8d4678b41966bb4cc1d0676880e84183a1ecc3f4b69f03e99c7a51"
+checksum = "fec8605d59fc2ae0c6c1aefc0c7c7a9769732017c0ce07f7a9cfffa7b4404f20"
 dependencies = [
  "once_cell",
  "pest",
- "sha2",
+ "sha1",
 ]
 
 [[package]]
@@ -3751,7 +3868,7 @@ version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd39bc6cdc9355ad1dc5eeedefee696bb35c34caf21768741e81826c0bbd7225"
 dependencies = [
- "base64 0.13.1",
+ "base64",
  "indexmap",
  "line-wrap",
  "serde",
@@ -3833,9 +3950,9 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.1.23"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e97e3215779627f01ee256d2fad52f3d95e8e1c11e9fc6fd08f7cd455d5d5c78"
+checksum = "2c8992a85d8e93a28bdf76137db888d3874e3b230dee5ed8bebac4c9f7617773"
 dependencies = [
  "proc-macro2",
  "syn",
@@ -3878,17 +3995,27 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-hack"
-version = "0.5.20+deprecated"
+version = "0.5.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
+checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.49"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57a8eca9f9c4ffde41714334dee777596264c7825420f521abc92b5b5deb63a5"
+checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "prost"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "444879275cb4fd84958b1a1d5420d15e6fcf7c235fe47f053c9c2a80aceb6001"
+dependencies = [
+ "bytes",
+ "prost-derive 0.9.0",
 ]
 
 [[package]]
@@ -3898,7 +4025,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21dc42e00223fc37204bd4aa177e69420c604ca4a183209a8f9de30c6d934698"
 dependencies = [
  "bytes",
- "prost-derive",
+ "prost-derive 0.11.6",
 ]
 
 [[package]]
@@ -3915,12 +4042,25 @@ dependencies = [
  "multimap",
  "petgraph",
  "prettyplease",
- "prost",
- "prost-types",
+ "prost 0.11.6",
+ "prost-types 0.11.6",
  "regex",
  "syn",
  "tempfile",
  "which",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9cc1a3263e07e0bf68e96268f37665207b49560d98739662cdfaae215c720fe"
+dependencies = [
+ "anyhow",
+ "itertools 0.10.5",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3938,12 +4078,22 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "534b7a0e836e3c482d2693070f982e39e7611da9695d4d1f5a4b186b51faef0a"
+dependencies = [
+ "bytes",
+ "prost 0.9.0",
+]
+
+[[package]]
+name = "prost-types"
 version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5e0526209433e96d83d750dd81a99118edbc55739e7e61a46764fd2ad537788"
 dependencies = [
  "bytes",
- "prost",
+ "prost 0.11.6",
 ]
 
 [[package]]
@@ -3954,8 +4104,8 @@ checksum = "300aa4bb993658e4943ddd48862b83ab76689157c82a102b60a780515126d44f"
 dependencies = [
  "anyhow",
  "futures-util",
- "prost",
- "prost-types",
+ "prost 0.11.6",
+ "prost-types 0.11.6",
  "reqwest",
  "tonic",
  "tonic-build",
@@ -3963,9 +4113,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.23"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
+checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
 dependencies = [
  "proc-macro2",
 ]
@@ -4158,9 +4308,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.7.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48aaa5748ba571fb95cd2c85c09f629215d3a6ece942baa100950af03a34f733"
+checksum = "e076559ef8e241f2ae3479e36f97bd5741c0330689e217ad51ce2c76808b868a"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4190,9 +4340,9 @@ checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
 name = "relative-path"
-version = "1.7.3"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3bf6b372449361333ac1f498b7edae4dd5e70dccd7c0c2a7c7bce8f05ede648"
+checksum = "0df32d82cedd1499386877b062ebe8721f806de80b08d183c70184ef17dd1d42"
 
 [[package]]
 name = "remove_dir_all"
@@ -4209,7 +4359,7 @@ version = "0.11.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68cc60575865c7831548863cc02356512e3f1dc2f3f82cb837d7fc4cc8f3c97c"
 dependencies = [
- "base64 0.13.1",
+ "base64",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -4316,28 +4466,28 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver 1.0.16",
+ "semver 1.0.14",
 ]
 
 [[package]]
 name = "rustix"
-version = "0.36.6"
+version = "0.36.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4feacf7db682c6c329c4ede12649cd36ecab0f3be5b7d74e6a20304725db4549"
+checksum = "a3807b5d10909833d3e9acd1eb5fb988f79376ff10fce42937de71a449c4c588"
 dependencies = [
  "bitflags",
  "errno",
  "io-lifetimes",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.20.8"
+version = "0.20.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fff78fc74d175294f4e83b28343315ffcfb114b156f0185e9741cb5570f50e2f"
+checksum = "539a2bfe908f471bfa933876bd1eb6a19cf2176d375f82ef7f99530a40e48c2c"
 dependencies = [
  "log",
  "ring",
@@ -4359,24 +4509,24 @@ dependencies = [
 
 [[package]]
 name = "rustls-pemfile"
-version = "1.0.2"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
+checksum = "0864aeff53f8c05aa08d86e5ef839d3dfcf07aeba2db32f12db0ef716e87bd55"
 dependencies = [
- "base64 0.21.0",
+ "base64",
 ]
 
 [[package]]
 name = "rustversion"
-version = "1.0.11"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5583e89e108996506031660fe09baa5011b9dd0341b89029313006d1fb508d70"
+checksum = "97477e48b4cf8603ad5f7aaf897467cf42ab4218a38ef76fb14c2d6773a6d6a8"
 
 [[package]]
 name = "ryu"
-version = "1.0.12"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
+checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
 
 [[package]]
 name = "safemem"
@@ -4395,11 +4545,12 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.21"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "713cfb06c7059f3588fb8044c0fad1d09e3c01d225e25b9220dbfdcf16dbb1b3"
+checksum = "88d6731146462ea25d9244b2ed5fd1d716d25c52e4d54aa4fb0f3c4e9854dbe2"
 dependencies = [
- "windows-sys",
+ "lazy_static",
+ "windows-sys 0.36.1",
 ]
 
 [[package]]
@@ -4416,9 +4567,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "scratch"
-version = "1.0.3"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddccb15bcce173023b3fedd9436f882a0739b8dfb45e4f6b6002bee5929f61b2"
+checksum = "9c8132065adcfd6e02db789d9285a0deb2f3fcb04002865ab67d5fb103533898"
 
 [[package]]
 name = "sct"
@@ -4508,9 +4659,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.16"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58bc9567378fc7690d6b2addae4e60ac2eeea07becb2c64b9f218b53865cba2a"
+checksum = "e25dfac463d778e353db5be2449d1cce89bd6fd23c9f1ea21310ce6e5a1b29c4"
 dependencies = [
  "serde",
 ]
@@ -4609,18 +4760,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.152"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
+checksum = "97fed41fc1a24994d044e6db6935e69511a1153b52c15eb42493b26fa87feba0"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.152"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
+checksum = "255abe9a125a985c05190d687b320c12f9b1f0b99445e608c21ba0782c719ad8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4633,25 +4784,25 @@ version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877c235533714907a8c2464236f5c4b2a17262ef1bd71f38f35ea592c8da6883"
 dependencies = [
- "itoa 1.0.5",
+ "itoa 1.0.4",
  "ryu",
  "serde",
 ]
 
 [[package]]
 name = "serde_path_to_error"
-version = "0.1.9"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b04f22b563c91331a10074bda3dd5492e3cc39d56bd557e91c0af42b6c7341"
+checksum = "184c643044780f7ceb59104cef98a5a6f12cb2288a7bc701ab93a362b49fd47d"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "serde_repr"
-version = "0.1.10"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a5ec9fa74a20ebbe5d9ac23dac1fc96ba0ecfe9f50f2843b52e537b10fbcb4e"
+checksum = "1fe39d9fbb0ebf5eb2c7cb7e2a47e4f462fad1379f1166b8ae49ad9eae89a7ca"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4665,7 +4816,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
 dependencies = [
  "form_urlencoded",
- "itoa 1.0.5",
+ "itoa 1.0.4",
  "ryu",
  "serde",
 ]
@@ -4711,7 +4862,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92b5b431e8907b50339b51223b97d102db8d987ced36f6e4d03621db9316c834"
 dependencies = [
  "indexmap",
- "itoa 1.0.5",
+ "itoa 1.0.4",
  "ryu",
  "serde",
  "unsafe-libyaml",
@@ -4750,6 +4901,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.10.6",
+]
+
+[[package]]
+name = "sha2"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
+dependencies = [
+ "block-buffer 0.9.0",
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.9.0",
+ "opaque-debug",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4757,7 +4932,7 @@ checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.10.6",
 ]
 
 [[package]]
@@ -4787,6 +4962,12 @@ checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "signature"
+version = "1.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
 
 [[package]]
 name = "simple_asn1"
@@ -4826,9 +5007,9 @@ dependencies = [
 
 [[package]]
 name = "snafu"
-version = "0.7.4"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb0656e7e3ffb70f6c39b3c2a86332bb74aa3c679da781642590f3c1118c5045"
+checksum = "a152ba99b054b22972ee794cf04e5ef572da1229e33b65f3c57abbff0525a454"
 dependencies = [
  "backtrace",
  "doc-comment",
@@ -4837,9 +5018,9 @@ dependencies = [
 
 [[package]]
 name = "snafu-derive"
-version = "0.7.4"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "475b3bbe5245c26f2d8a6f62d67c1f30eb9fffeccee721c45d162c3ebbdf81b2"
+checksum = "d5e79cdebbabaebb06a9bdbaedc7f159b410461f63611d4d0e3fb0fab8fed850"
 dependencies = [
  "heck 0.4.0",
  "proc-macro2",
@@ -4906,7 +5087,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5851699c4033c63636f7ea4cf7b7c1f1bf06d0cc03cfb42e711de5a5c46cf326"
 dependencies = [
- "base64 0.13.1",
+ "base64",
  "nom",
  "serde",
  "unicode-segmentation",
@@ -5001,6 +5182,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20518fe4a4c9acf048008599e464deb21beeae3d3578418951a189c235a7a9a8"
 
 [[package]]
+name = "synstructure"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "unicode-xid",
+]
+
+[[package]]
 name = "system-deps"
 version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5033,7 +5226,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69d1878f2daa432d6b907e1a7e16a25ba7eab6cc0da059e69943276a5165d81b"
 dependencies = [
  "async-trait",
- "base64 0.13.1",
+ "base64",
  "bitpacking",
  "byteorder",
  "census",
@@ -5117,9 +5310,9 @@ dependencies = [
 
 [[package]]
 name = "tao"
-version = "0.15.8"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac8e6399427c8494f9849b58694754d7cc741293348a6836b6c8d2c5aa82d8e6"
+checksum = "a0382fcc02b87420a0d024ff6ec2dbfccdccafb46de8c03fb07dbf2f36810a42"
 dependencies = [
  "bitflags",
  "cairo-rs",
@@ -5174,13 +5367,13 @@ dependencies = [
 
 [[package]]
 name = "tauri"
-version = "1.2.3"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b48820ee3bb6a5031a83b2b6e11f8630bdc5a2f68cb841ab8ebc7a15a916679"
+checksum = "d8ea1d785ab2164373703817bff144c4610a69ad3f659becaca0e1ea004b98d8"
 dependencies = [
  "anyhow",
  "attohttpc",
- "base64 0.13.1",
+ "base64",
  "cocoa",
  "dirs-next",
  "embed_plist",
@@ -5204,7 +5397,7 @@ dependencies = [
  "raw-window-handle",
  "regex",
  "rfd",
- "semver 1.0.16",
+ "semver 1.0.14",
  "serde",
  "serde_json",
  "serde_repr",
@@ -5238,7 +5431,7 @@ dependencies = [
  "cargo_toml",
  "heck 0.4.0",
  "json-patch",
- "semver 1.0.16",
+ "semver 1.0.14",
  "serde_json",
  "tauri-utils",
  "winres",
@@ -5250,7 +5443,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14388d484b6b1b5dc0f6a7d6cc6433b3b230bec85eaa576adcdf3f9fafa49251"
 dependencies = [
- "base64 0.13.1",
+ "base64",
  "brotli",
  "ico",
  "json-patch",
@@ -5259,10 +5452,10 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "semver 1.0.16",
+ "semver 1.0.14",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.6",
  "tauri-utils",
  "thiserror",
  "time 0.3.17",
@@ -5342,7 +5535,7 @@ dependencies = [
  "phf 0.10.1",
  "proc-macro2",
  "quote",
- "semver 1.0.16",
+ "semver 1.0.14",
  "serde",
  "serde_json",
  "serde_with",
@@ -5394,6 +5587,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -5463,7 +5666,7 @@ version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a561bf4617eebd33bca6434b988f39ed798e527f51a1e797d0ee4f61c0a38376"
 dependencies = [
- "itoa 1.0.5",
+ "itoa 1.0.4",
  "serde",
  "time-core",
  "time-macros",
@@ -5546,9 +5749,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.24.1"
+version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d9f76183f91ecfb55e1d7d5602bd1d979e38a3a522fe900241cf195624d67ae"
+checksum = "eab6d665857cc6ca78d6e80303a02cea7a7851e85dfbd77cbdc09bd129f1ef46"
 dependencies = [
  "autocfg",
  "bytes",
@@ -5561,7 +5764,7 @@ dependencies = [
  "socket2",
  "tokio-macros",
  "tracing",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -5649,7 +5852,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "axum",
- "base64 0.13.1",
+ "base64",
  "bytes",
  "futures-core",
  "futures-util",
@@ -5660,8 +5863,8 @@ dependencies = [
  "hyper-timeout",
  "percent-encoding",
  "pin-project",
- "prost",
- "prost-derive",
+ "prost 0.11.6",
+ "prost-derive 0.11.6",
  "rustls-native-certs",
  "rustls-pemfile",
  "tokio",
@@ -5714,7 +5917,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f873044bf02dd1e8239e9c1293ea39dad76dc594ec16185d0a1bf31d8dc8d858"
 dependencies = [
- "base64 0.13.1",
+ "base64",
  "bitflags",
  "bytes",
  "futures-core",
@@ -5932,9 +6135,9 @@ dependencies = [
 
 [[package]]
 name = "try-lock"
-version = "0.2.4"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
+checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
 name = "typenum"
@@ -5965,9 +6168,9 @@ checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.6"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
+checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
 
 [[package]]
 name = "unicode-normalization"
@@ -6000,6 +6203,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
+
+[[package]]
 name = "unicode_categories"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6007,9 +6216,9 @@ checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
 
 [[package]]
 name = "unsafe-libyaml"
-version = "0.2.5"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc7ed8ba44ca06be78ea1ad2c3682a43349126c8818054231ee6f4748012aed2"
+checksum = "c1e5fa573d8ac5f1a856f8d7be41d390ee973daf97c806b2c1a465e4e1406e68"
 
 [[package]]
 name = "untrusted"
@@ -6019,11 +6228,12 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "ureq"
-version = "2.6.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "733b5ad78377302af52c0dbcb2623d78fe50e4b3bf215948ff29e9ee031d8566"
+checksum = "b97acb4c28a254fd7a4aeec976c46a7fa404eac4d7c134b30c75144846d7cb8f"
 dependencies = [
- "base64 0.13.1",
+ "base64",
+ "chunked_transfer",
  "flate2",
  "log",
  "native-tls",
@@ -6330,9 +6540,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.22.6"
+version = "0.22.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
+checksum = "368bfe657969fb01238bb756d351dcade285e0f6fcbd36dcb23359a5169975be"
 dependencies = [
  "webpki",
 ]
@@ -6419,6 +6629,19 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbedf6db9096bc2364adce0ae0aa636dcd89f3c3f2cd67947062aaf0ca2a10ec"
+dependencies = [
+ "windows_aarch64_msvc 0.32.0",
+ "windows_i686_gnu 0.32.0",
+ "windows_i686_msvc 0.32.0",
+ "windows_x86_64_gnu 0.32.0",
+ "windows_x86_64_msvc 0.32.0",
+]
+
+[[package]]
+name = "windows"
 version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57b543186b344cc61c85b5aab0d2e3adf4e0f99bc076eff9aa5927bcc0b8a647"
@@ -6472,17 +6695,30 @@ checksum = "9ee5e275231f07c6e240d14f34e1b635bf1faa1c76c57cfd59a5cdb9848e4278"
 
 [[package]]
 name = "windows-sys"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
+dependencies = [
+ "windows_aarch64_msvc 0.36.1",
+ "windows_i686_gnu 0.36.1",
+ "windows_i686_msvc 0.36.1",
+ "windows_x86_64_gnu 0.36.1",
+ "windows_x86_64_msvc 0.36.1",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
 dependencies = [
  "windows_aarch64_gnullvm",
- "windows_aarch64_msvc 0.42.1",
- "windows_i686_gnu 0.42.1",
- "windows_i686_msvc 0.42.1",
- "windows_x86_64_gnu 0.42.1",
+ "windows_aarch64_msvc 0.42.0",
+ "windows_i686_gnu 0.42.0",
+ "windows_i686_msvc 0.42.0",
+ "windows_x86_64_gnu 0.42.0",
  "windows_x86_64_gnullvm",
- "windows_x86_64_msvc 0.42.1",
+ "windows_x86_64_msvc 0.42.0",
 ]
 
 [[package]]
@@ -6493,9 +6729,21 @@ checksum = "f838de2fe15fe6bac988e74b798f26499a8b21a9d97edec321e79b28d1d7f597"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.1"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
+checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8e92753b1c443191654ec532f14c199742964a061be25d77d7a96f09db20bf5"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -6511,9 +6759,21 @@ checksum = "ec7711666096bd4096ffa835238905bb33fb87267910e154b18b44eaabb340f2"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.1"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
+checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a711c68811799e017b6038e0922cb27a5e2f43a2ddb609fe0b6f3eeda9de615"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6529,9 +6789,21 @@ checksum = "763fc57100a5f7042e3057e7e8d9bdd7860d330070251a73d003563a3bb49e1b"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.1"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640"
+checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "146c11bb1a02615db74680b32a68e2d61f553cc24c4eb5b4ca10311740e44172"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -6547,9 +6819,21 @@ checksum = "7bc7cbfe58828921e10a9f446fcaaf649204dcfe6c1ddd712c5eebae6bda1106"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.1"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605"
+checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c912b12f7454c6620635bbff3450962753834be2a594819bd5e945af18ec64bc"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -6565,15 +6849,27 @@ checksum = "6868c165637d653ae1e8dc4d82c25d4f97dd6605eaa8d784b5c6e0ab2a252b65"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.1"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
+checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.1"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
+checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "504a2476202769977a040c6364301a3f65d0cc9e3fb08600b2bda150a0488316"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -6589,9 +6885,9 @@ checksum = "5e4d40883ae9cae962787ca76ba76390ffa29214667a111db9e0a1ad8377e809"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.1"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
+checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
 
 [[package]]
 name = "winreg"
@@ -6617,7 +6913,7 @@ version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c1ad8e2424f554cc5bdebe8aa374ef5b433feff817aebabca0389961fc7ef98"
 dependencies = [
- "base64 0.13.1",
+ "base64",
  "block",
  "cocoa",
  "core-graphics",
@@ -6637,7 +6933,7 @@ dependencies = [
  "once_cell",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.6",
  "soup2",
  "tao",
  "thiserror",
@@ -6651,9 +6947,9 @@ dependencies = [
 
 [[package]]
 name = "x11"
-version = "2.20.1"
+version = "2.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2638d5b9c17ac40575fb54bb461a4b1d2a8d1b4ffcc4ff237d254ec59ddeb82"
+checksum = "f7ae97874a928d821b061fce3d1fc52f08071dd53c89a6102bc06efcac3b2908"
 dependencies = [
  "libc",
  "pkg-config",
@@ -6661,9 +6957,9 @@ dependencies = [
 
 [[package]]
 name = "x11-dl"
-version = "2.20.1"
+version = "2.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1536d6965a5d4e573c7ef73a2c15ebcd0b2de3347bdf526c34c297c00ac40f0"
+checksum = "0c83627bc137605acc00bb399c7b908ef460b621fc37c953db2b09f88c449ea6"
 dependencies = [
  "lazy_static",
  "libc",
@@ -6705,6 +7001,21 @@ name = "zeroize"
 version = "1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c394b5bd0c6f669e7275d9c20aa90ae064cb22e75a1cad54e1b34088034b149f"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44bf07cb3e50ea2003396695d58bf46bc9887a1f362260446fad6bc4e79bd36c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
 
 [[package]]
 name = "zip"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,9 +123,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.60"
+version = "0.1.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d1d8ab452a3936018a687b20e6f7cf5363d713b732b8884001317b0e48aa3"
+checksum = "705339e0e4a9690e2908d2b3d049d85682cf19fbd5782494498fbf7003a6a282"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -353,7 +353,7 @@ dependencies = [
  "biscuit-auth",
  "blake3",
  "chrono",
- "clap 4.0.29",
+ "clap 4.0.32",
  "color-eyre",
  "compact_str",
  "console-subscriber",
@@ -484,11 +484,12 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "0.2.17"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
+checksum = "b45ea9b00a7b3f2988e9a65ad3917e62123c38dba709b666506207be96d1790b"
 dependencies = [
  "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -756,9 +757,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.0.29"
+version = "4.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d63b9e9c07271b9957ad22c173bae2a4d9a81127680962039296abcd2f8251d"
+checksum = "a7db700bc935f9e43e88d00b0850dae18a63773cfbec6d8e070fccf7fef89a39"
 dependencies = [
  "bitflags",
  "clap_derive",
@@ -2056,9 +2057,9 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "globset"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a1e17342619edbc21a964c2afbeb6c820c6a2560032872f397bb97ea127bd0a"
+checksum = "029d74589adefde59de1a0c4f4732695c32805624aec7b68d91503d4dba79afc"
 dependencies = [
  "aho-corasick",
  "bstr",
@@ -2449,11 +2450,10 @@ dependencies = [
 
 [[package]]
 name = "ignore"
-version = "0.4.18"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "713f1b139373f96a2e0ce3ac931cd01ee973c3c5dd7c40c0c2efe96ad2b6751d"
+checksum = "a05705bc64e0b66a806c3740bd6578ea66051b157ec42dc219c785cbf185aef3"
 dependencies = [
- "crossbeam-utils",
  "globset",
  "lazy_static",
  "log",
@@ -3366,9 +3366,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
+checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
 
 [[package]]
 name = "oneshot"
@@ -3634,9 +3634,9 @@ checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "pest"
-version = "2.5.1"
+version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc8bed3549e0f9b0a2a78bf7c0018237a2cdf085eecbbc048e52612438e4e9d0"
+checksum = "4257b4a04d91f7e9e6290be5d3da4804dd5784fafde3a497d73eb2b4a158c30a"
 dependencies = [
  "thiserror",
  "ucd-trie",
@@ -3644,9 +3644,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.5.1"
+version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdc078600d06ff90d4ed238f0119d84ab5d43dbaad278b0e33a8820293b32344"
+checksum = "241cda393b0cdd65e62e07e12454f1f25d57017dcc514b1514cd3c4645e3a0a6"
 dependencies = [
  "pest",
  "pest_generator",
@@ -3654,9 +3654,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.5.1"
+version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28a1af60b1c4148bb269006a750cff8e2ea36aff34d2d96cf7be0b14d1bed23c"
+checksum = "46b53634d8c8196302953c74d5352f33d0c512a9499bd2ce468fc9f4128fa27c"
 dependencies = [
  "pest",
  "pest_meta",
@@ -3667,13 +3667,13 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.5.1"
+version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fec8605d59fc2ae0c6c1aefc0c7c7a9769732017c0ce07f7a9cfffa7b4404f20"
+checksum = "0ef4f1332a8d4678b41966bb4cc1d0676880e84183a1ecc3f4b69f03e99c7a51"
 dependencies = [
  "once_cell",
  "pest",
- "sha1",
+ "sha2 0.10.6",
 ]
 
 [[package]]
@@ -4340,9 +4340,9 @@ checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
 name = "relative-path"
-version = "1.7.2"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0df32d82cedd1499386877b062ebe8721f806de80b08d183c70184ef17dd1d42"
+checksum = "d3bf6b372449361333ac1f498b7edae4dd5e70dccd7c0c2a7c7bce8f05ede648"
 
 [[package]]
 name = "remove_dir_all"
@@ -4760,18 +4760,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.151"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fed41fc1a24994d044e6db6935e69511a1153b52c15eb42493b26fa87feba0"
+checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.151"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "255abe9a125a985c05190d687b320c12f9b1f0b99445e608c21ba0782c719ad8"
+checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4898,17 +4898,6 @@ checksum = "d98238b800e0d1576d8b6e3de32827c2d74bee68bb97748dcf5071fb53965432"
 dependencies = [
  "nodrop",
  "stable_deref_trait",
-]
-
-[[package]]
-name = "sha1"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest 0.10.6",
 ]
 
 [[package]]
@@ -5749,9 +5738,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.23.0"
+version = "1.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eab6d665857cc6ca78d6e80303a02cea7a7851e85dfbd77cbdc09bd129f1ef46"
+checksum = "1d9f76183f91ecfb55e1d7d5602bd1d979e38a3a522fe900241cf195624d67ae"
 dependencies = [
  "autocfg",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,6 +200,7 @@ dependencies = [
  "bitflags",
  "bytes",
  "futures-util",
+ "headers",
  "http",
  "http-body",
  "hyper",
@@ -2188,6 +2189,31 @@ dependencies = [
  "flate2",
  "nom",
  "num-traits",
+]
+
+[[package]]
+name = "headers"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3e372db8e5c0d213e0cd0b9be18be2aca3d44cf2fe30a9d46a65581cd454584"
+dependencies = [
+ "base64",
+ "bitflags",
+ "bytes",
+ "headers-core",
+ "http",
+ "httpdate",
+ "mime",
+ "sha1",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
+dependencies = [
+ "http",
 ]
 
 [[package]]
@@ -4898,6 +4924,17 @@ checksum = "d98238b800e0d1576d8b6e3de32827c2d74bee68bb97748dcf5071fb53965432"
 dependencies = [
  "nodrop",
  "stable_deref_trait",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.10.6",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5714,6 +5714,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f873044bf02dd1e8239e9c1293ea39dad76dc594ec16185d0a1bf31d8dc8d858"
 dependencies = [
+ "base64 0.13.1",
  "bitflags",
  "bytes",
  "futures-core",

--- a/server/bleep/Cargo.toml
+++ b/server/bleep/Cargo.toml
@@ -65,6 +65,7 @@ petgraph = { version = "0.6.2", default-features = false, features = ["serde-1"]
 serde_json = "1.0.91"
 utoipa = { version = "2.4.2", features = ["axum_extras", "yaml"] }
 axum = { version = "0.6.2", features = ["http2"] }
+axum-extra = { version = "0.4.2", features = ["cookie"] }
 tower-http = { version = "0.3.5", features = ["auth", "cors", "catch-panic"] }
 
 # api integrations
@@ -101,6 +102,7 @@ tokenizers = "0.13.2"
 ort = { git = "https://github.com/bloopai/ort", branch = "arm64-convert-fix" }
 ndarray = "0.15"
 uuid = { version = "1.2.2", features = ["v4", "fast-rng"] }
+biscuit-auth = "2.2.0"
 
 # telemetry
 sentry = "0.29.1"

--- a/server/bleep/Cargo.toml
+++ b/server/bleep/Cargo.toml
@@ -65,7 +65,7 @@ petgraph = { version = "0.6.2", default-features = false, features = ["serde-1"]
 serde_json = "1.0.91"
 utoipa = { version = "2.4.2", features = ["axum_extras", "yaml"] }
 axum = { version = "0.6.2", features = ["http2"] }
-tower-http = {version = "0.3.5", features = ["cors", "catch-panic"]}
+tower-http = { version = "0.3.5", features = ["auth", "cors", "catch-panic"] }
 
 # api integrations
 octocrab = { git = "https://github.com/bloopai/octocrab", default-features = false, features = ["rustls"] }

--- a/server/bleep/Cargo.toml
+++ b/server/bleep/Cargo.toml
@@ -64,7 +64,7 @@ petgraph = { version = "0.6.2", default-features = false, features = ["serde-1"]
 # webserver
 serde_json = "1.0.91"
 utoipa = { version = "2.4.2", features = ["axum_extras", "yaml"] }
-axum = { version = "0.6.2", features = ["http2"] }
+axum = { version = "0.6.2", features = ["http2", "headers"] }
 axum-extra = { version = "0.4.2", features = ["cookie"] }
 tower-http = { version = "0.3.5", features = ["auth", "cors", "catch-panic"] }
 

--- a/server/bleep/src/background.rs
+++ b/server/bleep/src/background.rs
@@ -199,7 +199,7 @@ impl IndexWriter {
 		    bail!("no keys for backend {:?}", backend)
 		};
 
-                if !app.path_allowed(path) {
+                if !app.allow_path(path) {
                     bail!("path not authorized {repo:?}")
                 }
 

--- a/server/bleep/src/lib.rs
+++ b/server/bleep/src/lib.rs
@@ -16,7 +16,6 @@ use criterion as _;
 #[cfg(all(feature = "debug", not(tokio_unstable)))]
 use console_subscriber as _;
 
-use octocrab::current::ListReposForAuthenticatedUserBuilder;
 use semantic::{chunk::OverlapStrategy, Semantic};
 use webserver::AuthenticationLayer;
 

--- a/server/bleep/src/lib.rs
+++ b/server/bleep/src/lib.rs
@@ -32,7 +32,7 @@ use clap::Parser;
 use once_cell::sync::OnceCell;
 use relative_path::RelativePath;
 use secrecy::SecretString;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use std::{
     ops::Not,
     path::{Path, PathBuf},

--- a/server/bleep/src/lib.rs
+++ b/server/bleep/src/lib.rs
@@ -115,6 +115,8 @@ fn default_max_chunk_tokens() -> usize {
 pub enum Environment {
     /// Safe API that's suitable for public use
     Server,
+    /// Access to the API is access controlled using an OAuth provider
+    PrivateServer,
     /// Enables scanning arbitrary user-specified locations through a Web-endpoint.
     InsecureLocal,
 }
@@ -125,7 +127,7 @@ impl Default for Environment {
     }
 }
 
-#[derive(Serialize, Deserialize, Parser, Debug)]
+#[derive(Deserialize, Parser, Debug)]
 #[clap(author, version, about, long_about = None)]
 pub struct Configuration {
     #[clap(skip)]
@@ -189,16 +191,6 @@ pub struct Configuration {
     /// Bind the webserver to `<host>`
     pub port: u16,
 
-    #[clap(long, default_value_t = default_qdrant_url())]
-    #[serde(default = "default_qdrant_url")]
-    /// URL for the qdrant server
-    pub qdrant_url: String,
-
-    #[clap(long, default_value_t = default_answer_api_url())]
-    #[serde(default = "default_answer_api_url")]
-    /// URL for the answer-api
-    pub answer_api_url: String,
-
     #[clap(long, default_value_os_t = default_model_dir())]
     #[serde(default = "default_model_dir")]
     /// Path to the embedding model directory
@@ -217,6 +209,23 @@ pub struct Configuration {
     #[clap(long)]
     /// Chunking strategy
     pub overlap: Option<OverlapStrategy>,
+
+    //
+    // External dependencies
+    //
+    #[clap(long, default_value_t = default_qdrant())]
+    #[serde(default = "default_qdrant")]
+    /// URL for the qdrant server
+    pub qdrant_url: String,
+
+    #[clap(long, default_value_t = default_answer_api_base())]
+    #[serde(default = "default_answer_api_base")]
+    /// Answer API `base` string
+    pub answer_api_base: String,
+
+    #[clap(long)]
+    /// Address to authentication server for private deployments
+    pub auth_server_url: Option<SecretString>,
 }
 
 impl Configuration {
@@ -262,7 +271,12 @@ impl Application {
         config.buffer_size = config.buffer_size.max(threads * 3_000_000);
         config.repo_buffer_size = config.repo_buffer_size.max(threads * 3_000_000);
         config.source.set_default_dir(&config.index_dir);
-        config.env = env;
+
+        if config.auth_server_url.is_some() {
+            config.env = Environment::PrivateServer;
+        } else {
+            config.env = env;
+        }
 
         if let Some(ref executable) = config.ctags_path {
             ctags::CTAGS_BINARY
@@ -380,16 +394,16 @@ impl Application {
         Ok(())
     }
 
-    pub(crate) fn scan_allowed(&self) -> bool {
+    pub(crate) fn allow_path_scan(&self) -> bool {
         use Environment::*;
 
         match self.config.env {
-            Server => false,
             InsecureLocal => true,
+            _ => false,
         }
     }
 
-    pub(crate) fn path_allowed(&self, path: impl AsRef<Path>) -> bool {
+    pub(crate) fn allow_path(&self, path: impl AsRef<Path>) -> bool {
         use Environment::*;
 
         let source_dir = self.config.source.directory();
@@ -398,7 +412,27 @@ impl Application {
                 .map(|p| p.to_logical_path(&source_dir))
                 .unwrap_or_else(|_| path.as_ref().to_owned())
                 .starts_with(&source_dir),
+            PrivateServer => false,
             InsecureLocal => true,
+        }
+    }
+
+    pub(crate) fn allow_github_device_flow(&self) -> bool {
+        use Environment::*;
+        match self.config.env {
+            Server => true,
+            InsecureLocal => true,
+            PrivateServer => false,
+        }
+    }
+
+    /// Use AAA layer (authentication, authorization, accounting)
+    pub(crate) fn use_aaa(&self) -> bool {
+        use Environment::*;
+        match self.config.env {
+            Server => false,
+            InsecureLocal => false,
+            PrivateServer => true,
         }
     }
 
@@ -408,7 +442,6 @@ impl Application {
     // To be performed on the background executor
     //
     //
-
     pub(crate) fn write_index(&self) -> background::IndexWriter {
         background::IndexWriter(self.clone())
     }

--- a/server/bleep/src/lib.rs
+++ b/server/bleep/src/lib.rs
@@ -114,7 +114,7 @@ fn default_max_chunk_tokens() -> usize {
     256
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum Environment {
     /// Safe API that's suitable for public use
     Server,
@@ -124,19 +124,39 @@ pub enum Environment {
     InsecureLocal,
 }
 
-impl Default for Environment {
-    fn default() -> Self {
-        Environment::Server
+impl Environment {
+    pub(crate) fn allow_path_scan(&self) -> bool {
+        use Environment::*;
+
+        match self {
+            InsecureLocal => true,
+            _ => false,
+        }
+    }
+
+    pub(crate) fn allow_github_device_flow(&self) -> bool {
+        use Environment::*;
+        match self {
+            Server => true,
+            InsecureLocal => true,
+            PrivateServer => false,
+        }
+    }
+
+    /// Use AAA layer (authentication, authorization, accounting)
+    pub(crate) fn use_aaa(&self) -> bool {
+        use Environment::*;
+        match self {
+            Server => false,
+            InsecureLocal => false,
+            PrivateServer => true,
+        }
     }
 }
 
 #[derive(Deserialize, Parser, Debug)]
 #[clap(author, version, about, long_about = None)]
 pub struct Configuration {
-    #[clap(skip)]
-    #[serde(skip)]
-    pub(crate) env: Environment,
-
     #[clap(short, long)]
     #[serde(skip)]
     /// If a config file is given, it will override _all_ command line parameters!
@@ -248,6 +268,7 @@ impl Configuration {
 
 #[derive(Clone)]
 pub struct Application {
+    pub env: Environment,
     pub config: Arc<Configuration>,
     pub segment: Arc<Option<Segment>>,
     pub(crate) repo_pool: RepositoryPool,
@@ -275,12 +296,6 @@ impl Application {
         config.buffer_size = config.buffer_size.max(threads * 3_000_000);
         config.repo_buffer_size = config.repo_buffer_size.max(threads * 3_000_000);
         config.source.set_default_dir(&config.index_dir);
-
-        if config.auth_server_url.is_some() {
-            config.env = Environment::PrivateServer;
-        } else {
-            config.env = env;
-        }
 
         if let Some(ref executable) = config.ctags_path {
             ctags::CTAGS_BINARY
@@ -310,16 +325,24 @@ impl Application {
 
         let indexes = Arc::new(Indexes::new(config.clone(), semantic.clone())?);
         let auth = AuthenticationLayer::new(&config);
+        let env = if config.auth_server_url.is_some() {
+            Environment::PrivateServer
+        } else {
+            env
+        };
 
         Ok(Self {
             repo_pool: config.source.initialize_pool()?,
-            credentials: config.source.initialize_credentials()?,
             background: BackgroundExecutor::start(config.clone()),
+            credentials: config
+                .source
+                .initialize_credentials(auth.clone(), env.clone())?,
             indexes,
             semantic,
             config,
             segment,
             auth,
+            env,
         })
     }
 
@@ -400,45 +423,17 @@ impl Application {
         Ok(())
     }
 
-    pub(crate) fn allow_path_scan(&self) -> bool {
-        use Environment::*;
-
-        match self.config.env {
-            InsecureLocal => true,
-            _ => false,
-        }
-    }
-
     pub(crate) fn allow_path(&self, path: impl AsRef<Path>) -> bool {
         use Environment::*;
 
         let source_dir = self.config.source.directory();
-        match self.config.env {
+        match self.env {
             Server => RelativePath::from_path(&path)
                 .map(|p| p.to_logical_path(&source_dir))
                 .unwrap_or_else(|_| path.as_ref().to_owned())
                 .starts_with(&source_dir),
             PrivateServer => false,
             InsecureLocal => true,
-        }
-    }
-
-    pub(crate) fn allow_github_device_flow(&self) -> bool {
-        use Environment::*;
-        match self.config.env {
-            Server => true,
-            InsecureLocal => true,
-            PrivateServer => false,
-        }
-    }
-
-    /// Use AAA layer (authentication, authorization, accounting)
-    pub(crate) fn use_aaa(&self) -> bool {
-        use Environment::*;
-        match self.config.env {
-            Server => false,
-            InsecureLocal => false,
-            PrivateServer => true,
         }
     }
 

--- a/server/bleep/src/remotes.rs
+++ b/server/bleep/src/remotes.rs
@@ -131,22 +131,6 @@ pub(crate) enum BackendCredential {
 }
 
 impl BackendCredential {
-    pub(crate) fn to_github_client(&self) -> octocrab::Result<octocrab::Octocrab> {
-        let Self::Github(github::Auth {
-            access_token,
-            token_type,
-            scope,
-        }) = self.clone();
-
-        let token = octocrab::auth::OAuth {
-            access_token,
-            token_type,
-            scope,
-        };
-
-        octocrab::Octocrab::builder().oauth(token).build()
-    }
-
     pub(crate) async fn sync(self, app: Application, repo_ref: RepoRef) -> Result<()> {
         tokio::task::spawn_blocking(move || {
             use BackendCredential::*;

--- a/server/bleep/src/remotes.rs
+++ b/server/bleep/src/remotes.rs
@@ -131,6 +131,14 @@ pub(crate) enum BackendCredential {
 }
 
 impl BackendCredential {
+    pub(crate) async fn validate(&self) -> Result<()> {
+        let BackendCredential::Github(auth) = self;
+
+        let client = auth.client()?;
+        client.current().user().await?;
+        Ok(())
+    }
+
     pub(crate) async fn sync(self, app: Application, repo_ref: RepoRef) -> Result<()> {
         tokio::task::spawn_blocking(move || {
             use BackendCredential::*;

--- a/server/bleep/src/remotes/github.rs
+++ b/server/bleep/src/remotes/github.rs
@@ -1,4 +1,6 @@
 use anyhow::Result;
+use chrono::{DateTime, Utc};
+use octocrab::Octocrab;
 use secrecy::{ExposeSecret, SecretString};
 use serde::{Deserialize, Serialize};
 
@@ -7,11 +9,33 @@ use crate::state::Repository;
 use super::*;
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
-pub struct Auth {
-    #[serde(serialize_with = "crate::state::serialize_secret_str")]
-    pub access_token: SecretString,
-    pub token_type: String,
-    pub scope: Vec<String>,
+pub enum Auth {
+    /// Copy of [`octocrab::auth::OAuth`] that can be serialized
+    OAuth {
+        #[serde(serialize_with = "crate::state::serialize_secret_str")]
+        access_token: SecretString,
+        token_type: String,
+        scope: Vec<String>,
+    },
+    /// Github App Installation JWT token.
+    JWT {
+        #[serde(serialize_with = "crate::state::serialize_secret_str")]
+        /// Technically, serializing this doesn't make any sense,
+        /// because it expires quickly, but the current code paths
+        /// make this the most straightforward way to implement it
+        token: SecretString,
+        expiry: DateTime<Utc>,
+    },
+}
+
+impl From<octocrab::auth::OAuth> for Auth {
+    fn from(auth: octocrab::auth::OAuth) -> Self {
+        Self::OAuth {
+            access_token: auth.access_token,
+            token_type: auth.token_type,
+            scope: auth.scope,
+        }
+    }
 }
 
 impl Auth {
@@ -24,7 +48,36 @@ impl Auth {
     }
 
     fn git_cred(&self) -> Box<git2::Credentials<'static>> {
-        let token = self.access_token.clone();
-        Box::new(move |_, _, _| Cred::userpass_plaintext(token.expose_secret(), "x-oauth-basic"))
+        use Auth::*;
+        match self.clone() {
+            OAuth { access_token, .. } => Box::new(move |_, _, _| {
+                Cred::userpass_plaintext(access_token.expose_secret(), "ignored by github")
+            }),
+            JWT { token, .. } => Box::new(move |_, _, _| {
+                Cred::userpass_plaintext("x-access-token", token.expose_secret())
+            }),
+        }
+    }
+
+    pub fn client(&self) -> octocrab::Result<Octocrab> {
+        use Auth::*;
+        match self.clone() {
+            OAuth {
+                access_token,
+                token_type,
+                scope,
+            } => {
+                let token = octocrab::auth::OAuth {
+                    access_token,
+                    token_type,
+                    scope,
+                };
+
+                Octocrab::builder().oauth(token).build()
+            }
+            JWT { token, .. } => Octocrab::builder()
+                .personal_token(token.expose_secret().to_string())
+                .build(),
+        }
     }
 }

--- a/server/bleep/src/remotes/poll.rs
+++ b/server/bleep/src/remotes/poll.rs
@@ -29,9 +29,10 @@ pub(crate) async fn check_credentials(app: Application) {
                 .ensure_fresh_github_installation_token()
                 .await
         } else {
-            let expired = 'expired: {
-                let Some(client) = app.credentials.github_client().await else { break 'expired true };
-                client.current().user().await.is_err()
+            let expired = if let Some(github) = app.credentials.get(Backend::Github) {
+                github.validate().await.is_err()
+            } else {
+                true
             };
 
             if expired && app.credentials.remove(&Backend::Github).is_some() {

--- a/server/bleep/src/state.rs
+++ b/server/bleep/src/state.rs
@@ -2,7 +2,7 @@ use crate::{
     ctags::{get_symbols, SymbolMap},
     indexes,
     language::{get_language_info, LanguageInfo},
-    remotes::{gather_repo_roots, BackendCredential},
+    remotes::gather_repo_roots,
     AuthenticationLayer, Environment,
 };
 use clap::Args;

--- a/server/bleep/src/state/credentials.rs
+++ b/server/bleep/src/state/credentials.rs
@@ -1,0 +1,99 @@
+use std::{borrow::Borrow, sync::Arc};
+
+use anyhow::Result;
+use chrono::{Duration, Utc};
+use dashmap::DashMap;
+use tracing::error;
+
+use crate::{
+    remotes::{self, BackendCredential},
+    AuthenticationLayer, Environment,
+};
+
+use super::Backend;
+
+type CredStore = DashMap<Backend, BackendCredential>;
+
+#[derive(Clone)]
+pub(crate) struct Credentials {
+    credstore: Arc<CredStore>,
+    auth: AuthenticationLayer,
+    env: Environment,
+}
+
+impl Credentials {
+    pub(super) fn new(
+        credstore: Arc<CredStore>,
+        auth: AuthenticationLayer,
+        env: Environment,
+    ) -> Self {
+        Self {
+            credstore,
+            auth,
+            env,
+        }
+    }
+
+    pub(super) fn serializable(&self) -> &CredStore {
+        &self.credstore
+    }
+
+    pub fn get(&self, backend: impl Borrow<Backend>) -> Option<BackendCredential> {
+        self.credstore
+            .get(backend.borrow())
+            .map(|elem| elem.value().clone())
+    }
+
+    pub fn insert(&self, backend: impl Borrow<Backend>, creds: BackendCredential) {
+        self.credstore.insert(backend.borrow().clone(), creds);
+    }
+
+    pub fn remove(&self, backend: impl Borrow<Backend>) -> Option<(Backend, BackendCredential)> {
+        self.credstore.remove(backend.borrow())
+    }
+
+    pub(crate) async fn ensure_fresh_github_installation_token(&self) {
+        let Some(BackendCredential::Github(auth)) = self.get(Backend::Github) else {
+	    self.get_new_github_token().await;
+	    return;
+	};
+
+        if let remotes::github::Auth::JWT { expiry, .. } = auth {
+            if expiry < Utc::now() + Duration::minutes(10) {
+                self.get_new_github_token().await;
+            }
+        }
+    }
+
+    pub(crate) async fn github_client(&self) -> Option<octocrab::Octocrab> {
+        let auth = match self.get(Backend::Github) {
+            Some(BackendCredential::Github(auth)) => auth,
+            None => {
+                let BackendCredential::Github(auth) = self.get_new_github_token().await.ok()?;
+                auth
+            }
+        };
+
+        auth.client().ok()
+    }
+
+    async fn get_new_github_token(&self) -> Result<BackendCredential> {
+        let jwt = self
+            .auth
+            .get("/private/jwt")
+            .await?
+            .json::<BackendCredential>()
+            .await;
+
+        match jwt {
+            Ok(token) => {
+                self.insert(Backend::Github, token.clone());
+                Ok(token)
+            }
+            Err(err) => {
+                error!(?err, "failed to refresh token");
+                Err(err.into())
+            }
+        }
+    }
+}

--- a/server/bleep/src/state/credentials.rs
+++ b/server/bleep/src/state/credentials.rs
@@ -71,6 +71,12 @@ impl Credentials {
         }
     }
 
+    /// TODO: Get the list of users that can access the organization
+    /// referenced by the current installation token.
+    pub(crate) async fn github_installation_org_users(&self) -> Vec<String> {
+        todo!()
+    }
+
     pub(crate) async fn github_client(&self) -> Option<octocrab::Octocrab> {
         let auth = match self.get(Backend::Github) {
             Some(BackendCredential::Github(auth)) => auth,

--- a/server/bleep/src/webserver.rs
+++ b/server/bleep/src/webserver.rs
@@ -82,11 +82,11 @@ pub async fn start(app: Application) -> Result<()> {
     }
 
     router = router
-        .layer(CatchPanicLayer::new())
         .layer(Extension(app.indexes.clone()))
         .layer(Extension(app.semantic.clone()))
         .layer(Extension(app))
-        .layer(CorsLayer::permissive());
+        .layer(CorsLayer::permissive())
+        .layer(CatchPanicLayer::new());
 
     info!(%bind, "starting webserver");
     axum::Server::bind(&bind)

--- a/server/bleep/src/webserver.rs
+++ b/server/bleep/src/webserver.rs
@@ -21,6 +21,8 @@ mod query;
 mod repos;
 mod semantic;
 
+pub(super) use aaa::AuthenticationLayer;
+
 #[allow(unused)]
 pub(in crate::webserver) mod prelude {
     pub(in crate::webserver) use super::{error, json, EndpointError, ErrorKind};
@@ -76,12 +78,7 @@ pub async fn start(app: Application) -> Result<()> {
     }
 
     if app.use_aaa() {
-        router = router
-            .route("/auth/login", get(aaa::login))
-            .route("/auth/authorized", put(aaa::authorized))
-            .route("/auth/users", put(aaa::list_users))
-            .route("/auth/users/:user", put(aaa::set_user))
-            .layer(RequireAuthorizationLayer::custom(aaa::MyAuth));
+        router = router.merge(aaa::router(app.auth.clone()));
     }
 
     router = router

--- a/server/bleep/src/webserver.rs
+++ b/server/bleep/src/webserver.rs
@@ -78,7 +78,7 @@ pub async fn start(app: Application) -> Result<()> {
     }
 
     if app.env.use_aaa() {
-        router = router.merge(aaa::router(app.auth.clone()));
+        router = router.merge(aaa::router());
     }
 
     router = router

--- a/server/bleep/src/webserver.rs
+++ b/server/bleep/src/webserver.rs
@@ -67,17 +67,17 @@ pub async fn start(app: Application) -> Result<()> {
         .route("/api-doc/openapi.yaml", get(openapi_yaml::handle))
         .route("/health", get(health));
 
-    if app.allow_github_device_flow() {
+    if app.env.allow_github_device_flow() {
         router = router
             .route("/remotes/github/login", get(github::login))
             .route("/remotes/github/status", get(github::status));
     }
 
-    if app.allow_path_scan() {
+    if app.env.allow_path_scan() {
         router = router.route("/repos/scan", get(repos::scan_local));
     }
 
-    if app.use_aaa() {
+    if app.env.use_aaa() {
         router = router.merge(aaa::router(app.auth.clone()));
     }
 

--- a/server/bleep/src/webserver.rs
+++ b/server/bleep/src/webserver.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 use axum::routing::put;
 use axum::{response::IntoResponse, routing::get, Extension, Json, Router};
 use std::{borrow::Cow, net::SocketAddr};
-use tower_http::{auth::RequireAuthorizationLayer, catch_panic::CatchPanicLayer, cors::CorsLayer};
+use tower_http::{catch_panic::CatchPanicLayer, cors::CorsLayer};
 use tracing::info;
 use utoipa::OpenApi;
 use utoipa::ToSchema;

--- a/server/bleep/src/webserver/aaa.rs
+++ b/server/bleep/src/webserver/aaa.rs
@@ -367,7 +367,15 @@ pub(super) async fn authorized(
     };
     app.auth.backend_tokens.insert(userid.clone(), oauth);
 
-    let perms = UserPermissions::default();
+    // we need to check if this is a re-auth, or they've been
+    // pre-provisioned through a `/private/hello` call.
+    let perms = app
+        .auth
+        .user_perms
+        .get(&userid)
+        .map(|elem| elem.value().clone())
+        .unwrap_or_default();
+
     let token = app.auth.issue_auth_cookie(userid, perms);
 
     (jar.add(Cookie::new(COOKIE, token)), Redirect::to("/"))

--- a/server/bleep/src/webserver/aaa.rs
+++ b/server/bleep/src/webserver/aaa.rs
@@ -1,0 +1,90 @@
+use super::*;
+use axum::{
+    body::{self, boxed},
+    extract::Path,
+    http::{self, header::AUTHORIZATION, Error, Request, Response, StatusCode},
+};
+use tower_http::auth::{AuthorizeRequest, RequireAuthorizationLayer};
+
+#[derive(Clone, Copy)]
+pub(super) struct MyAuth;
+
+#[derive(Debug)]
+struct UserId(String);
+
+impl<B> AuthorizeRequest<B> for MyAuth {
+    type ResponseBody = body::BoxBody;
+
+    fn authorize(&mut self, request: &mut Request<B>) -> Result<(), Response<Self::ResponseBody>> {
+        if let Some(user_id) = check_auth(request) {
+            // Set `user_id` as a request extension so it can be accessed by other
+            // services down the stack.
+            request.extensions_mut().insert(user_id);
+
+            Ok(())
+        } else {
+            let unauthorized_response = Response::builder()
+                .status(StatusCode::UNAUTHORIZED)
+                .body(boxed(body::Empty::new()))
+                .unwrap();
+
+            Err(unauthorized_response)
+        }
+    }
+}
+
+fn check_auth<B>(request: &Request<B>) -> Option<UserId> {
+    // ...
+    None
+}
+
+/// Initiate a new login using a web-based OAuth flow
+#[utoipa::path(get, path = "/auth/login",
+    responses(
+        (status = 200, description = "Execute query successfully", body = Response),
+        (status = 400, description = "Bad request", body = EndpointError),
+        (status = 500, description = "Server error", body = EndpointError),
+    ),
+)]
+pub(super) async fn login(Extension(app): Extension<Application>) -> impl IntoResponse {
+    todo!()
+}
+
+/// Complete the login flow. Can only be called by the `auth_server` daemon
+#[utoipa::path(post, path = "/auth/authorized",
+    responses(
+        (status = 200, description = "Execute query successfully", body = Response),
+        (status = 400, description = "Bad request", body = EndpointError),
+        (status = 500, description = "Server error", body = EndpointError),
+    ),
+)]
+pub(super) async fn authorized(Extension(app): Extension<Application>) -> impl IntoResponse {
+    todo!()
+}
+
+/// List all users in the organization (admin only)
+#[utoipa::path(get, path = "/auth/users",
+    responses(
+        (status = 200, description = "Execute query successfully", body = Response),
+        (status = 400, description = "Bad request", body = EndpointError),
+        (status = 500, description = "Server error", body = EndpointError),
+    ),
+)]
+pub(super) async fn list_users(Extension(app): Extension<Application>) -> impl IntoResponse {
+    todo!()
+}
+
+/// Set user permissions & details (admin only)
+#[utoipa::path(put, path = "/auth/users/:user",
+    responses(
+        (status = 200, description = "Execute query successfully", body = Response),
+        (status = 400, description = "Bad request", body = EndpointError),
+        (status = 500, description = "Server error", body = EndpointError),
+    ),
+)]
+pub(super) async fn set_user(
+    Path(user): Path<String>,
+    Extension(app): Extension<Application>,
+) -> impl IntoResponse {
+    todo!()
+}

--- a/server/bleep/src/webserver/aaa.rs
+++ b/server/bleep/src/webserver/aaa.rs
@@ -1,18 +1,77 @@
+use std::sync::Arc;
+
+use crate::Configuration;
+
 use super::*;
 use axum::{
     body::{self, boxed},
-    extract::Path,
+    extract::{Path, Query},
     http::{self, header::AUTHORIZATION, Error, Request, Response, StatusCode},
+    response::Redirect,
 };
+use axum_extra::extract::cookie::{Cookie, CookieJar};
+use dashmap::{DashMap, DashSet};
+use secrecy::{ExposeSecret, SecretString};
+use serde::Deserialize;
+use serde_json::json;
 use tower_http::auth::{AuthorizeRequest, RequireAuthorizationLayer};
 
-#[derive(Clone, Copy)]
-pub(super) struct MyAuth;
+type State = String;
+type Token = String;
+type Oauth = String;
+
+pub(super) fn router(auth: AuthenticationLayer) -> Router {
+    Router::new()
+        .route("/auth/login/start", get(login))
+        .route("/auth/login/complete", put(authorized))
+        .route("/auth/users", put(list_users))
+        .route("/auth/users/:user", put(set_user))
+        .layer(RequireAuthorizationLayer::custom(auth))
+}
+
+#[derive(Clone)]
+pub(crate) struct AuthenticationLayer {
+    client: reqwest::Client,
+    host: Option<SecretString>,
+    initialized_login: Arc<DashSet<State>>,
+    cached_tokens: Arc<DashMap<State, Token>>,
+}
+
+impl AuthenticationLayer {
+    pub fn new(config: &Configuration) -> Self {
+        AuthenticationLayer {
+            client: reqwest::Client::new(),
+            host: config.auth_server_url.clone(),
+            initialized_login: DashSet::default().into(),
+            cached_tokens: DashMap::default().into(),
+        }
+    }
+
+    async fn post(
+        &self,
+        path: &str,
+        json: &serde_json::Value,
+    ) -> reqwest::Result<reqwest::Response> {
+        let url = format!(
+            "{}/{path}",
+            self.host
+                .as_ref()
+                .expect("auth server not found")
+                .expose_secret()
+        );
+        self.client.post(url).json(json).send().await
+    }
+
+    async fn get(&self, path: &str) -> reqwest::Result<reqwest::Response> {
+        let url = format!("{}/{path}", self.host.as_ref().unwrap().expose_secret());
+        self.client.get(url).send().await
+    }
+}
 
 #[derive(Debug)]
 struct UserId(String);
 
-impl<B> AuthorizeRequest<B> for MyAuth {
+impl<B> AuthorizeRequest<B> for AuthenticationLayer {
     type ResponseBody = body::BoxBody;
 
     fn authorize(&mut self, request: &mut Request<B>) -> Result<(), Response<Self::ResponseBody>> {
@@ -38,28 +97,75 @@ fn check_auth<B>(request: &Request<B>) -> Option<UserId> {
     None
 }
 
-/// Initiate a new login using a web-based OAuth flow
-#[utoipa::path(get, path = "/auth/login",
-    responses(
-        (status = 200, description = "Execute query successfully", body = Response),
-        (status = 400, description = "Bad request", body = EndpointError),
-        (status = 500, description = "Server error", body = EndpointError),
-    ),
-)]
-pub(super) async fn login(Extension(app): Extension<Application>) -> impl IntoResponse {
-    todo!()
+#[derive(Deserialize)]
+pub(super) struct LoginParams {
+    state: State,
 }
 
-/// Complete the login flow. Can only be called by the `auth_server` daemon
-#[utoipa::path(post, path = "/auth/authorized",
+#[derive(Deserialize)]
+pub(super) struct LoginComplete {
+    oauth: String,
+    token: Token,
+}
+
+/// Initiate a new login using a web-based OAuth flow
+#[utoipa::path(get, path = "/auth/login/start",
     responses(
         (status = 200, description = "Execute query successfully", body = Response),
         (status = 400, description = "Bad request", body = EndpointError),
         (status = 500, description = "Server error", body = EndpointError),
     ),
 )]
-pub(super) async fn authorized(Extension(app): Extension<Application>) -> impl IntoResponse {
-    todo!()
+pub(super) async fn login(
+    Extension(app): Extension<Application>,
+    Query(params): Query<LoginParams>,
+) -> impl IntoResponse {
+    let state = params.state;
+    let github_oauth_url = &format!(
+        "https://github.com/login/oauth/authorize?client_id={}&state={state}&allow_signup=false",
+        app.config
+            .github_client_id
+            .as_ref()
+            .expect("github client id must be provided")
+            .expose_secret()
+    );
+
+    app.auth
+        .post("/private/start_login", &json!({ "state": &state }))
+        .await
+        .unwrap();
+
+    app.auth.initialized_login.insert(state);
+    Redirect::to(github_oauth_url)
+}
+
+/// Complete the login flow.
+#[utoipa::path(post, path = "/auth/login/complete",
+    responses(
+        (status = 200, description = "Execute query successfully", body = Response),
+        (status = 400, description = "Bad request", body = EndpointError),
+        (status = 500, description = "Server error", body = EndpointError),
+    ),
+)]
+pub(super) async fn authorized(
+    Extension(app): Extension<Application>,
+    Query(params): Query<LoginParams>,
+    jar: CookieJar,
+) -> impl IntoResponse {
+    let state = params.state;
+    let token = app
+        .auth
+        .get(&format!("/private/issue_token?state={state}"))
+        .await
+        .unwrap()
+        .json::<LoginComplete>()
+        .await
+        .unwrap();
+
+    (
+        jar.add(Cookie::new("auth_token", token.token)),
+        Redirect::to("/"),
+    )
 }
 
 /// List all users in the organization (admin only)

--- a/server/bleep/src/webserver/repos.rs
+++ b/server/bleep/src/webserver/repos.rs
@@ -272,7 +272,7 @@ pub(super) async fn scan_local(
 ) -> impl IntoResponse {
     let root = std::path::Path::new(&scan_request.path);
 
-    if app.path_allowed(root) {
+    if app.allow_path(root) {
         (
             StatusCode::OK,
             json(ReposResponse::List(


### PR DESCRIPTION
This PR adds a mode for `bloop` to work as a [Github App](https://docs.github.com/en/developers/apps/getting-started-with-apps/about-apps) installation that's limited in scope to [a single organization](https://docs.github.com/en/developers/apps/building-github-apps/authenticating-with-github-apps#authenticating-as-an-installation).

The base assumption is that the **only** entity that controls the Github App keys is the auth bastion server (`auth_server_url` command line/config option), while **only** the bloop instances hold the users' OAuth keys.

This PR holds an initial bloop client implementation that talks to an emergent auth bastion specification (TBD).

## Current status:

 * the main addition is `webserver/aaa.rs` to hold AAA-related functionality
 * there are lot of corner cases not covered here, I tried to document these in the code as I went
 * wiring up bloop to an auth bastion should work, and syncing repos should be possible (not tested, though)
 * users should be able to sign up with the correct Github App setup, and an auth bastion
 * token issuance
 * key rotation, check for expiry, upstream revokation
 
## Not implemented

 * setting up a root admin user (should send a `/private/hello` to the auth bastion to see who asked for the deployment?)
 * persistence of user oauth keys (this forces users to re-login every time we restart the service)
 * there are a few DoS opportunities
 * error handling, nice HTTP responses
 * `TODO` comments in the PR code, `todo!()` macros
 * the auth bastion server itself