### PR TITLE
fix the remaining cache keys

### DIFF
--- a/.github/workflows/server-test.yml
+++ b/.github/workflows/server-test.yml
@@ -49,7 +49,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           prefix-key: "bloop"
-          shared-key: "server-test"
+          shared-key: "server-clippy"
 
       - name: Rust fmt
         run: cargo fmt -p bleep -- --check
@@ -84,7 +84,8 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: "bloop"
+          prefix-key: "bloop"
+          shared-key: "server-test"
 
       - name: Tests
         run: cargo test -p bleep

--- a/.github/workflows/tauri-release.yml
+++ b/.github/workflows/tauri-release.yml
@@ -26,9 +26,8 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: "bloop"
           prefix-key: "bloop"
-          shared-key: "tauri-release"
+          shared-key: "tauri-checks"
 
       - name: Install Rust stable
         uses: actions-rs/toolchain@v1
@@ -139,6 +138,9 @@ jobs:
         run: pnpm install
 
       - uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: "bloop"
+          shared-key: "tauri-release"
       - name: Install Rust stable
         uses: actions-rs/toolchain@v1
         with:


### PR DESCRIPTION
This in conjunction with not using the caches from the docker build (which would take too many entries, thus evicting our builders) should take care of the Rust build time woes.