### PR TITLE
split workflow caches

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -31,7 +31,8 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: "bloop"
+          prefix-key: "bloop"
+          shared-key: "doc"
 
       - name: Start webserver and fetch OpenAPI
         run: |

--- a/.github/workflows/server-test.yml
+++ b/.github/workflows/server-test.yml
@@ -48,7 +48,8 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: "bloop"
+          prefix-key: "bloop"
+          shared-key: "server-test"
 
       - name: Rust fmt
         run: cargo fmt -p bleep -- --check

--- a/.github/workflows/tauri-release.yml
+++ b/.github/workflows/tauri-release.yml
@@ -27,6 +27,9 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: "bloop"
+          prefix-key: "bloop"
+          shared-key: "tauri-release"
+
       - name: Install Rust stable
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/tauri-test.yml
+++ b/.github/workflows/tauri-test.yml
@@ -49,6 +49,10 @@ jobs:
         run: touch apps/desktop/src-tauri/bin/qdrant-x86_64-unknown-linux-gnu
 
       - uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: "bloop"
+          shared-key: "tauri-test"
+
       - name: Install Rust stable
         uses: actions-rs/toolchain@v1
         with:


### PR DESCRIPTION
In my recent investigations, I found that giving all workflows the same cache will lead to errors where one workflow takes away the cache from another. So let's try splitting the caches instead.

Related to https://github.com/BloopAI/roadmap/issues/371