### PR TITLE
Track each step of the query pipeline in Segment

### DIFF
--- a/server/bleep/src/segment.rs
+++ b/server/bleep/src/segment.rs
@@ -5,6 +5,15 @@ use segment::{
 };
 use serde_json::json;
 
+pub struct QueryEvent {
+    pub user_id: String,
+    pub query: String,
+    pub select_prompt: String,
+    pub relevant_snippet_index: usize,
+    pub explain_prompt: String,
+    pub explanation: String,
+}
+
 pub struct Segment {
     pub key: Secret<String>,
     pub client: segment::HttpClient,
@@ -18,19 +27,21 @@ impl Segment {
         }
     }
 
-    pub async fn track_query(&self, user_id: &str, query: &str, snippet: &str, response: &str) {
+    pub async fn track_query(&self, event: QueryEvent) {
         self.client
             .send(
                 self.key.expose_secret().clone(),
                 Message::from(Track {
                     user: User::UserId {
-                        user_id: user_id.to_owned(),
+                        user_id: event.user_id,
                     },
                     event: "openai query".to_owned(),
                     properties: json!({
-                        "query": query.to_owned(),
-                        "relevant_snippet": snippet.to_owned(),
-                        "response": response.to_owned(),
+                        "query": event.query,
+                        "select_prompt": event.select_prompt,
+                        "relevant_snippet_index": event.relevant_snippet_index,
+                        "explain_prompt": event.explain_prompt,
+                        "explanation": event.explanation,
                         "id": uuid::Uuid::new_v4().to_string()
                     }),
                     ..Default::default()

--- a/server/bleep/src/webserver/answer.rs
+++ b/server/bleep/src/webserver/answer.rs
@@ -269,13 +269,13 @@ impl Semantic {
 impl<'s> AnswerAPIClient<'s> {
     async fn send(
         &self,
-        prompt: String,
+        prompt: &str,
         max_tokens: u32,
     ) -> Result<reqwest::Response, reqwest::Error> {
         self.client
             .post(self.host.as_str())
             .json(&OpenAIRequest {
-                prompt: prompt.clone(),
+                prompt: prompt.to_string(),
                 max_tokens,
             })
             .send()
@@ -339,7 +339,7 @@ impl<'a> AnswerAPIClient<'a> {
     }
 
     async fn select_snippet(&self, prompt: &str) -> Result<reqwest::Response, reqwest::Error> {
-        self.send(prompt.to_string(), 1).await
+        self.send(prompt, 1).await
     }
 
     async fn explain_snippet(&self, prompt: &str) -> Result<reqwest::Response, reqwest::Error> {
@@ -355,6 +355,6 @@ impl<'a> AnswerAPIClient<'a> {
         // do not let the completion cross 2500 tokens
         let max_tokens = max_tokens.clamp(1, 500);
         info!(%max_tokens, "clamping max tokens");
-        self.send(prompt.to_string(), max_tokens as u32).await
+        self.send(prompt, max_tokens as u32).await
     }
 }


### PR DESCRIPTION
This PR updates our Segment query logging. Now we track each step of the query pipeline as a separate Segment property:
- User query
- Select prompt (includes all snippets returned by semantic search)
- Most relevant snippet
- Explain prompt
- Answer