### PR TITLE
Speed up CI

### DIFF
--- a/.github/workflows/server-test.yml
+++ b/.github/workflows/server-test.yml
@@ -36,11 +36,6 @@ jobs:
           override: true
           components: rustfmt, clippy
 
-      - name: Install Tauri dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libgtk-3-dev webkit2gtk-4.0 libappindicator3-dev librsvg2-dev patchelf
-
       - name: Dummy Qdrant binary
         run: touch apps/desktop/src-tauri/bin/qdrant-x86_64-unknown-linux-gnu
 
@@ -55,9 +50,6 @@ jobs:
 
       - name: Rust fmt
         run: cargo fmt -p bleep -- --check
-
-      - name: Build whole project
-        run: cargo build
 
       - uses: actions-rs/clippy-check@v1
         with:

--- a/apps/desktop/src-tauri/src/backend.rs
+++ b/apps/desktop/src-tauri/src/backend.rs
@@ -1,9 +1,8 @@
 use bleep::{Application, Configuration, Environment};
-use tauri::{Manager, Runtime};
 
-use crate::{relative_command_path, Payload};
+use super::{plugin, relative_command_path, App, Manager, Payload, Runtime};
 
-pub(super) fn bleep<R>(app: &mut tauri::App<R>) -> tauri::plugin::Result<()>
+pub(super) fn bleep<R>(app: &mut App<R>) -> plugin::Result<()>
 where
     R: Runtime,
 {

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -12,6 +12,7 @@ use bleep::Application;
 use once_cell::sync::OnceCell;
 use sentry::ClientInitGuard;
 use std::sync::{Arc, RwLock};
+pub use tauri::{plugin, App, Manager, Runtime};
 
 static TELEMETRY: RwLock<bool> = RwLock::new(false);
 static SENTRY: OnceCell<ClientInitGuard> = OnceCell::new();

--- a/server/bleep/tests/desktop.rs
+++ b/server/bleep/tests/desktop.rs
@@ -1,0 +1,70 @@
+// This test just stubs out the tauri interface so that we can
+// ensure that the desktop app will build with this server.
+
+use std::{
+    marker::PhantomData,
+    path::{Path, PathBuf},
+};
+
+// Rust-analyzer isn't happy about this, but the test seems to
+// work, so who can say if it's good or not?
+#[path = "../../../apps/desktop/src-tauri/src/backend.rs"]
+pub mod backend;
+
+#[test]
+#[should_panic]
+fn run_server() {
+    let mut app: App<()> = App(PhantomData);
+    backend::bleep(&mut app).unwrap();
+}
+
+#[derive(Copy, Clone)]
+struct App<R>(PhantomData<R>);
+
+pub struct AppHandle;
+
+pub trait Manager {
+    fn handle(&self) -> AppHandle;
+}
+
+impl<R> Manager for App<R> {
+    fn handle(&self) -> AppHandle {
+        AppHandle
+    }
+}
+
+struct Payload {
+    message: String,
+}
+
+pub trait Runtime {}
+impl Runtime for () {}
+
+impl<R> App<R> {
+    fn path_resolver(&mut self) -> &mut Self {
+        self
+    }
+
+    fn resolve_resource(&mut self, _p: impl AsRef<Path>) -> Option<PathBuf> {
+        None
+    }
+
+    fn app_cache_dir(&self) -> Option<PathBuf> {
+        None
+    }
+}
+
+impl AppHandle {
+    fn emit_all(&self, _event: &str, payload: Payload) -> plugin::Result<()> {
+        println!("{}", payload.message);
+        Ok(())
+    }
+}
+
+fn relative_command_path(_: impl AsRef<str>) -> Option<PathBuf> {
+    None
+}
+
+pub mod plugin {
+    pub type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
+}


### PR DESCRIPTION
This removes the whole tauri install and full build from the server-test workflow, replacing it with a test that ensures the frontend will still compile with the server by including a `Application::initialize` call.

rust-analyzer will display an error, because it appears not to look outside of the crate (and not workspace) root, but the tests and the build run fine.