### PR TITLE
index less

### DIFF
--- a/server/bleep/src/indexes/file.rs
+++ b/server/bleep/src/indexes/file.rs
@@ -177,7 +177,7 @@ fn should_index<P: AsRef<Path>>(p: &P) -> bool {
         // executable
         "com", "exe", "out", "coff", "obj", "dll", "app", "class",
         // misc.
-        "log", "wad", "bsp", "bak", "sav", "dat",
+        "log", "wad", "bsp", "bak", "sav", "dat", "lock",
     ];
 
     let Some(ext) = path.extension() else {


### PR DESCRIPTION
If my hunch is right, the recent indexing slowdown is due to the fact that we also index a full onnxruntime (because we don't filter out the `target`  directory. This should hopefully help.