### PR TITLE
fix overlong chunks

### DIFF
--- a/server/bleep/src/semantic/chunk.rs
+++ b/server/bleep/src/semantic/chunk.rs
@@ -177,7 +177,7 @@ fn add_token_range<'s>(
     if trimmed_end_byte <= start_byte {
         return;
     }
-    assert!(
+    debug_assert!(
         end - start < 256,
         "chunk too large: {} tokens in {:?} bytes {:?}",
         end - start,

--- a/server/bleep/src/semantic/chunk.rs
+++ b/server/bleep/src/semantic/chunk.rs
@@ -1,4 +1,7 @@
-use std::{fmt::{Display, Write}, ops::Range};
+use std::{
+    fmt::{Display, Write},
+    ops::Range,
+};
 
 use crate::text_range::{Point, TextRange};
 


### PR DESCRIPTION
The problem was two-fold. First, the last chunk ignored overlong lines (especially for files with one long line) and second, the  add_token_range method always extended the chunk back to the start of the line. So on an overlong line, the first partial chunk was OK, the next one a bit too long, the next one even longer and so on.

To make matters worse, onnxruntime broadcasted the dimension by 512, allocating huge swathes of memory in the process.

So here's hope that will at least significantly reduce our perf problem during indexing.
