### PR TITLE
Error refactor

### DIFF
--- a/server/bleep/src/webserver.rs
+++ b/server/bleep/src/webserver.rs
@@ -26,7 +26,7 @@ pub type Router<S = Application> = axum::Router<S>;
 
 #[allow(unused)]
 pub(in crate::webserver) mod prelude {
-    pub(in crate::webserver) use super::{json, EndpointError, Error, ErrorKind};
+    pub(in crate::webserver) use super::{json, EndpointError, Error, ErrorKind, Result};
     pub(in crate::webserver) use crate::indexes::Indexes;
     pub(in crate::webserver) use axum::{
         extract::Query, http::StatusCode, response::IntoResponse, Extension,

--- a/server/bleep/src/webserver/answer.rs
+++ b/server/bleep/src/webserver/answer.rs
@@ -6,9 +6,8 @@ use std::{
 
 use axum::{
     extract::Query,
-    http::StatusCode,
     response::{sse::Event, IntoResponse, Sse},
-    Extension, Json,
+    Extension,
 };
 use futures::{Stream, StreamExt, TryStreamExt};
 use thiserror::Error;
@@ -25,7 +24,7 @@ use crate::{
     Application,
 };
 
-use super::ErrorKind;
+use super::{Error, ErrorKind};
 
 /// Mirrored from `answer_api/lib.rs` to avoid private dependency.
 pub mod api {
@@ -104,7 +103,7 @@ const SNIPPET_COUNT: usize = 13;
 pub(super) async fn handle(
     Query(params): Query<Params>,
     Extension(app): Extension<Application>,
-) -> Result<impl IntoResponse, (StatusCode, Json<super::Response<'static>>)> {
+) -> super::Result<impl IntoResponse> {
     // create a new analytics event for this query
     let event = Arc::new(RwLock::new(QueryEvent::default()));
 
@@ -126,16 +125,14 @@ async fn _handle(
     params: Params,
     app: Application,
     event: Arc<RwLock<QueryEvent>>,
-) -> Result<impl IntoResponse, (StatusCode, Json<super::Response<'static>>)> {
+) -> super::Result<impl IntoResponse> {
     let query_id = uuid::Uuid::new_v4();
     let mut stop_watch = StopWatch::start();
 
-    let semantic = app.semantic.clone().ok_or_else(|| {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            super::error(ErrorKind::Configuration, "Qdrant not configured"),
-        )
-    })?;
+    let semantic = app
+        .semantic
+        .clone()
+        .ok_or_else(|| Error::new(ErrorKind::Configuration, "Qdrant not configured"))?;
 
     let mut analytics_event = event.write().await;
 
@@ -147,28 +144,15 @@ async fn _handle(
         .stages
         .push(Stage::new("user query", &params.q).with_time(stop_watch.lap()));
 
-    let query = parser::parse_nl(&params.q).map_err(|e| {
-        (
-            StatusCode::BAD_REQUEST,
-            super::error(ErrorKind::User, e.to_string()),
-        )
-    })?;
-    let target = query.target().ok_or_else(|| {
-        (
-            StatusCode::BAD_REQUEST,
-            super::error(ErrorKind::User, "missing search target".to_owned()),
-        )
-    })?;
+    let query = parser::parse_nl(&params.q).map_err(Error::user)?;
+    let target = query
+        .target()
+        .ok_or_else(|| Error::user("missing search target"))?;
 
     let all_snippets: Vec<Snippet> = semantic
         .search(&query, 4 * SNIPPET_COUNT as u64) // heuristic
         .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                super::error(ErrorKind::Internal, e.to_string()),
-            )
-        })?
+        .map_err(Error::internal)?
         .into_iter()
         .map(|r| {
             use qdrant_client::qdrant::{value::Kind, Value};
@@ -253,10 +237,7 @@ async fn _handle(
 
     if snippets.is_empty() {
         warn!("Semantic search returned no snippets");
-        return Err((
-            StatusCode::INTERNAL_SERVER_ERROR,
-            (super::internal_error("semantic search returned no snippets")),
-        ));
+        return Err(Error::internal("semantic search returned no snippets"));
     } else {
         info!("Semantic search returned {} snippets", snippets.len());
     }
@@ -272,8 +253,7 @@ async fn _handle(
 
     let relevant_snippet_index = answer_api_client
         .select_snippet(&select_prompt)
-        .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e))?
+        .await?
         .trim()
         .to_string()
         .clone();
@@ -282,26 +262,22 @@ async fn _handle(
 
     let mut relevant_snippet_index = relevant_snippet_index
         .parse::<usize>()
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, super::internal_error(e)))?;
+        .map_err(Error::internal)?;
 
     analytics_event.stages.push(
         Stage::new("relevant snippet index", &relevant_snippet_index).with_time(stop_watch.lap()),
     );
 
     if relevant_snippet_index == 0 {
-        return Err((
-            StatusCode::INTERNAL_SERVER_ERROR,
-            super::internal_error("None of the snippets help answer the question"),
+        return Err(Error::internal(
+            "None of the snippets help answer the question",
         ));
     }
 
     relevant_snippet_index -= 1; // return to 0-indexing
-    let relevant_snippet = snippets.get(relevant_snippet_index).ok_or_else(|| {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            super::internal_error("answer-api returned out-of-bounds index"),
-        )
-    })?;
+    let relevant_snippet = snippets
+        .get(relevant_snippet_index)
+        .ok_or_else(|| Error::internal("answer-api returned out-of-bounds index"))?;
 
     // grow the snippet by 60 lines above and below, we have sufficient space
     // to grow this snippet by 10 times its original size (15 to 150)
@@ -309,13 +285,13 @@ async fn _handle(
         let repo_ref = &relevant_snippet
             .repo_ref
             .parse::<RepoRef>()
-            .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, super::internal_error(e)))?;
+            .map_err(Error::internal)?;
         let doc = app
             .indexes
             .file
             .by_path(repo_ref, &relevant_snippet.relative_path)
             .await
-            .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, super::internal_error(e)))?;
+            .map_err(Error::internal)?;
 
         let mut grow_size = 40;
         let grown_text = loop {
@@ -355,14 +331,14 @@ async fn _handle(
             user_id: params.user_id.clone(),
             answer_path,
         }))
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, super::internal_error(e)))?;
+        .map_err(Error::internal)?;
 
     let explain_prompt = answer_api_client.build_explain_prompt(&processed_snippet);
 
     let mut snippet_explanation = answer_api_client
         .explain_snippet(&explain_prompt)
         .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, super::internal_error(e)))
