### PR TITLE
Update tagging of runners for docker builds

### DIFF
--- a/.github/workflows/build-on-pr.yml
+++ b/.github/workflows/build-on-pr.yml
@@ -7,7 +7,7 @@ jobs:
     with:
       repository: bloop
       tag: build-${{ github.sha }}
-      runner: "docker"
+      runner: docker
     secrets:
       awsRegion: ${{ secrets.AWS_REGION }}
       awsAccountID: ${{ secrets.AWS_ACCOUNT_ID }}

--- a/.github/workflows/build-on-pr.yml
+++ b/.github/workflows/build-on-pr.yml
@@ -7,7 +7,7 @@ jobs:
     with:
       repository: bloop
       tag: build-${{ github.sha }}
-      runner: self-hosted
+      runner: "docker"
     secrets:
       awsRegion: ${{ secrets.AWS_REGION }}
       awsAccountID: ${{ secrets.AWS_ACCOUNT_ID }}


### PR DESCRIPTION
This makes possible expanding the self-hosted CI with more specific roles.