### PR TITLE
Respect gitignore when collecting repo roots

### DIFF
--- a/server/bleep/src/remotes.rs
+++ b/server/bleep/src/remotes.rs
@@ -104,7 +104,7 @@ pub(crate) fn gather_repo_roots(path: impl AsRef<Path>) -> impl Iterator<Item = 
     WalkBuilder::new(path)
         .ignore(true)
         .hidden(false)
-        .git_ignore(false)
+        .git_ignore(true)
         .git_global(false)
         .git_exclude(false)
         .build()


### PR DESCRIPTION
This PR skips repos that are ignored by a parent repo. These crept into `target/` and were seriously slowing down index times.