### PR TITLE
Add Docker caching to backend and frontend builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,2 @@
 /target
+node_modules

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 /target
-node_modules
+/node_modules
+**/node_modules

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
 /target
 /node_modules
 **/node_modules
+

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,40 @@
+name: Build docker container
+
+on:
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build-docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ghcr.io/bloopai/bloop:latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -28,13 +28,29 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-single-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-single-buildx
+
       - name: Build and push
         uses: docker/build-push-action@v3
         with:
           context: .
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
           platforms: linux/amd64
-          push: true
           tags: |
             ghcr.io/bloopai/bloop:latest
+          push: true
+          cache-from: type=local,src=/tmp/.buildx-cache
+          # Note the mode=max here
+          # More: https://github.com/moby/buildkit#--export-cache-options
+          # And: https://github.com/docker/buildx#--cache-tonametypetypekeyvalue
+          cache-to: type=local,mode=max,dest=/tmp/.buildx-cache-new
+
+      - name: Move cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,11 @@
+FROM node AS frontend
+WORKDIR /build
+RUN npm install -g pnpm && \
+    pnpm -g config set store-dir /tmp/pnpm-store
+COPY . .
+RUN --mount=target=/tmp/pnpm-store,type=cache pnpm install
+RUN --mount=target=/tmp/pnpm-store,type=cache pnpm run build-web
+
 FROM lukemathwalker/cargo-chef:latest-rust-1 AS chef
 WORKDIR /build
 
@@ -22,4 +30,5 @@ VOLUME ["/repos", "/data"]
 RUN apt-get update && apt-get -y install universal-ctags openssl ca-certificates && apt-get clean
 COPY model /model
 COPY --from=builder /bleep /
+COPY --from=frontend /build/client/dist /frontend
 ENTRYPOINT ["/bleep", "--host=0.0.0.0", "--source-dir=/repos", "--index-dir=/data", "--model-dir=/model"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,11 @@ FROM chef AS builder
 RUN apt-get update && apt-get -y install cmake python3 protobuf-compiler && apt-get -y clean
 COPY --from=planner /build/recipe.json recipe.json
 # Build dependencies - this is the caching Docker layer!
-RUN cargo chef cook -p bleep --release --recipe-path recipe.json
+RUN --mount=target=/build/target,type=cache \
+    cargo chef cook -p bleep --release --recipe-path recipe.json
 COPY . .
-RUN rm server/bleep/src/main.rs && cargo build -p bleep --release
+RUN --mount=target=/build/target,type=cache \
+    rm server/bleep/src/main.rs && cargo build -p bleep --release
 
 FROM debian:stable-slim
 VOLUME ["/repos", "/data"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,11 +13,13 @@ RUN --mount=target=/build/target,type=cache \
     cargo chef cook -p bleep --release --recipe-path recipe.json
 COPY . .
 RUN --mount=target=/build/target,type=cache \
-    rm server/bleep/src/main.rs && cargo build -p bleep --release
+    rm server/bleep/src/main.rs && \
+    cargo build -p bleep --release && \
+    cp /build/target/release/bleep /
 
 FROM debian:stable-slim
 VOLUME ["/repos", "/data"]
 RUN apt-get update && apt-get -y install universal-ctags openssl ca-certificates && apt-get clean
 COPY model /model
-COPY --from=builder /build/target/release/bleep /
+COPY --from=builder /bleep /
 ENTRYPOINT ["/bleep", "--host=0.0.0.0", "--source-dir=/repos", "--index-dir=/data", "--model-dir=/model"]


### PR DESCRIPTION
This is supposed to give us a caching layer for our dependencies, which should be a big win.

An extra step would be to store our built Docker artifacts & layers in the [GitHub Container Registry](https://github.com/docker/build-push-action/), so we could rely on the CI always keeping a copy of `main` up-to-date.