### PR TITLE
Lock cargo CI workflows

### DIFF
--- a/.github/workflows/server-test.yml
+++ b/.github/workflows/server-test.yml
@@ -52,13 +52,13 @@ jobs:
           shared-key: "server-clippy"
 
       - name: Rust fmt
-        run: cargo fmt -p bleep -- --check
+        run: cargo --locked fmt -p bleep -- --check
 
       - uses: actions-rs/clippy-check@v1
         with:
           toolchain: stable
           token: ${{ secrets.GITHUB_TOKEN }}
-          args: -p bleep --all-features --manifest-path Cargo.toml
+          args: --locked -p bleep --all-features --manifest-path Cargo.toml
 
   test:
     runs-on: ubuntu-latest
@@ -88,7 +88,7 @@ jobs:
           shared-key: "server-test"
 
       - name: Tests
-        run: cargo test -p bleep
+        run: cargo --locked test -p bleep
 
   # benchmark:
   #   runs-on: [self-hosted, benchmark]

--- a/.github/workflows/tauri-release.yml
+++ b/.github/workflows/tauri-release.yml
@@ -36,11 +36,11 @@ jobs:
 
       - name: Check Formatting
         run: |
-          cargo fmt -p bloop -- --check
+          cargo --locked fmt -p bloop -- --check
 
       - name: Run tests
         run: |
-          cargo test -p bloop --verbose
+          cargo --locked test -p bloop --verbose
 
   build-mac-linux-ctags:
     strategy:
@@ -211,7 +211,7 @@ jobs:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
         with:
-          args: -v -- -v
+          args: --locked -v -- -v
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/tauri-test.yml
+++ b/.github/workflows/tauri-test.yml
@@ -63,14 +63,14 @@ jobs:
 
       - name: Check Formatting
         run: |
-          cargo fmt -p bloop -- --check
+          cargo --locked fmt -p bloop -- --check 
 
       - name: Run tests
         run: |
-          cargo test -p bloop --verbose
+          cargo --locked test -p bloop --verbose
 
       - uses: actions-rs/clippy-check@v1
         with:
           toolchain: stable
           token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-features --manifest-path Cargo.toml
+          args: --locked -p bloop --all-features --manifest-path Cargo.toml

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,11 +18,11 @@ RUN apt-get update && apt-get -y install cmake python3 protobuf-compiler && apt-
 COPY --from=planner /build/recipe.json recipe.json
 # Build dependencies - this is the caching Docker layer!
 RUN --mount=target=/build/target,type=cache \
-    cargo chef cook -p bleep --release --recipe-path recipe.json
+    cargo --locked chef cook -p bleep --release --recipe-path recipe.json
 COPY . .
 RUN --mount=target=/build/target,type=cache \
     rm server/bleep/src/main.rs && \
-    cargo build -p bleep --release --locked --frozen --offline && \
+    cargo --locked --frozen --offline build -p bleep --release && \
     cp /build/target/release/bleep /
 
 FROM debian:stable-slim


### PR DESCRIPTION
This adds `--locked` to all automated CI workflows in hope of throwing away caches less often.