### PR TITLE
introduce sentry to bleep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,6 +321,7 @@ dependencies = [
  "criterion",
  "dashmap",
  "directories",
+ "dotenvy",
  "dunce",
  "either",
  "expect-test",
@@ -350,6 +351,7 @@ dependencies = [
  "reqwest",
  "secrecy",
  "segment",
+ "sentry",
  "serde",
  "serde_json",
  "serde_yaml 0.9.16",
@@ -1360,6 +1362,12 @@ name = "doc-comment"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
+name = "dotenvy"
+version = "0.15.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03d8c417d7a8cb362e0c37e5d815f5eb7c37f79ff93707329d5a194e42e54ca0"
 
 [[package]]
 name = "downcast-rs"

--- a/server/bleep/Cargo.toml
+++ b/server/bleep/Cargo.toml
@@ -100,8 +100,12 @@ qdrant-client = { version = "0.11.6", default-features = false }
 tokenizers = "0.13.2"
 ort = { git = "https://github.com/bloopai/ort", branch = "arm64-convert-fix" }
 ndarray = "0.15"
-segment = "0.2.1"
 uuid = { version = "1.2.2", features = ["v4", "fast-rng"] }
+
+# telemetry
+sentry = "0.29.1"
+dotenvy = "0.15.6"
+segment = "0.2.1"
 
 [target.'cfg(windows)'.dependencies]
 dunce = "1.0.3"

--- a/server/bleep/src/bin/bleep.rs
+++ b/server/bleep/src/bin/bleep.rs
@@ -4,6 +4,9 @@ use bleep::{Application, Configuration, Environment};
 #[tokio::main]
 async fn main() -> Result<()> {
     Application::install_logging();
+    Application::load_env_vars();
+    Application::install_sentry();
     let app = Application::initialize(Environment::Server, Configuration::from_cli()?).await?;
+
     app.run().await
 }

--- a/server/bleep/src/segment.rs
+++ b/server/bleep/src/segment.rs
@@ -1,4 +1,3 @@
-use secrecy::{ExposeSecret, Secret};
 use segment::{
     message::{Track, User},
     Client, Message,
@@ -15,12 +14,12 @@ pub struct QueryEvent {
 }
 
 pub struct Segment {
-    pub key: Secret<String>,
+    pub key: String,
     pub client: segment::HttpClient,
 }
 
 impl Segment {
-    pub fn new(segment_key: Secret<String>) -> Segment {
+    pub fn new(segment_key: String) -> Segment {
         Self {
             key: segment_key,
             client: segment::HttpClient::default(),
@@ -30,7 +29,7 @@ impl Segment {
     pub async fn track_query(&self, event: QueryEvent) {
         self.client
             .send(
-                self.key.expose_secret().clone(),
+                self.key.clone(),
                 Message::from(Track {
                     user: User::UserId {
                         user_id: event.user_id,


### PR DESCRIPTION
- attempts to load environment variables from `.env`
- attempts to initialize sentry with dsn: `VITE_SENTRY_DSN_BE`
- attempts to initialize segment with key from `SEGMENT_KEY_BE`
- gets rid of cli flag to initialize segment