### PR TITLE
Allow unlinking Github user profile from local app

### DIFF
--- a/server/bleep/src/webserver.rs
+++ b/server/bleep/src/webserver.rs
@@ -69,6 +69,7 @@ pub async fn start(app: Application) -> Result<()> {
     if app.env.allow(Feature::GithubDeviceFlow) {
         api = api
             .route("/remotes/github/login", get(github::login))
+            .route("/remotes/github/logout", get(github::logout))
             .route("/remotes/github/status", get(github::status));
     }
 


### PR DESCRIPTION
I think this is all we can do here.

According to Github docs, when [deauthorizing a token](https://docs.github.com/en/rest/apps/oauth-applications?apiVersion=2022-11-28#delete-an-app-token), they require both a `client_id`, AND a `client_secret`, which we decidedly don't have since we're using the device flow.

Octocrab also doesn't seem to have corresponding functionality. So we nuke the key and move on.