### PR TITLE
remove overlapping snippets from qdrant's response

### DIFF
--- a/server/bleep/src/lib.rs
+++ b/server/bleep/src/lib.rs
@@ -394,3 +394,10 @@ fn tracing_subscribe() -> bool {
         .try_init()
         .is_ok()
 }
+
+// FIXME: use usize::div_ceil soon
+fn div_ceil(a: usize, b: usize) -> usize {
+    let d = a / b;
+    let r = a % b;
+    d + usize::from(r > 0)
+}

--- a/server/bleep/src/semantic.rs
+++ b/server/bleep/src/semantic.rs
@@ -12,7 +12,7 @@ use qdrant_client::{
     qdrant::{
         r#match::MatchValue, vectors_config, with_payload_selector::SelectorOptions,
         CollectionOperationResponse, CreateCollection, Distance, FieldCondition, Filter, Match,
-        PointId, PointStruct, SearchPoints, Value, VectorParams, VectorsConfig,
+        PointId, PointStruct, ScoredPoint, SearchPoints, VectorParams, VectorsConfig,
         WithPayloadSelector,
     },
 };
@@ -161,7 +161,7 @@ impl Semantic {
         &self,
         nl_query: &NLQuery<'a>,
         limit: u64,
-    ) -> anyhow::Result<Vec<HashMap<String, Value>>> {
+    ) -> anyhow::Result<Vec<ScoredPoint>> {
         let Some(query) = nl_query.target() else {
             anyhow::bail!("no search target for query");
         };
@@ -207,7 +207,7 @@ impl Semantic {
             })
             .await?;
 
-        Ok(response.result.into_iter().map(|pt| pt.payload).collect())
+        Ok(response.result)
     }
 
     #[tracing::instrument(skip(self, repo_ref, relative_path, buffer))]
@@ -223,7 +223,7 @@ impl Semantic {
             repo_name,
             relative_path,
             buffer,
-            &self.tokenizer,
+            &self.gpt2_tokenizer,
             self.config.embedding_input_size,
             15,
             self.config

--- a/server/bleep/src/webserver/query.rs
+++ b/server/bleep/src/webserver/query.rs
@@ -197,7 +197,7 @@ impl PagingMetadata {
         Self {
             page,
             page_size,
-            page_count: total_count.map(|t| div_ceil(t, page_size)),
+            page_count: total_count.map(|t| crate::div_ceil(t, page_size)),
             total_count,
         }
     }
@@ -426,13 +426,6 @@ impl ExecuteQuery for ContentReader {
         };
         Ok(response)
     }
-}
-
-// FIXME: use usize::div_ceil soon
-fn div_ceil(a: usize, b: usize) -> usize {
-    let d = a / b;
-    let r = a % b;
-    d + usize::from(r > 0)
 }
 
 #[async_trait]

--- a/server/bleep/src/webserver/semantic.rs
+++ b/server/bleep/src/webserver/semantic.rs
@@ -35,7 +35,8 @@ pub(super) async fn raw_chunks(
         let result = semantic.search(&query, limit).await.and_then(|raw| {
             raw.into_iter()
                 .map(|v| {
-                    v.into_iter()
+                    v.payload
+                        .into_iter()
                         .map(|(k, v)| (k, kind_to_value(v.kind)))
                         .collect::<HashMap<_, _>>()
                 })


### PR DESCRIPTION
before sending snippets for selection, we trim the snippet collection by removing overlapping snippets and limiting the number of snippets to 2 per file. 

the algorithm used to remove overlapping snippets is the [activity-selection](https://en.wikipedia.org/wiki/Activity_selection_problem) algorithm. here, the line-intervals of each snippet are analogous to the time-intervals of each activity. this algorithm helps us maximize the number of snippets selected per file. 