### PR TITLE
Serve front-end in `PrivateServer` mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -425,6 +425,7 @@ dependencies = [
  "thiserror",
  "tokenizers",
  "tokio",
+ "tower",
  "tower-http",
  "tracing",
  "tracing-subscriber",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3084,6 +3084,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
+name = "mime_guess"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4192263c238a5f0d0c6bfd21f336a313a4ce1c450542449ca191bb657b4642ef"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5945,7 +5955,13 @@ dependencies = [
  "http",
  "http-body",
  "http-range-header",
+ "httpdate",
+ "mime",
+ "mime_guess",
+ "percent-encoding",
  "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",
@@ -6178,6 +6194,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b72f89f0ca32e4db1c04e2a72f5345d59796d4866a1ee0609084569f73683dc8"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "unicase"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
+dependencies = [
+ "version_check",
 ]
 
 [[package]]

--- a/client/src/services/api.ts
+++ b/client/src/services/api.ts
@@ -8,7 +8,7 @@ import {
 } from '../types/api';
 import { RepoType } from '../types/general';
 
-const API = 'http://127.0.01:7878';
+const API = 'http://127.0.0.1:7878/api';
 const DB_API = 'https://api.bloop.ai';
 const http = axios.create({
   baseURL: API,

--- a/server/bleep/Cargo.toml
+++ b/server/bleep/Cargo.toml
@@ -65,8 +65,9 @@ petgraph = { version = "0.6.2", default-features = false, features = ["serde-1"]
 serde_json = "1.0.91"
 utoipa = { version = "2.4.2", features = ["axum_extras", "yaml"] }
 axum = { version = "0.6.2", features = ["http2", "headers"] }
-axum-extra = { version = "0.4.2", features = ["spa", "cookie", "cookie-private"] }
-tower-http = { version = "0.3.5", features = ["auth", "cors", "catch-panic"] }
+axum-extra = { version = "0.4.2", features = ["cookie", "cookie-private"] }
+tower = "0.4.13"
+tower-http = { version = "0.3.5", features = ["auth", "cors", "catch-panic", "fs"] }
 
 # api integrations
 octocrab = { git = "https://github.com/bloopai/octocrab", default-features = false, features = ["rustls"] }

--- a/server/bleep/Cargo.toml
+++ b/server/bleep/Cargo.toml
@@ -65,7 +65,7 @@ petgraph = { version = "0.6.2", default-features = false, features = ["serde-1"]
 serde_json = "1.0.91"
 utoipa = { version = "2.4.2", features = ["axum_extras", "yaml"] }
 axum = { version = "0.6.2", features = ["http2", "headers"] }
-axum-extra = { version = "0.4.2", features = ["cookie", "cookie-private"] }
+axum-extra = { version = "0.4.2", features = ["spa", "cookie", "cookie-private"] }
 tower-http = { version = "0.3.5", features = ["auth", "cors", "catch-panic"] }
 
 # api integrations

--- a/server/bleep/src/lib.rs
+++ b/server/bleep/src/lib.rs
@@ -140,6 +140,14 @@ impl Environment {
             PrivateServer => false,
         }
     }
+
+    pub(crate) fn use_aaa(&self) -> bool {
+        matches!(self, Self::PrivateServer)
+    }
+
+    pub(crate) fn serve_frontend(&self) -> bool {
+        matches!(self, Self::PrivateServer)
+    }
 }
 
 #[derive(Deserialize, Parser, Debug)]

--- a/server/bleep/src/lib.rs
+++ b/server/bleep/src/lib.rs
@@ -140,16 +140,6 @@ impl Environment {
             PrivateServer => false,
         }
     }
-
-    /// Use AAA layer (authentication, authorization, accounting)
-    pub(crate) fn use_aaa(&self) -> bool {
-        use Environment::*;
-        match self {
-            Server => false,
-            InsecureLocal => false,
-            PrivateServer => true,
-        }
-    }
 }
 
 #[derive(Deserialize, Parser, Debug)]
@@ -250,6 +240,10 @@ pub struct Configuration {
     #[clap(long)]
     /// Chunking strategy
     pub overlap: Option<OverlapStrategy>,
+
+    /// Path to built front-end folder
+    #[clap(long)]
+    pub frontend_dist: Option<PathBuf>,
 
     //
     // External dependencies

--- a/server/bleep/src/lib.rs
+++ b/server/bleep/src/lib.rs
@@ -119,7 +119,26 @@ fn default_max_chunk_tokens() -> usize {
 pub enum Environment {
     /// Safe API that's suitable for public use
     Server,
-    /// Access to the API is access controlled using an OAuth provider
+    /// Use a GitHub App installation to manage repositories and user access.
+    ///
+    /// Running the server in this environment makes use of a GitHub App in order to list and fetch
+    /// repositories. Note that GitHub App installs for a user profile are not valid in this mode.
+    ///
+    /// Connecting properly to a GitHub App installation requires the following flags:
+    ///
+    /// - `--github-client-id`
+    /// - `--github-client-secret`
+    /// - `--github-app-id`
+    /// - `--github-app-private-key`
+    /// - `--github-app-install-id`
+    /// - `--instance-domain`
+    ///
+    /// In order to serve the front-end, the `--frontend-dist` flag can provide a path to a built
+    /// version of the Bloop client SPA.
+    ///
+    /// Users are authenticated by checking whether they belong to the organization which installed
+    /// the GitHub App. All users belonging to the organization are able to see all repos that the
+    /// installation was allowed to access.
     PrivateServer,
     /// Enables scanning arbitrary user-specified locations through a Web-endpoint.
     InsecureLocal,
@@ -139,14 +158,6 @@ impl Environment {
             InsecureLocal => true,
             PrivateServer => false,
         }
-    }
-
-    pub(crate) fn use_aaa(&self) -> bool {
-        matches!(self, Self::PrivateServer)
-    }
-
-    pub(crate) fn serve_frontend(&self) -> bool {
-        matches!(self, Self::PrivateServer)
     }
 }
 

--- a/server/bleep/src/remotes/poll.rs
+++ b/server/bleep/src/remotes/poll.rs
@@ -13,7 +13,7 @@ use tracing::{debug, error, info};
 use crate::{
     remotes,
     state::{Backend, RepoRef, SyncStatus},
-    Application, Environment,
+    Application,
 };
 
 const POLL_INTERVAL_MINUTE: &[Duration] = &[
@@ -26,7 +26,7 @@ const POLL_INTERVAL_MINUTE: &[Duration] = &[
 
 pub(crate) async fn check_credentials(app: Application) {
     loop {
-        if let Environment::PrivateServer = app.env {
+        if app.env.use_aaa() {
             match app
                 .credentials
                 .get(&Backend::Github)

--- a/server/bleep/src/remotes/poll.rs
+++ b/server/bleep/src/remotes/poll.rs
@@ -13,7 +13,7 @@ use tracing::{debug, error, info};
 use crate::{
     remotes,
     state::{Backend, RepoRef, SyncStatus},
-    Application,
+    Application, Environment,
 };
 
 const POLL_INTERVAL_MINUTE: &[Duration] = &[
@@ -26,7 +26,7 @@ const POLL_INTERVAL_MINUTE: &[Duration] = &[
 
 pub(crate) async fn check_credentials(app: Application) {
     loop {
-        if app.env.use_aaa() {
+        if let Environment::PrivateServer = app.env {
             match app
                 .credentials
                 .get(&Backend::Github)

--- a/server/bleep/src/webserver.rs
+++ b/server/bleep/src/webserver.rs
@@ -1,4 +1,4 @@
-use crate::{snippet, state, Application, Environment};
+use crate::{snippet, state, Application};
 
 use anyhow::Result;
 use axum::middleware;
@@ -77,7 +77,7 @@ pub async fn start(app: Application) -> Result<()> {
     }
 
     // Note: all routes above this point must be authenticated.
-    if let Environment::PrivateServer = app.env {
+    if app.env.use_aaa() {
         api = aaa::router(api, app.clone());
     }
 
@@ -96,7 +96,7 @@ pub async fn start(app: Application) -> Result<()> {
 
     let mut router = Router::new().nest("/api", api);
 
-    if let Environment::PrivateServer = app.env {
+    if app.env.serve_frontend() {
         if let Some(frontend_dist) = app.config.frontend_dist.clone() {
             router = router.nest_service(
                 "/",

--- a/server/bleep/src/webserver.rs
+++ b/server/bleep/src/webserver.rs
@@ -1,8 +1,9 @@
-use crate::{snippet, state, Application};
+use crate::{snippet, state, Application, Environment};
 
 use anyhow::Result;
 use axum::middleware;
 use axum::{response::IntoResponse, routing::get, Extension, Json};
+use axum_extra::routing::SpaRouter;
 use std::{borrow::Cow, net::SocketAddr};
 use tower_http::{catch_panic::CatchPanicLayer, cors::CorsLayer};
 use tracing::info;
@@ -38,7 +39,7 @@ pub(in crate::webserver) mod prelude {
 pub async fn start(app: Application) -> Result<()> {
     let bind = SocketAddr::new(app.config.host.parse()?, app.config.port);
 
-    let mut router = Router::new()
+    let mut api = Router::new()
         // querying
         .route("/q", get(query::handle))
         // autocomplete
@@ -65,32 +66,44 @@ pub async fn start(app: Application) -> Result<()> {
         .route("/answer", get(answer::handle));
 
     if app.env.allow_github_device_flow() {
-        router = router
+        api = api
             .route("/remotes/github/login", get(github::login))
             .route("/remotes/github/status", get(github::status));
     }
 
     if app.env.allow_path_scan() {
-        router = router.route("/repos/scan", get(repos::scan_local));
+        api = api.route("/repos/scan", get(repos::scan_local));
     }
 
     // Note: all routes above this point must be authenticated.
-    if app.env.use_aaa() {
-        router = aaa::router(router, app.clone());
+    if let Environment::PrivateServer = app.env {
+        api = aaa::router(api, app.clone());
     }
 
-    router = router
+    api = api
         .route("/api-doc/openapi.json", get(openapi_json::handle))
         .route("/api-doc/openapi.yaml", get(openapi_yaml::handle))
         .route("/health", get(health));
 
-    let router: Router<()> = router
+    let api: Router<()> = api
         .layer(Extension(app.indexes.clone()))
         .layer(Extension(app.semantic.clone()))
         .layer(Extension(app.clone()))
-        .with_state(app)
+        .with_state(app.clone())
         .layer(CorsLayer::permissive())
         .layer(CatchPanicLayer::new());
+
+    let mut router = Router::new().nest("/api", api);
+
+    if let Environment::PrivateServer = app.env {
+        router = router.merge(SpaRouter::new(
+            "/",
+            app.config
+                .frontend_dist
+                .as_ref()
+                .expect("need path to built frontend folder"),
+        ));
+    }
 
     info!(%bind, "starting webserver");
     axum::Server::bind(&bind)

--- a/server/bleep/src/webserver.rs
+++ b/server/bleep/src/webserver.rs
@@ -1,4 +1,4 @@
-use crate::{snippet, state, Application};
+use crate::{snippet, state, Application, Environment};
 
 use anyhow::Result;
 use axum::middleware;
@@ -77,7 +77,7 @@ pub async fn start(app: Application) -> Result<()> {
     }
 
     // Note: all routes above this point must be authenticated.
-    if app.env.use_aaa() {
+    if let Environment::PrivateServer = app.env {
         api = aaa::router(api, app.clone());
     }
 
@@ -96,7 +96,7 @@ pub async fn start(app: Application) -> Result<()> {
 
     let mut router = Router::new().nest("/api", api);
 
-    if app.env.serve_frontend() {
+    if let Environment::PrivateServer = app.env {
         if let Some(frontend_dist) = app.config.frontend_dist.clone() {
             router = router.nest_service(
                 "/",

--- a/server/bleep/src/webserver/aaa.rs
+++ b/server/bleep/src/webserver/aaa.rs
@@ -109,7 +109,7 @@ pub(super) async fn login(
         .expose_secret();
 
     let redirect_uri = format!(
-        "https://{}/auth/login/complete",
+        "https://{}/api/auth/login/complete",
         app.config
             .instance_domain
             .as_ref()


### PR DESCRIPTION
This adds a new option `--frontend-dist` which accepts a path to serve as part of the `PrivateServer` mode. All API routes have been moved to `/api`, and the front-end `baseURL` has been adjusted accordingly.