+        .map_err(Error::internal)
         .map(Box::pin)?;
 
     drop(analytics_event);
@@ -443,13 +419,13 @@ enum AnswerAPIError {
     BadRequest(#[from] api::Error),
 }
 
-impl From<AnswerAPIError> for super::Error {
-    fn from(e: AnswerAPIError) -> super::Error {
+impl From<AnswerAPIError> for Error {
+    fn from(e: AnswerAPIError) -> Error {
         sentry::capture_message(
             format!("answer-api failed to respond: {e}").as_str(),
             sentry::Level::Error,
         );
-        super::error(ErrorKind::UpstreamService, e.to_string())
+        Error::new(ErrorKind::UpstreamService, e.to_string())
     }
 }
 
@@ -497,8 +473,8 @@ impl<'s> AnswerAPIClient<'s> {
 
         match stream.next().await {
             Some(Ok(reqwest_eventsource::Event::Open)) => {}
-            Some(Err(e)) => Err(AnswerAPIError::EventSource(e))?,
-            _ => Err(AnswerAPIError::StreamFail)?,
+            Some(Err(e)) => return Err(AnswerAPIError::EventSource(e)),
+            _ => return Err(AnswerAPIError::StreamFail),
         }
 
         Ok(stream
@@ -513,8 +489,7 @@ impl<'s> AnswerAPIClient<'s> {
             .map(|result| match result {
                 Ok(s) => Ok(serde_json::from_str::<api::Result>(&s)??),
                 Err(e) => Err(AnswerAPIError::EventSource(e)),
-            })
-            .map(|result: Result<String, AnswerAPIError>| result))
+            }))
     }
 
     async fn send_until_success(
@@ -602,7 +577,7 @@ Answer in GitHub Markdown:",
                 format!("answer-api failed to respond: {e}").as_str(),
                 sentry::Level::Error,
             );
-            super::error(ErrorKind::UpstreamService, e.to_string())
+            Error::new(ErrorKind::UpstreamService, e.to_string())
         })
     }
 

--- a/server/bleep/src/webserver/answer.rs
+++ b/server/bleep/src/webserver/answer.rs
@@ -24,7 +24,7 @@ use crate::{
     Application,
 };
 
