### PR TITLE
Unify cache dirs for Tauri app

### DIFF
--- a/apps/desktop/src-tauri/src/backend.rs
+++ b/apps/desktop/src-tauri/src/backend.rs
@@ -20,9 +20,7 @@ where
         .expect("bad bundle");
 
     let cache_dir = app.path_resolver().app_cache_dir().unwrap();
-    configuration
-        .source
-        .set_default_dir(&cache_dir.join("bleep"));
+    configuration.index_dir = cache_dir.join("bleep");
 
     let app = app.handle();
     tokio::spawn(async move {

--- a/server/bleep/src/state.rs
+++ b/server/bleep/src/state.rs
@@ -401,7 +401,7 @@ pub struct StateSource {
 }
 
 impl StateSource {
-    pub fn set_default_dir(&mut self, dir: &Path) {
+    pub(crate) fn set_default_dir(&mut self, dir: &Path) {
         self.state_file
             .get_or_insert_with(|| dir.join("repo_state.json"));
 
@@ -422,7 +422,7 @@ impl StateSource {
         });
     }
 
-    pub fn initialize_pool(&self) -> Result<RepositoryPool, RepoError> {
+    pub(crate) fn initialize_pool(&self) -> Result<RepositoryPool, RepoError> {
         #[cfg(target = "windows")]
         use dunce::canonicalize;
         #[cfg(not(target = "windows"))]


### PR DESCRIPTION
Also restrict internal functions to prevent future accidental misuse, such as what lead to this.