### PR TITLE
Merge CLI arguments with config-supplied values, prefer CLI args

### DIFF
--- a/apps/desktop/src-tauri/src/backend.rs
+++ b/apps/desktop/src-tauri/src/backend.rs
@@ -11,7 +11,10 @@ where
         .resolve_resource("config.json")
         .expect("failed to resolve resource");
 
-    let mut configuration = Configuration::read(config).unwrap();
+    let mut configuration = Configuration::merge(
+        Configuration::read(config).unwrap(),
+        Configuration::from_cli().unwrap(),
+    );
     configuration.ctags_path = relative_command_path("ctags");
     configuration.max_threads = bleep::default_parallelism() / 4;
     configuration.model_dir = app

--- a/server/bleep/src/bin/bleep.rs
+++ b/server/bleep/src/bin/bleep.rs
@@ -4,7 +4,11 @@ use bleep::{Application, Configuration, Environment};
 #[tokio::main]
 async fn main() -> Result<()> {
     Application::install_logging();
-    let app = Application::initialize(Environment::server(), Configuration::from_cli()?).await?;
+    let app = Application::initialize(
+        Environment::server(),
+        Configuration::cli_overriding_config_file()?,
+    )
+    .await?;
 
     app.install_sentry();
     app.run().await

--- a/server/bleep/src/lib.rs
+++ b/server/bleep/src/lib.rs
@@ -85,10 +85,7 @@ impl Application {
     pub async fn initialize(env: Environment, config: Configuration) -> Result<Application> {
         let mut config = match config.config_file {
             None => config,
-            Some(ref path) => {
-                let file = std::fs::File::open(path)?;
-                serde_json::from_reader::<_, Configuration>(file)?
-            }
+            Some(ref path) => Configuration::read(path)?,
         };
 
         config.max_threads = config.max_threads.max(minimum_parallelism());

--- a/server/bleep/src/state.rs
+++ b/server/bleep/src/state.rs
@@ -371,7 +371,7 @@ fn get_unix_time(time: SystemTime) -> u64 {
         .as_secs()
 }
 
-#[derive(Serialize, Deserialize, Args, Debug, Clone, Default)]
+#[derive(Serialize, Deserialize, Args, Debug, Clone, Default, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub struct StateSource {
     /// Directory where repositories are located


### PR DESCRIPTION
Previously the config file would strictly override all configuration options.

This allows the intuitive syntax when running either the Tauri app:

    pnpm --filter @bloop/desktop run tauri-dev -- -- --github-client-id=xxxx

or `bleep`:

    cargo run -p bleep -- -c=/config.json --source-dir=/data