### PR TITLE
Make sure `/api/health-check` fails with 500 if qdrant doesn't work

### DIFF
--- a/server/bleep/src/semantic.rs
+++ b/server/bleep/src/semantic.rs
@@ -127,6 +127,11 @@ impl Semantic {
         })
     }
 
+    pub async fn health_check(&self) -> anyhow::Result<()> {
+        self.qdrant.health_check().await?;
+        Ok(())
+    }
+
     pub fn embed(&self, chunk: &str) -> anyhow::Result<Vec<f32>> {
         let tokenizer_output = self.tokenizer.encode(chunk, true).unwrap();
 

--- a/server/bleep/src/webserver.rs
+++ b/server/bleep/src/webserver.rs
@@ -309,4 +309,10 @@ pub mod openapi_yaml {
     }
 }
 
-async fn health() {}
+async fn health(Extension(app): Extension<Application>) {
+    if let Some(ref semantic) = app.semantic {
+        // panic is fine here, we don't need exact reporting of
+        // subsystem checks at this stage
+        semantic.health_check().await.unwrap()
+    }
+}


### PR DESCRIPTION
A more involved health-check API is out of scope here, as I also don't know if Kube could inspect a JSON as a response.