### PR TITLE
references files from across the repo in the prompt

### DIFF
--- a/server/bleep/src/indexes/file.rs
+++ b/server/bleep/src/indexes/file.rs
@@ -423,7 +423,7 @@ impl Indexer<File> {
             None => BooleanQuery::intersection(vec![path_query]),
         };
 
-        let collector = TopDocs::with_limit(100);
+        let collector = TopDocs::with_limit(200);
         searcher
             .search(&query, &collector)
             .expect("failed to search index")

--- a/server/bleep/src/intelligence/scope_resolution/def.rs
+++ b/server/bleep/src/intelligence/scope_resolution/def.rs
@@ -2,7 +2,7 @@ use crate::{intelligence::namespace::SymbolId, text_range::TextRange};
 
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct LocalDef {
     pub range: TextRange,
     pub symbol_id: Option<SymbolId>,


### PR DESCRIPTION
cross-referencing is a three-staged process:

- pass the original snippet into an `extract` prompt, the extract prompt retrieves the most "important" function calls in the snippet, by whatever metric GPT deems fit
- the definitions of these function calls are located using scope-graphs from across the code-base
- the explain prompt is given snippets of these definitions

TODO: comparative analysis of cross-referencing vs no-cross-referencing.