### PR TITLE
Build Docker images on merging to `main`

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -36,8 +36,8 @@ jobs:
           tags: |
             ghcr.io/bloopai/bloop:latest
           push: true
-          cache-from: type=gha
+          cache-from: type=gha, scope=${{ github.workflow }}
           # Note the mode=max here
           # More: https://github.com/moby/buildkit#--export-cache-options
           # And: https://github.com/docker/buildx#--cache-tonametypetypekeyvalue
-          cache-to: type=gha,mode=max
+          cache-to: type=gha,mode=max, scope=${{ github.workflow }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,7 +1,7 @@
 name: Build docker container
 
 on:
-  pull_request:
+  push:
     branches: [main]
 
 #schedule:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -28,14 +28,6 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Cache Docker layers
-        uses: actions/cache@v2
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-single-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-single-buildx
-
       - name: Build and push
         uses: docker/build-push-action@v3
         with:
@@ -44,13 +36,8 @@ jobs:
           tags: |
             ghcr.io/bloopai/bloop:latest
           push: true
-          cache-from: type=gha,src=/tmp/.buildx-cache
+          cache-from: type=gha
           # Note the mode=max here
           # More: https://github.com/moby/buildkit#--export-cache-options
           # And: https://github.com/docker/buildx#--cache-tonametypetypekeyvalue
           cache-to: type=gha,mode=max
-
-      - name: Move cache
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -44,11 +44,11 @@ jobs:
           tags: |
             ghcr.io/bloopai/bloop:latest
           push: true
-          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-from: type=gha,src=/tmp/.buildx-cache
           # Note the mode=max here
           # More: https://github.com/moby/buildkit#--export-cache-options
           # And: https://github.com/docker/buildx#--cache-tonametypetypekeyvalue
-          cache-to: type=local,mode=max,dest=/tmp/.buildx-cache-new
+          cache-to: type=gha,mode=max
 
       - name: Move cache
         run: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [main]
 
+#schedule:
+#  - cron: '0 0 * * *'
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN --mount=target=/build/target,type=cache \
 COPY . .
 RUN --mount=target=/build/target,type=cache \
     rm server/bleep/src/main.rs && \
-    cargo build -p bleep --release --locked && \
+    cargo build -p bleep --release --locked --frozen --offline && \
     cp /build/target/release/bleep /
 
 FROM debian:stable-slim


### PR DESCRIPTION
Caching to GHA caches works, but due to the sheer size, potentially conflicts with with rust-cache from other workflows.

Still investigating this