### PR TITLE
Fix off-by-one in line counting

### DIFF
--- a/server/bleep/src/semantic/chunk.rs
+++ b/server/bleep/src/semantic/chunk.rs
@@ -248,7 +248,7 @@ pub fn by_tokens<'s>(
     let mut chunks = Vec::new();
     let mut s = 0;
     let mut offset = 0;
-    let (mut last_line, mut last_byte) = (1, 0);
+    let (mut last_line, mut last_byte) = (0, 0);
     while let Some(index_diff) = starts[s..].iter().position(|&p| p - offset > max_tokens) {
         let index_diff = index_diff - 1;
         // add (offset, end) to token_ranges, split if necessary


### PR DESCRIPTION
When I wrote the chunking, I didn't have the frontend running, so I did not know that it incremented the line count by 1. Therefore, I "naturally" counted from one, which leads to us counting from 2 in the frontend.

This removes the increment in the backend, so we are counting from one again.