-use super::{Error, ErrorKind};
+use super::prelude::*;
 
 /// Mirrored from `answer_api/lib.rs` to avoid private dependency.
 pub mod api {
@@ -103,7 +103,7 @@ const SNIPPET_COUNT: usize = 13;
 pub(super) async fn handle(
     Query(params): Query<Params>,
     Extension(app): Extension<Application>,
-) -> super::Result<impl IntoResponse> {
+) -> Result<impl IntoResponse> {
     // create a new analytics event for this query
     let event = Arc::new(RwLock::new(QueryEvent::default()));
 
@@ -125,7 +125,7 @@ async fn _handle(
     params: Params,
     app: Application,
     event: Arc<RwLock<QueryEvent>>,
-) -> super::Result<impl IntoResponse> {
+) -> Result<impl IntoResponse> {
     let query_id = uuid::Uuid::new_v4();
     let mut stop_watch = StopWatch::start();
 
@@ -571,7 +571,7 @@ Answer in GitHub Markdown:",
         prompt
     }
 
-    async fn select_snippet(&self, prompt: &str) -> super::Result<String> {
+    async fn select_snippet(&self, prompt: &str) -> Result<String> {
         self.send_until_success(prompt, 1, 0.0).await.map_err(|e| {
             sentry::capture_message(
                 format!("answer-api failed to respond: {e}").as_str(),

--- a/server/bleep/src/webserver/autocomplete.rs
+++ b/server/bleep/src/webserver/autocomplete.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use super::{json, EndpointError, ErrorKind};
+use super::{json, Error, Result};
 use crate::{
     indexes::{
         reader::{ContentReader, FileReader, RepoReader},
@@ -13,78 +13,10 @@ use crate::{
     webserver::query::{ApiQuery, ExecuteQuery, QueryResult},
 };
 
-use axum::{
-    extract::Query, http::StatusCode, response::IntoResponse as IntoAxumResponse, Extension,
-};
+use axum::{extract::Query, response::IntoResponse as IntoAxumResponse, Extension};
 use futures::{stream, StreamExt, TryStreamExt};
 use serde::Serialize;
 use utoipa::ToSchema;
-
-impl ApiQuery {
-    async fn autocomplete(
-        self: Arc<Self>,
-        indexes: Arc<Indexes>,
-    ) -> Result<AutocompleteResponse, EndpointError<'static>> {
-        let queries =
-            parser::parse(&self.q).map_err(|e| EndpointError::user(e.to_string().into()))?;
-        let mut autocomplete_results = vec![];
-
-        // Only execute prefix search on flag names if there is a non-regex content target.
-        // Always matches against the last query.
-        //
-        //      `la repo:bloop or sy` -> search with prefix `sy`
-        //      `repo:bloop re path:src` -> search with prefix `re`
-        if let Some(Target::Content(Literal::Plain(q))) = queries.last().unwrap().target.clone() {
-            autocomplete_results.append(
-                &mut complete_flag(&q)
-                    .map(|f| QueryResult::Flag(f.to_string()))
-                    .collect(),
-            );
-        }
-
-        // Bypass the parser and execute a prefix search using the last whitespace-split token
-        // in the query string.
-        //
-        // This should be revisited when we implement cursor-aware autocomplete.
-        //
-        //      `api lang:p` -> search lang list with prefix `p`
-        //      `lang:p api` -> lang prefix search not triggered
-        if let Some(matched_langs) = complete_lang(&self.q) {
-            autocomplete_results.append(
-                &mut matched_langs
-                    .map(|l| QueryResult::Lang(l.to_string()))
-                    .collect(),
-            );
-        }
-
-        // If no flags completion, run a search with full query
-        if autocomplete_results.is_empty() {
-            let contents = ContentReader.execute(&indexes.file, &queries, &self);
-            let repos = RepoReader.execute(&indexes.repo, &queries, &self);
-            let files = FileReader.execute(&indexes.file, &queries, &self);
-
-            autocomplete_results = stream::iter([contents, repos, files])
-                // Buffer several readers at the same time. The exact number is not important; this is
-                // simply an upper bound.
-                .buffered(10)
-                .try_fold(Vec::new(), |mut a, e| async {
-                    a.extend(e.data.into_iter());
-                    Ok(a)
-                })
-                .await
-                .map_err(|e| EndpointError {
-                    kind: ErrorKind::Internal,
-                    message: e.to_string().into(),
-                })?;
-        }
-
-        let count = autocomplete_results.len();
-        let data = autocomplete_results;
-        let response = AutocompleteResponse { count, data };
-
-        Ok(response)
-    }
-}
 
 #[utoipa::path(
     get,
@@ -99,17 +31,65 @@ impl ApiQuery {
 pub(super) async fn handle(
     Query(mut api_params): Query<ApiQuery>,
     Extension(indexes): Extension<Arc<Indexes>>,
-) -> impl IntoAxumResponse {
+) -> Result<impl IntoAxumResponse> {
     // Override page_size and set to low value
     api_params.page = 0;
     api_params.page_size = 3;
 
-    let response = Arc::new(api_params).autocomplete(indexes).await;
-    match response {
-        Ok(r) => (StatusCode::OK, json(r)),
-        Err(e) if e.kind == ErrorKind::User => (StatusCode::BAD_REQUEST, json(e)),
-        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, json(e)),
+    let queries = parser::parse(&api_params.q).map_err(Error::user)?;
+    let mut autocomplete_results = vec![];
+
+    // Only execute prefix search on flag names if there is a non-regex content target.
+    // Always matches against the last query.
+    //
+    //      `la repo:bloop or sy` -> search with prefix `sy`
+    //      `repo:bloop re path:src` -> search with prefix `re`
+    if let Some(Target::Content(Literal::Plain(q))) = queries.last().unwrap().target.clone() {
+        autocomplete_results.append(
+            &mut complete_flag(&q)
+                .map(|f| QueryResult::Flag(f.to_string()))
+                .collect(),
+        );
     }
+
+    // Bypass the parser and execute a prefix search using the last whitespace-split token
+    // in the query string.
+    //
+    // This should be revisited when we implement cursor-aware autocomplete.
+    //
+    //      `api lang:p` -> search lang list with prefix `p`
+    //      `lang:p api` -> lang prefix search not triggered
+    if let Some(matched_langs) = complete_lang(&api_params.q) {
+        autocomplete_results.append(
+            &mut matched_langs
+                .map(|l| QueryResult::Lang(l.to_string()))
+                .collect(),
+        );
+    }
+
+    // If no flags completion, run a search with full query
+    if autocomplete_results.is_empty() {
+        let contents = ContentReader.execute(&indexes.file, &queries, &api_params);
+        let repos = RepoReader.execute(&indexes.repo, &queries, &api_params);
+        let files = FileReader.execute(&indexes.file, &queries, &api_params);
+
+        autocomplete_results = stream::iter([contents, repos, files])
+            // Buffer several readers at the same time. The exact number is not important; this is
+            // simply an upper bound.
+            .buffered(10)
+            .try_fold(Vec::new(), |mut a, e| async {
+                a.extend(e.data.into_iter());
+                Ok(a)
+            })
+            .await
+            .map_err(Error::internal)?;
+    }
+
+    let count = autocomplete_results.len();
+    let data = autocomplete_results;
+    let response = AutocompleteResponse { count, data };
+
+    Ok(json(response))
 }
 
 fn complete_flag(q: &str) -> impl Iterator<Item = &str> + '_ {

--- a/server/bleep/src/webserver/autocomplete.rs
+++ b/server/bleep/src/webserver/autocomplete.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use super::{json, Error, Result};
+use super::prelude::*;
 use crate::{
     indexes::{
         reader::{ContentReader, FileReader, RepoReader},

--- a/server/bleep/src/webserver/file.rs
+++ b/server/bleep/src/webserver/file.rs
@@ -2,12 +2,11 @@ use std::sync::Arc;
 
 use axum::{
     extract::{Path, Query},
-    response::{IntoResponse, Result},
+    response::IntoResponse,
     Extension,
 };
-use reqwest::StatusCode;
 
-use super::{json, prelude::Indexes, EndpointError, ErrorKind};
+use super::{json, prelude::Indexes, Error};
 
 #[derive(Debug, serde::Deserialize)]
 pub struct Params {
@@ -27,33 +26,15 @@ pub async fn handle(
     // Strip leading slash, always present.
     let file_disk_path = &path[1..];
 
-    match fetch(&indexes, file_disk_path, &params).await {
-        Ok(r) => (StatusCode::OK, json(r)),
-        Err(e) if e.kind == ErrorKind::User => (StatusCode::BAD_REQUEST, json(e)),
-        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, json(e)),
-    }
-}
-
-async fn fetch(
-    indexes: &Indexes,
-    file_disk_path: &str,
-    params: &Params,
-) -> Result<FileResponse, EndpointError<'static>> {
     if params.rev.is_some() {
-        return Err(EndpointError {
-            kind: ErrorKind::Internal,
-            message: "the `rev` parameter is not yet supported".into(),
-        });
+        return Err(Error::internal("the `rev` parameter is not yet supported"));
     }
 
     let contents = indexes
         .file
         .file_body(file_disk_path)
         .await
-        .map_err(|e| EndpointError {
-            kind: ErrorKind::Internal,
-            message: e.to_string().into(),
-        })?;
+        .map_err(Error::internal)?;
 
-    Ok(FileResponse { contents })
+    Ok(json(FileResponse { contents }))
 }

--- a/server/bleep/src/webserver/file.rs
+++ b/server/bleep/src/webserver/file.rs
@@ -6,7 +6,7 @@ use axum::{
     Extension,
 };
 
-use super::{json, prelude::Indexes, Error};
+use super::prelude::*;
 
 #[derive(Debug, serde::Deserialize)]
 pub struct Params {

--- a/server/bleep/src/webserver/github.rs
+++ b/server/bleep/src/webserver/github.rs
@@ -61,10 +61,10 @@ pub(super) async fn login(Extension(app): Extension<Application>) -> impl IntoRe
     let client_id = match app.config.github_client_id.as_ref() {
         Some(id) => id.clone(),
         None => {
-            return (
-                StatusCode::SERVICE_UNAVAILABLE,
-                error(ErrorKind::Configuration, "Github Client ID not available"),
-            )
+            return Err(
+                Error::new(ErrorKind::Configuration, "Github Client ID not available")
+                    .with_status(StatusCode::SERVICE_UNAVAILABLE),
+            );
         }
     };
 
@@ -87,13 +87,10 @@ pub(super) async fn login(Extension(app): Extension<Application>) -> impl IntoRe
         app.clone(),
     ));
 
-    (
-        StatusCode::OK,
-        json(GithubResponse::AuthenticationNeeded {
-            url: codes.verification_uri,
-            code: codes.user_code,
-        }),
-    )
+    Ok(json(GithubResponse::AuthenticationNeeded {
+        url: codes.verification_uri,
+        code: codes.user_code,
+    }))
 }
 
 /// Remove Github OAuth credentials
@@ -111,16 +108,18 @@ pub(super) async fn logout(Extension(app): Extension<Application>) -> impl IntoR
         let saved = app.config.source.save_credentials(&app.credentials);
 
         if saved.is_ok() {
-            return json(GithubResponse::Status(GithubCredentialStatus::Ok));
+            return Ok(json(GithubResponse::Status(GithubCredentialStatus::Ok)));
         }
 
         if let Err(err) = saved {
             error!(?err, "Failed to delete credentials from disk");
-            return error(ErrorKind::Internal, "failed to save changes");
+            return Err(Error::internal("failed to save changes"));
         }
     }
 
-    json(GithubResponse::Status(GithubCredentialStatus::Missing))
+    Ok(json(GithubResponse::Status(
+        GithubCredentialStatus::Missing,
+    )))
 }
 
 async fn poll_for_oauth_token(

--- a/server/bleep/src/webserver/hoverable.rs
+++ b/server/bleep/src/webserver/hoverable.rs
@@ -1,9 +1,9 @@
 use std::sync::Arc;
 
-use super::{json, EndpointError, ErrorKind};
+use super::{json, Error};
 use crate::{indexes::Indexes, state::RepoRef, symbol::SymbolLocations, text_range::TextRange};
 
-use axum::{extract::Query, http::StatusCode, response::IntoResponse, Extension};
+use axum::{extract::Query, response::IntoResponse, Extension};
 use serde::{Deserialize, Serialize};
 use utoipa::{IntoParams, ToSchema};
 
@@ -23,38 +23,6 @@ pub(super) struct HoverableResponse {
     ranges: Vec<TextRange>,
 }
 
-impl HoverableRequest {
-    async fn handle(
-        &self,
-        indexes: Arc<Indexes>,
-    ) -> Result<HoverableResponse, EndpointError<'static>> {
-        let repo_ref = &self
-            .repo_ref
-            .parse::<RepoRef>()
-            .map_err(|err| EndpointError::user(err.to_string().into()))?;
-
-        let document = match indexes.file.by_path(repo_ref, &self.relative_path).await {
-            Ok(doc) => doc,
-            Err(e) => {
-                return Err(EndpointError {
-                    kind: ErrorKind::User,
-                    message: e.to_string().into(),
-                })
-            }
-        };
-        let ranges = match document.symbol_locations {
-            SymbolLocations::TreeSitter(graph) => graph.hoverable_ranges().collect(),
-            _ => {
-                return Err(EndpointError {
-                    kind: ErrorKind::User,
-                    message: "Intelligence is unavailable for this language".into(),
-                })
-            }
-        };
-        Ok(HoverableResponse { ranges })
-    }
-}
-
 #[utoipa::path(
     get,
     path = "/hoverable",
@@ -69,12 +37,17 @@ pub(super) async fn handle(
     Query(payload): Query<HoverableRequest>,
     Extension(indexes): Extension<Arc<Indexes>>,
 ) -> impl IntoResponse {
-    let response = payload.handle(indexes).await;
-    match response {
-        Ok(r) => (StatusCode::OK, json(r)),
-        Err(e) if e.kind == ErrorKind::User => (StatusCode::BAD_REQUEST, json(e)),
-        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, json(e)),
-    }
+    let repo_ref = &payload.repo_ref.parse::<RepoRef>().map_err(Error::user)?;
+
+    let document = match indexes.file.by_path(repo_ref, &payload.relative_path).await {
+        Ok(doc) => doc,
+        Err(e) => return Err(Error::user(e)),
+    };
+    let ranges = match document.symbol_locations {
+        SymbolLocations::TreeSitter(graph) => graph.hoverable_ranges().collect(),
+        _ => return Err(Error::user("Intelligence is unavailable for this language")),
+    };
+    Ok(json(HoverableResponse { ranges }))
 }
 
 #[cfg(test)]

--- a/server/bleep/src/webserver/hoverable.rs
+++ b/server/bleep/src/webserver/hoverable.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use super::{json, Error};
+use super::prelude::*;
 use crate::{indexes::Indexes, state::RepoRef, symbol::SymbolLocations, text_range::TextRange};
 
 use axum::{extract::Query, response::IntoResponse, Extension};

--- a/server/bleep/src/webserver/intelligence.rs
+++ b/server/bleep/src/webserver/intelligence.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use super::{json, Error, Result};
+use super::prelude::*;
 use crate::{
     indexes::{reader::ContentDocument, Indexes},
     intelligence::{code_navigation, NodeKind, ScopeGraph},

--- a/server/bleep/src/webserver/intelligence.rs
+++ b/server/bleep/src/webserver/intelligence.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use super::{json, EndpointError, ErrorKind};
+use super::{json, Error, Result};
 use crate::{
     indexes::{reader::ContentDocument, Indexes},
     intelligence::{code_navigation, NodeKind, ScopeGraph},
@@ -10,7 +10,7 @@ use crate::{
     text_range::TextRange,
 };
 
-use axum::{extract::Query, http::StatusCode, response::IntoResponse, Extension};
+use axum::{extract::Query, response::IntoResponse, Extension};
 use petgraph::graph::NodeIndex;
 use serde::{Deserialize, Serialize};
 use utoipa::{IntoParams, ToSchema};
@@ -72,111 +72,6 @@ pub(super) struct SymbolOccurrence {
 
     /// A few lines of surrounding context
     pub(super) snippet: Snippet,
-}
-
-impl TokenInfoRequest {
-    async fn handle(
-        &self,
-        indexes: Arc<Indexes>,
-    ) -> Result<TokenInfoResponse, EndpointError<'static>> {
-        let repo_ref = &self
-            .repo_ref
-            .parse::<RepoRef>()
-            .map_err(|err| EndpointError::user(err.to_string().into()))?;
-
-        let content = indexes
-            .file
-            .by_path(repo_ref, &self.relative_path)
-            .await
-            .map_err(|e| EndpointError {
-                kind: ErrorKind::User,
-                message: e.to_string().into(),
-            })?;
-
-        let scope_graph = match content.symbol_locations {
-            SymbolLocations::TreeSitter(ref graph) => graph,
-            _ => {
-                return Err(EndpointError {
-                    kind: ErrorKind::User,
-                    message: "Intelligence is unavailable for this language".into(),
-                })
-            }
-        };
-
-        let node = scope_graph.node_by_range(self.start, self.end);
-
-        let idx = match node {
-            None => {
-                return Err(EndpointError {
-                    kind: ErrorKind::User,
-                    message: "provided range is not a valid token".into(),
-                })
-            }
-            Some(idx) => idx,
-        };
-
-        let src = &content.content;
-        let current_file = &content.relative_path;
-        let kind = scope_graph.symbol_name_of(idx);
-        let lang = content.lang.as_deref();
-        let all_docs = indexes.file.by_repo(repo_ref, lang).await;
-
-        match &scope_graph.graph[idx] {
-            // we are already at a def
-            // - find refs from the current file
-            // - find refs from other files
-            NodeKind::Def(d) => {
-                // fetch local references with scope-graphs
-                let local_references = handle_definition_local(scope_graph, idx, &content);
-
-                // fetch repo-wide references with trivial search, only if the def is
-                // a top-level def (typically functions, ADTs, consts)
-                let repo_wide_references = if scope_graph.is_top_level(idx) {
-                    let token = d.name(src.as_bytes());
-                    handle_definition_repo_wide(token, kind, current_file, &all_docs)
-                } else {
-                    vec![]
-                };
-
-                // merge the two
-                let references = merge([local_references], repo_wide_references);
-
-                Ok(TokenInfoResponse::Definition { references })
-            }
-
-            // we are at a reference:
-            // - find def from the current file
-            // - find defs from other files
-            // - find refs from the current file
-            // - find refs from other files
-            //
-            // the ordering here prefers occurrences from the current file, over occurrences
-            // from other files.
-            NodeKind::Ref(r) => {
-                // fetch local (defs, refs) with scope-graphs
-                let (local_definitions, local_references) =
-                    handle_reference_local(scope_graph, idx, &content);
-
-                // fetch repo-wide (defs, refs) with trivial search
-                let token = r.name(src.as_bytes());
-                let (repo_wide_definitions, repo_wide_references) =
-                    handle_reference_repo_wide(token, kind, current_file, &all_docs);
-
-                // merge the two
-                let definitions = merge([local_definitions], repo_wide_definitions);
-                let references = merge([local_references], repo_wide_references);
-
-                Ok(TokenInfoResponse::Reference {
-                    definitions,
-                    references,
-                })
-            }
-            _ => Err(EndpointError {
-                kind: ErrorKind::User,
-                message: "provided range is not eligible for intelligence".into(),
-            }),
-        }
-    }
 }
 
 fn handle_definition_local(
@@ -335,12 +230,86 @@ fn merge(
 pub(super) async fn handle(
     Query(payload): Query<TokenInfoRequest>,
     Extension(indexes): Extension<Arc<Indexes>>,
-) -> impl IntoResponse {
-    let response = payload.handle(indexes).await;
-    match response {
-        Ok(r) => (StatusCode::OK, json(r)),
-        Err(e) if e.kind == ErrorKind::User => (StatusCode::BAD_REQUEST, json(e)),
-        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, json(e)),
+) -> Result<impl IntoResponse> {
+    let repo_ref = &payload.repo_ref.parse::<RepoRef>().map_err(Error::user)?;
+
+    let content = indexes
+        .file
+        .by_path(repo_ref, &payload.relative_path)
+        .await
+        .map_err(Error::user)?;
+
+    let scope_graph = match content.symbol_locations {
+        SymbolLocations::TreeSitter(ref graph) => graph,
+        _ => return Err(Error::user("Intelligence is unavailable for this language")),
+    };
+
+    let node = scope_graph.node_by_range(payload.start, payload.end);
+
+    let idx = match node {
+        None => return Err(Error::user("provided range is not a valid token")),
+        Some(idx) => idx,
+    };
+
+    let src = &content.content;
+    let current_file = &content.relative_path;
+    let kind = scope_graph.symbol_name_of(idx);
+    let lang = content.lang.as_deref();
+    let all_docs = indexes.file.by_repo(repo_ref, lang).await;
+
+    match &scope_graph.graph[idx] {
+        // we are already at a def
+        // - find refs from the current file
+        // - find refs from other files
+        NodeKind::Def(d) => {
+            // fetch local references with scope-graphs
+            let local_references = handle_definition_local(scope_graph, idx, &content);
+
+            // fetch repo-wide references with trivial search, only if the def is
+            // a top-level def (typically functions, ADTs, consts)
+            let repo_wide_references = if scope_graph.is_top_level(idx) {
+                let token = d.name(src.as_bytes());
+                handle_definition_repo_wide(token, kind, current_file, &all_docs)
+            } else {
+                vec![]
+            };
+
+            // merge the two
+            let references = merge([local_references], repo_wide_references);
+
+            Ok(json(TokenInfoResponse::Definition { references }))
+        }
+
+        // we are at a reference:
+        // - find def from the current file
+        // - find defs from other files
+        // - find refs from the current file
+        // - find refs from other files
+        //
+        // the ordering here prefers occurrences from the current file, over occurrences
+        // from other files.
+        NodeKind::Ref(r) => {
+            // fetch local (defs, refs) with scope-graphs
+            let (local_definitions, local_references) =
+                handle_reference_local(scope_graph, idx, &content);
+
+            // fetch repo-wide (defs, refs) with trivial search
+            let token = r.name(src.as_bytes());
+            let (repo_wide_definitions, repo_wide_references) =
+                handle_reference_repo_wide(token, kind, current_file, &all_docs);
+
+            // merge the two
+            let definitions = merge([local_definitions], repo_wide_definitions);
+            let references = merge([local_references], repo_wide_references);
+
+            Ok(json(TokenInfoResponse::Reference {
+                definitions,
+                references,
+            }))
+        }
+        _ => Err(Error::user(
+            "provided range is not eligible for intelligence",
+        )),
     }
 }
 

--- a/server/bleep/src/webserver/query.rs
+++ b/server/bleep/src/webserver/query.rs
@@ -4,7 +4,7 @@ use std::{
     sync::Arc,
 };
 
-use super::{json, EndpointError, ErrorKind};
+use super::{json, Error, Result};
 use crate::{
     collector::{BytesFilterCollector, FrequencyCollector},
     indexes::{
@@ -15,11 +15,8 @@ use crate::{
     snippet::{HighlightedString, SnippedFile, Snipper},
 };
 
-use anyhow::Result;
 use async_trait::async_trait;
-use axum::{
-    extract::Query, http::StatusCode, response::IntoResponse as IntoAxumResponse, Extension,
-};
+use axum::{extract::Query, response::IntoResponse as IntoAxumResponse, Extension};
 use regex::{
     bytes::{Regex as ByteRegex, RegexBuilder as ByteRegexBuilder},
     Regex,
@@ -82,12 +79,8 @@ impl ApiQuery {
         self.page_size * self.page
     }
 
-    async fn query(
-        self: Arc<Self>,
-        indexes: Arc<Indexes>,
-    ) -> Result<QueryResponse, EndpointError<'static>> {
-        let queries =
-            parser::parse(&self.q).map_err(|e| EndpointError::user(e.to_string().into()))?;
+    async fn query(self: Arc<Self>, indexes: Arc<Indexes>) -> Result<QueryResponse> {
+        let queries = parser::parse(&self.q).map_err(Error::user)?;
 
         // FIXME: this for-loop prevents us from ever producing heterogenous
         // results.
@@ -118,26 +111,26 @@ impl ApiQuery {
                 return ContentReader
                     .execute(&indexes.file, &queries, &self)
                     .await
-                    .map_err(|e| EndpointError::internal(e.to_string().into()));
+                    .map_err(Error::internal);
             } else if RepoReader.query_matches(q) {
                 return RepoReader
                     .execute(&indexes.repo, &queries, &self)
                     .await
-                    .map_err(|e| EndpointError::internal(e.to_string().into()));
+                    .map_err(Error::internal);
             } else if FileReader.query_matches(q) {
                 return FileReader
                     .execute(&indexes.file, &queries, &self)
                     .await
-                    .map_err(|e| EndpointError::internal(e.to_string().into()));
+                    .map_err(Error::internal);
             } else if OpenReader.query_matches(q) {
                 return OpenReader
                     .execute(&indexes.file, &queries, &self)
                     .await
-                    .map_err(|e| EndpointError::internal(e.to_string().into()));
+                    .map_err(Error::internal);
             }
         }
 
-        return Err(EndpointError::user("mangled query".into()));
+        Err(Error::user("mangled query"))
     }
 }
 
@@ -155,12 +148,7 @@ pub(super) async fn handle(
     Query(api_params): Query<ApiQuery>,
     Extension(indexes): Extension<Arc<Indexes>>,
 ) -> impl IntoAxumResponse {
-    let response = Arc::new(api_params).query(indexes).await;
-    match response {
-        Ok(r) => (StatusCode::OK, json(r)),
-        Err(e) if e.kind == ErrorKind::User => (StatusCode::BAD_REQUEST, json(e)),
-        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, json(e)),
-    }
+    Arc::new(api_params).query(indexes).await.map(json)
 }
 
 #[derive(Serialize, ToSchema)]
@@ -316,7 +304,7 @@ pub trait ExecuteQuery {
         indexer: &Indexer<Self::Index>,
         queries: &[parser::Query<'_>],
         q: &ApiQuery,
-    ) -> Result<QueryResponse>;
+    ) -> anyhow::Result<QueryResponse>;
 }
 
 #[async_trait]
@@ -328,7 +316,7 @@ impl ExecuteQuery for ContentReader {
         indexer: &Indexer<Self::Index>,
         queries: &[parser::Query<'_>],
         q: &ApiQuery,
-    ) -> Result<QueryResponse> {
+    ) -> anyhow::Result<QueryResponse> {
         // queries that produce content results
         let relevant_queries = queries.iter().filter(|q| self.query_matches(q));
 
@@ -437,7 +425,7 @@ impl ExecuteQuery for FileReader {
         indexer: &Indexer<File>,
         queries: &[parser::Query<'_>],
         q: &ApiQuery,
-    ) -> Result<QueryResponse> {
+    ) -> anyhow::Result<QueryResponse> {
         let (filter_regexes, byte_filter_regexes): (Vec<_>, Vec<_>) = queries
             .iter()
             .filter(|q| self.query_matches(q))
@@ -518,7 +506,7 @@ impl ExecuteQuery for RepoReader {
         indexer: &Indexer<Self::Index>,
         queries: &[parser::Query<'_>],
         q: &ApiQuery,
-    ) -> Result<QueryResponse> {
+    ) -> anyhow::Result<QueryResponse> {
         let (filter_regexes, byte_filter_regexes): (Vec<_>, Vec<_>) = queries
             .iter()
             .filter(|q| self.query_matches(q))
@@ -591,7 +579,7 @@ impl ExecuteQuery for OpenReader {
         indexer: &Indexer<Self::Index>,
         queries: &[parser::Query<'_>],
         _q: &ApiQuery,
-    ) -> Result<QueryResponse> {
+    ) -> anyhow::Result<QueryResponse> {
         #[derive(Debug)]
         struct Directive<'a> {
             relative_path: &'a str,

--- a/server/bleep/src/webserver/query.rs
+++ b/server/bleep/src/webserver/query.rs
@@ -4,7 +4,7 @@ use std::{
     sync::Arc,
 };
 
-use super::{json, Error, Result};
+use super::prelude::*;
 use crate::{
     collector::{BytesFilterCollector, FrequencyCollector},
     indexes::{

--- a/server/bleep/src/webserver/repos.rs
+++ b/server/bleep/src/webserver/repos.rs
@@ -14,7 +14,7 @@ use chrono::{DateTime, NaiveDateTime, Utc};
 use serde::{Deserialize, Serialize};
 use utoipa::{IntoParams, ToSchema};
 
-use super::{json, Error, ErrorKind, Result};
+use super::prelude::*;
 
 #[derive(Serialize, ToSchema, Debug)]
 pub(super) struct Repo {

--- a/server/bleep/src/webserver/repos.rs
+++ b/server/bleep/src/webserver/repos.rs
@@ -14,7 +14,7 @@ use chrono::{DateTime, NaiveDateTime, Utc};
 use serde::{Deserialize, Serialize};
 use utoipa::{IntoParams, ToSchema};
 
-use super::{error, json, ErrorKind};
+use super::{json, Error, ErrorKind, Result};
 
 #[derive(Serialize, ToSchema, Debug)]
 pub(super) struct Repo {
@@ -113,24 +113,17 @@ pub(super) async fn indexed(Extension(app): Extension<Application>) -> impl Into
 pub(super) async fn get_by_id(
     Path(path): Path<Vec<String>>,
     Extension(app): Extension<Application>,
-) -> impl IntoResponse {
+) -> Result<impl IntoResponse> {
     let Ok(reporef) = RepoRef::from_components(&app.config.source.directory(), path) else {
-	return (StatusCode::NOT_FOUND,
-		error(ErrorKind::NotFound, "Can't find repository"))
+        return Err(Error::new(ErrorKind::NotFound, "Can't find repository"));
     };
 
     match app.repo_pool.get(&reporef) {
-        Some(result) => (
-            StatusCode::OK,
-            json(ReposResponse::Item(Repo::from((
-                result.key(),
-                result.value(),
-            )))),
-        ),
-        None => (
-            StatusCode::NOT_FOUND,
-            error(ErrorKind::NotFound, "Can't find repository"),
-        ),
+        Some(result) => Ok(json(ReposResponse::Item(Repo::from((
+            result.key(),
+            result.value(),
+        ))))),
+        None => Err(Error::new(ErrorKind::NotFound, "Can't find repository")),
     }
 }
 
@@ -148,19 +141,15 @@ pub(super) async fn delete_by_id(
     Extension(app): Extension<Application>,
 ) -> impl IntoResponse {
     let Ok(reporef) = RepoRef::from_components(&app.config.source.directory(), path) else {
-	return (StatusCode::NOT_FOUND,
-		error(ErrorKind::NotFound, "Can't find repository"))
+        return Err(Error::new(ErrorKind::NotFound, "Can't find repository"));
     };
 
     match app.repo_pool.get_mut(&reporef) {
         Some(mut result) => {
             result.value_mut().delete();
-            (StatusCode::OK, json(ReposResponse::Deleted))
+            Ok(json(ReposResponse::Deleted))
         }
-        None => (
-            StatusCode::NOT_FOUND,
-            error(ErrorKind::NotFound, "Can't find repository"),
-        ),
+        None => Err(Error::new(ErrorKind::NotFound, "Can't find repository")),
     }
 }
 
@@ -177,12 +166,11 @@ pub(super) async fn sync(
     Extension(app): Extension<Application>,
 ) -> impl IntoResponse {
     let Ok(reporef) = RepoRef::from_components(&app.config.source.directory(), path) else {
-	return (StatusCode::NOT_FOUND,
-		error(ErrorKind::NotFound, "Can't find repository"))
+        return Err(Error::new(ErrorKind::NotFound, "Can't find repository"));
     };
 
     app.write_index().queue_sync_and_index(vec![reporef]);
-    (StatusCode::OK, json(ReposResponse::SyncQueued))
+    Ok(json(ReposResponse::SyncQueued))
 }
 
 /// List all repositories that are either indexed, or available for indexing
@@ -247,7 +235,8 @@ pub(super) async fn set_indexed(
     for repo in new {
         app.write_index().queue_sync_and_index(vec![repo]);
     }
-    (StatusCode::OK, json(ReposResponse::SyncQueued))
+
+    json(ReposResponse::SyncQueued)
 }
 
 #[derive(Deserialize, IntoParams)]
@@ -272,23 +261,17 @@ pub(super) async fn scan_local(
     let root = std::path::Path::new(&scan_request.path);
 
     if app.allow_path(root) {
-        (
-            StatusCode::OK,
-            json(ReposResponse::List(
-                crate::remotes::gather_repo_roots(&root, app.config.source.repo_dir())
-                    .map(|reporef| {
-                        let mut repo = Repository::local_from(&reporef);
-                        repo.sync_status = SyncStatus::Uninitialized;
+        Ok(json(ReposResponse::List(
+            crate::remotes::gather_repo_roots(&root, app.config.source.repo_dir())
+                .map(|reporef| {
+                    let mut repo = Repository::local_from(&reporef);
+                    repo.sync_status = SyncStatus::Uninitialized;
 
-                        (&reporef, &repo).into()
-                    })
-                    .collect(),
-            )),
-        )
+                    (&reporef, &repo).into()
+                })
+                .collect(),
+        )))
     } else {
-        (
-            StatusCode::UNAUTHORIZED,
-            error(ErrorKind::User, "scanning not allowed"),
-        )
+        Err(Error::user("scanning not allowed").with_status(StatusCode::UNAUTHORIZED))
     }
 }

--- a/server/bleep/src/webserver/semantic.rs
+++ b/server/bleep/src/webserver/semantic.rs
@@ -47,23 +47,17 @@ pub(super) async fn raw_chunks(
 
         if let Err(err) = result {
             error!(?err, "qdrant query failed");
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                error(ErrorKind::UpstreamService, "error"),
-            );
+            return Err(Error::new(ErrorKind::UpstreamService, "error"));
         };
 
-        (
-            StatusCode::OK,
-            json(SemanticResponse {
-                chunks: result.unwrap(),
-            }),
-        )
+        Ok(json(SemanticResponse {
+            chunks: result.unwrap(),
+        }))
     } else {
-        return (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            error(ErrorKind::Configuration, "Qdrant not configured"),
-        );
+        Err(Error::new(
+            ErrorKind::Configuration,
+            "Qdrant not configured",
+        ))
     }
 }
 


### PR DESCRIPTION
This allows us to use simple `Result<impl IntoResponse>` for webserver handler return types, and use plain `?`-based error handling, which correctly propagates HTTP status codes.