### PR TITLE
Make backend feature-matrix enforced

### DIFF
--- a/apps/desktop/src-tauri/src/backend.rs
+++ b/apps/desktop/src-tauri/src/backend.rs
@@ -24,7 +24,8 @@ where
 
     let app = app.handle();
     tokio::spawn(async move {
-        let initialized = Application::initialize(Environment::InsecureLocal, configuration).await;
+        let initialized =
+            Application::initialize(Environment::insecure_local(), configuration).await;
 
         if let Ok(backend) = initialized {
             if let Err(_e) = backend.run().await {

--- a/server/bleep/src/bin/bleep.rs
+++ b/server/bleep/src/bin/bleep.rs
@@ -4,7 +4,7 @@ use bleep::{Application, Configuration, Environment};
 #[tokio::main]
 async fn main() -> Result<()> {
     Application::install_logging();
-    let app = Application::initialize(Environment::Server, Configuration::from_cli()?).await?;
+    let app = Application::initialize(Environment::server(), Configuration::from_cli()?).await?;
 
     app.install_sentry();
     app.run().await

--- a/server/bleep/src/env.rs
+++ b/server/bleep/src/env.rs
@@ -1,5 +1,6 @@
 use Feature::*;
 
+#[repr(u64)]
 pub(crate) enum Feature {
     /// Allow scanning any path on the system. This is dangerous!
     AnyPathScan = 1 << 0,
@@ -22,11 +23,17 @@ pub(crate) enum Feature {
 
 #[rustfmt::skip]
 #[derive(Debug, Clone, Copy)]
+#[repr(u64)]
+/// Select the environment the service will run in.
+///
+/// The different variants represent distinct capability sets that are
+/// suited for different deployment model, and will enable or disable
+/// certain features.
 pub enum Environment {
     /// Safe API that's suitable for public use
     Server =
-	GithubDeviceFlow as isize
-	| SafePathScan as isize,
+	GithubDeviceFlow as u64
+	| SafePathScan as u64,
 
     /// Use a GitHub App installation to manage repositories and user access.
     ///
@@ -46,13 +53,13 @@ pub enum Environment {
     /// the GitHub App. All users belonging to the organization are able to see all repos that the
     /// installation was allowed to access.
     PrivateServer =
-	GithubInstallation as isize
-	| AuthorizationRequired as isize,
+	GithubInstallation as u64
+	| AuthorizationRequired as u64,
 
     /// Enables scanning arbitrary user-specified locations through a Web-endpoint.
     InsecureLocal =
-	AnyPathScan as isize
-	| GithubDeviceFlow as isize,
+	AnyPathScan as u64
+	| GithubDeviceFlow as u64,
 }
 
 #[derive(Debug, Clone)]
@@ -64,6 +71,6 @@ impl RuntimeEnvironment {
     }
 
     pub(crate) fn allow(&self, f: Feature) -> bool {
-        0 < self.0 as isize & f as isize
+        0 < self.0 as u64 & f as u64
     }
 }

--- a/server/bleep/src/env.rs
+++ b/server/bleep/src/env.rs
@@ -1,0 +1,69 @@
+use Feature::*;
+
+pub(crate) enum Feature {
+    /// Allow scanning any path on the system. This is dangerous!
+    AnyPathScan = 1 << 0,
+
+    /// Only allow scanning inside the directories in
+    /// `app.config.source_dir`
+    SafePathScan = 1 << 1,
+
+    /// Require authorization to access API endpoints
+    AuthorizationRequired = 1 << 2,
+
+    /// Allow GitHub Device flow. This is useful for typically local
+    /// installations
+    GithubDeviceFlow = 1 << 3,
+
+    /// Use GitHub App permission system scoped to a single
+    /// installation. Cloud instances use this.
+    GithubInstallation = 1 << 4,
+}
+
+#[rustfmt::skip]
+#[derive(Debug, Clone, Copy)]
+pub enum Environment {
+    /// Safe API that's suitable for public use
+    Server =
+	GithubDeviceFlow as isize
+	| SafePathScan as isize,
+
+    /// Use a GitHub App installation to manage repositories and user access.
+    ///
+    /// Running the server in this environment makes use of a GitHub App in order to list and fetch
+    /// repositories. Note that GitHub App installs for a user profile are not valid in this mode.
+    ///
+    /// Connecting properly to a GitHub App installation requires the following flags:
+    ///
+    /// - `--github-client-id`
+    /// - `--github-client-secret`
+    /// - `--github-app-id`
+    /// - `--github-app-private-key`
+    /// - `--github-app-install-id`
+    /// - `--instance-domain`
+    ///
+    /// Users are authenticated by checking whether they belong to the organization which installed
+    /// the GitHub App. All users belonging to the organization are able to see all repos that the
+    /// installation was allowed to access.
+    PrivateServer =
+	GithubInstallation as isize
+	| AuthorizationRequired as isize,
+
+    /// Enables scanning arbitrary user-specified locations through a Web-endpoint.
+    InsecureLocal =
+	AnyPathScan as isize
+	| GithubDeviceFlow as isize,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct RuntimeEnvironment(Environment);
+
+impl RuntimeEnvironment {
+    pub(crate) fn new(env: Environment) -> Self {
+        Self(env)
+    }
+
+    pub(crate) fn allow(&self, f: Feature) -> bool {
+        0 < self.0 as isize & f as isize
+    }
+}

--- a/server/bleep/src/env.rs
+++ b/server/bleep/src/env.rs
@@ -29,7 +29,7 @@ pub(crate) enum Feature {
 /// The different variants represent distinct capability sets that are
 /// suited for different deployment model, and will enable or disable
 /// certain features.
-pub enum Environment {
+enum EnvironmentInner {
     /// Safe API that's suitable for public use
     Server =
 	GithubDeviceFlow as u64
@@ -63,11 +63,19 @@ pub enum Environment {
 }
 
 #[derive(Debug, Clone)]
-pub(crate) struct RuntimeEnvironment(Environment);
+pub struct Environment(EnvironmentInner);
 
-impl RuntimeEnvironment {
-    pub(crate) fn new(env: Environment) -> Self {
-        Self(env)
+impl Environment {
+    pub fn server() -> Self {
+        Self(EnvironmentInner::Server)
+    }
+
+    pub fn private_server() -> Self {
+        Self(EnvironmentInner::PrivateServer)
+    }
+
+    pub fn insecure_local() -> Self {
+        Self(EnvironmentInner::InsecureLocal)
     }
 
     pub(crate) fn allow(&self, f: Feature) -> bool {

--- a/server/bleep/src/lib.rs
+++ b/server/bleep/src/lib.rs
@@ -63,7 +63,6 @@ pub mod text_range;
 
 pub use config::{default_parallelism, minimum_parallelism, Configuration};
 pub use env::Environment;
-use env::RuntimeEnvironment;
 
 const LOG_ENV_VAR: &str = "BLOOP_LOG";
 static LOGGER_INSTALLED: OnceCell<bool> = OnceCell::new();
@@ -71,7 +70,7 @@ static SENTRY_GUARD: OnceCell<sentry::ClientInitGuard> = OnceCell::new();
 
 #[derive(Clone)]
 pub struct Application {
-    env: RuntimeEnvironment,
+    env: Environment,
     pub config: Arc<Configuration>,
     repo_pool: RepositoryPool,
     background: BackgroundExecutor,
@@ -133,11 +132,11 @@ impl Application {
         let analytics_client = Arc::new(analytics_client);
 
         let indexes = Arc::new(Indexes::new(config.clone(), semantic.clone())?);
-        let env = RuntimeEnvironment::new(if config.github_app_id.is_some() {
-            Environment::PrivateServer
+        let env = if config.github_app_id.is_some() {
+            Environment::private_server()
         } else {
             env
-        });
+        };
 
         Ok(Self {
             indexes,

--- a/server/bleep/src/lib.rs
+++ b/server/bleep/src/lib.rs
@@ -46,6 +46,7 @@ mod analytics;
 mod background;
 mod collector;
 mod config;
+mod env;
 mod language;
 mod remotes;
 mod webserver;
@@ -61,60 +62,16 @@ pub mod symbol;
 pub mod text_range;
 
 pub use config::{default_parallelism, minimum_parallelism, Configuration};
+pub use env::Environment;
+use env::RuntimeEnvironment;
 
 const LOG_ENV_VAR: &str = "BLOOP_LOG";
 static LOGGER_INSTALLED: OnceCell<bool> = OnceCell::new();
 static SENTRY_GUARD: OnceCell<sentry::ClientInitGuard> = OnceCell::new();
 
-#[derive(Debug, Clone)]
-pub enum Environment {
-    /// Safe API that's suitable for public use
-    Server,
-    /// Use a GitHub App installation to manage repositories and user access.
-    ///
-    /// Running the server in this environment makes use of a GitHub App in order to list and fetch
-    /// repositories. Note that GitHub App installs for a user profile are not valid in this mode.
-    ///
-    /// Connecting properly to a GitHub App installation requires the following flags:
-    ///
-    /// - `--github-client-id`
-    /// - `--github-client-secret`
-    /// - `--github-app-id`
-    /// - `--github-app-private-key`
-    /// - `--github-app-install-id`
-    /// - `--instance-domain`
-    ///
-    /// In order to serve the front-end, the `--frontend-dist` flag can provide a path to a built
-    /// version of the Bloop client SPA.
-    ///
-    /// Users are authenticated by checking whether they belong to the organization which installed
-    /// the GitHub App. All users belonging to the organization are able to see all repos that the
-    /// installation was allowed to access.
-    PrivateServer,
-    /// Enables scanning arbitrary user-specified locations through a Web-endpoint.
-    InsecureLocal,
-}
-
-impl Environment {
-    pub(crate) fn allow_path_scan(&self) -> bool {
-        use Environment::*;
-
-        matches!(self, InsecureLocal)
-    }
-
-    pub(crate) fn allow_github_device_flow(&self) -> bool {
-        use Environment::*;
-        match self {
-            Server => true,
-            InsecureLocal => true,
-            PrivateServer => false,
-        }
-    }
-}
-
 #[derive(Clone)]
 pub struct Application {
-    pub env: Environment,
+    env: RuntimeEnvironment,
     pub config: Arc<Configuration>,
     repo_pool: RepositoryPool,
     background: BackgroundExecutor,
@@ -176,11 +133,11 @@ impl Application {
         let analytics_client = Arc::new(analytics_client);
 
         let indexes = Arc::new(Indexes::new(config.clone(), semantic.clone())?);
-        let env = if config.github_app_id.is_some() {
+        let env = RuntimeEnvironment::new(if config.github_app_id.is_some() {
             Environment::PrivateServer
         } else {
             env
-        };
+        });
 
         Ok(Self {
             indexes,
@@ -267,17 +224,19 @@ impl Application {
     }
 
     pub(crate) fn allow_path(&self, path: impl AsRef<Path>) -> bool {
-        use Environment::*;
+        if self.env.allow(env::Feature::AnyPathScan) {
+            return true;
+        }
 
-        let source_dir = self.config.source.directory();
-        match self.env {
-            Server => RelativePath::from_path(&path)
+        if self.env.allow(env::Feature::SafePathScan) {
+            let source_dir = self.config.source.directory();
+            return RelativePath::from_path(&path)
                 .map(|p| p.to_logical_path(&source_dir))
                 .unwrap_or_else(|_| path.as_ref().to_owned())
-                .starts_with(&source_dir),
-            PrivateServer => false,
-            InsecureLocal => true,
+                .starts_with(&source_dir);
         }
+
+        false
     }
 
     //

--- a/server/bleep/src/remotes/poll.rs
+++ b/server/bleep/src/remotes/poll.rs
@@ -11,9 +11,10 @@ use tokio::time::sleep;
 use tracing::{debug, error, info};
 
 use crate::{
+    env::Feature,
     remotes,
     state::{Backend, RepoRef, SyncStatus},
-    Application, Environment,
+    Application,
 };
 
 const POLL_INTERVAL_MINUTE: &[Duration] = &[
@@ -26,7 +27,7 @@ const POLL_INTERVAL_MINUTE: &[Duration] = &[
 
 pub(crate) async fn check_credentials(app: Application) {
     loop {
-        if let Environment::PrivateServer = app.env {
+        if app.env.allow(Feature::GithubInstallation) {
             match app
                 .credentials
                 .get(&Backend::Github)
@@ -41,7 +42,9 @@ pub(crate) async fn check_credentials(app: Application) {
                     }
                 }
             }
-        } else {
+        }
+
+        if app.env.allow(Feature::GithubDeviceFlow) {
             let expired = if let Some(github) = app.credentials.get(&Backend::Github) {
                 github.validate().await.is_err()
             } else {

--- a/server/bleep/src/webserver.rs
+++ b/server/bleep/src/webserver.rs
@@ -1,4 +1,4 @@
-use crate::{snippet, state, Application, Environment};
+use crate::{env::Feature, snippet, state, Application};
 
 use anyhow::Result;
 use axum::middleware;
@@ -66,18 +66,18 @@ pub async fn start(app: Application) -> Result<()> {
         .route("/semantic/chunks", get(semantic::raw_chunks))
         .route("/answer", get(answer::handle));
 
-    if app.env.allow_github_device_flow() {
+    if app.env.allow(Feature::GithubDeviceFlow) {
         api = api
             .route("/remotes/github/login", get(github::login))
             .route("/remotes/github/status", get(github::status));
     }
 
-    if app.env.allow_path_scan() {
+    if app.env.allow(Feature::AnyPathScan) {
         api = api.route("/repos/scan", get(repos::scan_local));
     }
 
     // Note: all routes above this point must be authenticated.
-    if let Environment::PrivateServer = app.env {
+    if app.env.allow(Feature::AuthorizationRequired) {
         api = aaa::router(api, app.clone());
     }
 
@@ -96,22 +96,20 @@ pub async fn start(app: Application) -> Result<()> {
 
     let mut router = Router::new().nest("/api", api);
 
-    if let Environment::PrivateServer = app.env {
-        if let Some(frontend_dist) = app.config.frontend_dist.clone() {
-            router = router.nest_service(
-                "/",
-                tower::service_fn(move |req| {
-                    let frontend_dist = frontend_dist.clone();
-                    async move {
-                        Ok(ServeDir::new(&frontend_dist)
-                            .fallback(ServeFile::new(frontend_dist.join("index.html")))
-                            .call(req)
-                            .await
-                            .unwrap())
-                    }
-                }),
-            );
-        }
+    if let Some(frontend_dist) = app.config.frontend_dist.clone() {
+        router = router.nest_service(
+            "/",
+            tower::service_fn(move |req| {
+                let frontend_dist = frontend_dist.clone();
+                async move {
+                    Ok(ServeDir::new(&frontend_dist)
+                        .fallback(ServeFile::new(frontend_dist.join("index.html")))
+                        .call(req)
+                        .await
+                        .unwrap())
+                }
+            }),
+        );
     }
 
     info!(%bind, "starting webserver");


### PR DESCRIPTION
This PR tries to improve documentation and control flow that's associated with the different modes of possible installation.

Every installation mode will allow different features, and we can toggle these behaviours without relying on which specific mode is running.

One notable change is that serving local files is not permission gated here. Since it's a static configuration item that works independently, I don't believe there's a point in coupling this with authorization.