### PR TITLE
tweak analytics to function on partially complete answer pipelines

### DIFF
--- a/server/bleep/src/analytics.rs
+++ b/server/bleep/src/analytics.rs
@@ -1,21 +1,61 @@
-use crate::{semantic::chunk::OverlapStrategy, webserver::answer::Snippet};
+use std::time::Duration;
+
+use crate::semantic::chunk::OverlapStrategy;
+
 use rudderanalytics::{
     client::RudderAnalytics,
     message::{Message, Track},
 };
-use serde_json::json;
+use serde_json::{json, Value};
 
+#[derive(Debug, Default)]
 pub struct QueryEvent {
     pub user_id: String,
     pub query_id: uuid::Uuid,
-    pub query: String,
-    pub select_prompt: String,
-    pub semantic_results: Vec<Snippet>,
-    pub filtered_semantic_results: Vec<Snippet>,
-    pub relevant_snippet_index: usize,
-    pub explain_prompt: String,
-    pub explanation: String,
     pub overlap_strategy: OverlapStrategy,
+    pub stages: Vec<Stage>,
+}
+
+/// Represents a single stage of the Answer API pipeline
+#[derive(Debug, serde::Serialize)]
+pub struct Stage {
+    /// The name of this stage, e.g.: "filtered semantic results"
+    pub name: &'static str,
+
+    /// The type of the data being serialized
+    #[serde(rename = "type")]
+    pub _type: &'static str,
+
+    /// Stage payload
+    pub data: Value,
+
+    /// Time taken for this stage in milliseconds
+    pub time_elapsed: Option<u128>,
+}
+
+impl Stage {
+    pub fn new<T: serde::Serialize>(name: &'static str, data: T) -> Self {
+        let data = serde_json::to_value(data).unwrap();
+        let _type = match data {
+            Value::Null => "null",
+            Value::Bool(_) => "bool",
+            Value::Number(_) => "number",
+            Value::String(_) => "string",
+            Value::Array(_) => "array",
+            Value::Object(_) => "object",
+        };
+        Self {
+            name,
+            _type,
+            data,
+            time_elapsed: None,
+        }
+    }
+
+    pub fn with_time(mut self, time_elapsed: Duration) -> Self {
+        self.time_elapsed = Some(time_elapsed.as_millis());
+        self
+    }
 }
 
 pub trait QueryAnalyticsSource {
@@ -30,43 +70,7 @@ impl QueryAnalyticsSource for RudderAnalytics {
             properties: Some(json!({
                 "query_id": event.query_id,
                 "overlap_strategy": event.overlap_strategy,
-                "stages": [
-                    {
-                        "name": "user query",
-                        "type": "string",
-                        "data": event.query,
-                    },
-                    {
-                        "name": "semantic results",
-                        "type": "array",
-                        "data": event.semantic_results,
-                    },
-                    {
-                        "name": "filtered semantic results",
-                        "type": "array",
-                        "data": event.filtered_semantic_results,
-                    },
-                    {
-                        "name": "select prompt",
-                        "type": "string",
-                        "data": event.select_prompt,
-                    },
-                    {
-                        "name": "relevant snippet index",
-                        "type": "number",
-                        "data": event.relevant_snippet_index,
-                    },
-                    {
-                        "name": "explain prompt",
-                        "type": "string",
-                        "data": event.explain_prompt,
-                    },
-                    {
-                        "name": "explanation",
-                        "type": "string",
-                        "data": event.explanation,
-                    }
-                ]
+                "stages": event.stages,
             })),
             ..Default::default()
         }));

--- a/server/bleep/src/analytics.rs
+++ b/server/bleep/src/analytics.rs
@@ -8,7 +8,7 @@ use rudderanalytics::{
 };
 use serde_json::{json, Value};
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct QueryEvent {
     pub user_id: String,
     pub query_id: uuid::Uuid,
@@ -17,7 +17,7 @@ pub struct QueryEvent {
 }
 
 /// Represents a single stage of the Answer API pipeline
-#[derive(Debug, serde::Serialize)]
+#[derive(Debug, serde::Serialize, Clone)]
 pub struct Stage {
     /// The name of this stage, e.g.: "filtered semantic results"
     pub name: &'static str,

--- a/server/bleep/src/analytics.rs
+++ b/server/bleep/src/analytics.rs
@@ -34,7 +34,7 @@ pub struct Stage {
 }
 
 impl Stage {
-    pub fn new<T: serde::Serialize>(name: &'static str, data: T) -> Self {
+    pub fn new<T: serde::Serialize>(name: &'static str, data: &T) -> Self {
         let data = serde_json::to_value(data).unwrap();
         let _type = match data {
             Value::Null => "null",

--- a/server/bleep/src/indexes/file.rs
+++ b/server/bleep/src/indexes/file.rs
@@ -666,7 +666,7 @@ mod test {
         ];
 
         for (path, index) in tests {
-            assert_eq!(should_index(&Path::new(dbg!(path))), index);
+            assert_eq!(should_index(&Path::new(path)), index);
         }
     }
 }

--- a/server/bleep/src/lib.rs
+++ b/server/bleep/src/lib.rs
@@ -192,9 +192,9 @@ impl Application {
         LOGGER_INSTALLED.set(true).unwrap();
     }
 
-    pub fn track_query(&self, event: analytics::QueryEvent) {
+    pub fn track_query(&self, event: &analytics::QueryEvent) {
         if let Some(client) = &*self.analytics_client {
-            tokio::task::block_in_place(|| client.track_query(event));
+            tokio::task::block_in_place(|| client.track_query(event.clone()));
         }
     }
 

--- a/server/bleep/src/semantic.rs
+++ b/server/bleep/src/semantic.rs
@@ -291,8 +291,6 @@ impl Semantic {
     }
 
     pub fn overlap_strategy(&self) -> chunk::OverlapStrategy {
-        self.config
-            .overlap
-            .unwrap_or(chunk::OverlapStrategy::Partial(0.5))
+        self.config.overlap.unwrap_or_default()
     }
 }

--- a/server/bleep/src/semantic/chunk.rs
+++ b/server/bleep/src/semantic/chunk.rs
@@ -149,6 +149,12 @@ impl OverlapStrategy {
     }
 }
 
+impl Default for OverlapStrategy {
+    fn default() -> Self {
+        Self::Partial(0.5)
+    }
+}
+
 /// This should take care of [CLS], [SEP] etc. which could be introduced during per-chunk tokenization
 pub const DEDUCT_SPECIAL_TOKENS: usize = 2;
 

--- a/server/bleep/src/webserver/answer.rs
+++ b/server/bleep/src/webserver/answer.rs
@@ -145,7 +145,7 @@ async fn _handle(
 
     analytics_event
         .stages
-        .push(Stage::new("user query", params.q.clone()).with_time(stop_watch.lap()));
+        .push(Stage::new("user query", &params.q).with_time(stop_watch.lap()));
 
     let query = parser::parse_nl(&params.q).map_err(|e| {
         (
@@ -208,7 +208,7 @@ async fn _handle(
 
     analytics_event
         .stages
-        .push(Stage::new("semantic results", all_snippets.clone()).with_time(stop_watch.lap()));
+        .push(Stage::new("semantic results", &all_snippets).with_time(stop_watch.lap()));
 
     let mut snippets = vec![];
     let mut chunk_ranges_by_file: HashMap<String, Vec<std::ops::Range<usize>>> = HashMap::new();
@@ -247,9 +247,9 @@ async fn _handle(
         }
     }
 
-    analytics_event.stages.push(
-        Stage::new("filtered semantic results", snippets.clone()).with_time(stop_watch.lap()),
-    );
+    analytics_event
+        .stages
+        .push(Stage::new("filtered semantic results", &snippets).with_time(stop_watch.lap()));
 
     if snippets.is_empty() {
         warn!("Semantic search returned no snippets");
@@ -268,7 +268,7 @@ async fn _handle(
 
     analytics_event
         .stages
-        .push(Stage::new("select prompt", select_prompt.clone()).with_time(stop_watch.lap()));
+        .push(Stage::new("select prompt", &select_prompt).with_time(stop_watch.lap()));
 
     let relevant_snippet_index = answer_api_client
         .select_snippet(&select_prompt)
@@ -285,7 +285,7 @@ async fn _handle(
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, super::internal_error(e)))?;
 
     analytics_event.stages.push(
-        Stage::new("relevant snippet index", relevant_snippet_index).with_time(stop_watch.lap()),
+        Stage::new("relevant snippet index", &relevant_snippet_index).with_time(stop_watch.lap()),
     );
 
     if relevant_snippet_index == 0 {
@@ -387,7 +387,7 @@ async fn _handle(
 
         event
             .stages
-            .push(Stage::new("explanation", explanation).with_time(stop_watch.lap()));
+            .push(Stage::new("explanation", &explanation).with_time(stop_watch.lap()));
 
         app.track_query(&event);
     };

--- a/server/bleep/src/webserver/answer.rs
+++ b/server/bleep/src/webserver/answer.rs
@@ -114,7 +114,7 @@ pub(super) async fn handle(
     if response.is_err() {
         // send event to rudderstack
         let event = event.read().await;
-        app.track_query(&*event);
+        app.track_query(&event);
     } else {
         // the analytics event is fired when the stream is consumed
     }
@@ -368,8 +368,6 @@ async fn _handle(
     drop(analytics_event);
 
     let analytics_event = Arc::clone(&event);
-    let c_app = app.clone();
-
     let stream = async_stream::stream! {
         yield Ok(initial_event);
 
@@ -391,7 +389,7 @@ async fn _handle(
             .stages
             .push(Stage::new("explanation", explanation).with_time(stop_watch.lap()));
 
-        c_app.clone().track_query(&*event);
+        app.track_query(&event);
     };
 
     Ok(Sse::new(stream))

--- a/server/bleep/src/webserver/answer.rs
+++ b/server/bleep/src/webserver/answer.rs
@@ -1,4 +1,7 @@
-use std::collections::HashMap;
+use std::{
+    collections::HashMap,
+    time::{Duration, Instant},
+};
 
 use axum::{
     extract::Query,
@@ -12,8 +15,12 @@ use tracing::{debug, error, info, warn};
 use utoipa::ToSchema;
 
 use crate::{
-    analytics::QueryEvent, indexes::reader::ContentDocument, query::parser, semantic::Semantic,
-    state::RepoRef, Application,
+    analytics::{QueryEvent, Stage},
+    indexes::reader::ContentDocument,
+    query::parser,
+    semantic::Semantic,
+    state::RepoRef,
+    Application,
 };
 
 use super::ErrorKind;
@@ -96,12 +103,40 @@ pub(super) async fn handle(
     Query(params): Query<Params>,
     Extension(app): Extension<Application>,
 ) -> Result<impl IntoResponse, (StatusCode, Json<super::Response<'static>>)> {
+    // create a new analytics event for this query
+    let mut event = QueryEvent::default();
+
+    // populate analytics event
+    let response = _handle(params, app.clone(), &mut event).await;
+
+    // send event to rudderstack
+    app.track_query(event);
+
+    response
+}
+
+async fn _handle(
+    params: Params,
+    app: Application,
+    analytics_event: &mut QueryEvent,
+) -> Result<impl IntoResponse, (StatusCode, Json<super::Response<'static>>)> {
+    let query_id = uuid::Uuid::new_v4();
+    let mut stop_watch = StopWatch::start();
+
     let semantic = app.semantic.clone().ok_or_else(|| {
         (
             StatusCode::INTERNAL_SERVER_ERROR,
             super::error(ErrorKind::Configuration, "Qdrant not configured"),
         )
     })?;
+
+    analytics_event.user_id = params.user_id.clone();
+    analytics_event.query_id = query_id;
+    analytics_event.overlap_strategy = semantic.overlap_strategy();
+
+    analytics_event
+        .stages
+        .push(Stage::new("user query", params.q.clone()).with_time(stop_watch.lap()));
 
     let query = parser::parse_nl(&params.q).map_err(|e| {
         (
@@ -162,6 +197,10 @@ pub(super) async fn handle(
         })
         .collect();
 
+    analytics_event
+        .stages
+        .push(Stage::new("semantic results", all_snippets.clone()).with_time(stop_watch.lap()));
+
     let mut snippets = vec![];
     let mut chunk_ranges_by_file: HashMap<String, Vec<std::ops::Range<usize>>> = HashMap::new();
 
@@ -199,6 +238,10 @@ pub(super) async fn handle(
         }
     }
 
+    analytics_event.stages.push(
+        Stage::new("filtered semantic results", snippets.clone()).with_time(stop_watch.lap()),
+    );
+
     if snippets.is_empty() {
         warn!("Semantic search returned no snippets");
         return Err((
@@ -213,6 +256,11 @@ pub(super) async fn handle(
     let answer_api_client = semantic.build_answer_api_client(answer_api_host.as_str(), target, 5);
 
     let select_prompt = answer_api_client.build_select_prompt(&snippets);
+
+    analytics_event
+        .stages
+        .push(Stage::new("select prompt", select_prompt.clone()).with_time(stop_watch.lap()));
+
     let relevant_snippet_index = answer_api_client
         .select_snippet(&select_prompt)
         .await
@@ -226,6 +274,10 @@ pub(super) async fn handle(
     let mut relevant_snippet_index = relevant_snippet_index
         .parse::<usize>()
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, super::internal_error(e)))?;
+
+    analytics_event.stages.push(
+        Stage::new("relevant snippet index", relevant_snippet_index).with_time(stop_watch.lap()),
+    );
 
     if relevant_snippet_index == 0 {
         return Err((
@@ -284,8 +336,6 @@ pub(super) async fn handle(
     // reorder snippets
     snippets.swap(relevant_snippet_index, 0);
 
-    let query_id = uuid::Uuid::new_v4();
-
     // answering snippet is always at index 0
     let answer_path = snippets.get(0).unwrap().relative_path.to_string();
 
@@ -297,6 +347,10 @@ pub(super) async fn handle(
             answer_path,
         }))
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, super::internal_error(e)))?;
+
+    analytics_event
+        .stages
+        .push(Stage::new("explanation", "").with_time(stop_watch.lap()));
 
     let explain_prompt = answer_api_client.build_explain_prompt(&processed_snippet);
 
@@ -321,18 +375,6 @@ pub(super) async fn handle(
             }
         }
 
-        app.track_query(QueryEvent {
-            user_id: params.user_id,
-            query_id,
-            query: params.q.clone(),
-            semantic_results: all_snippets,
-            filtered_semantic_results: snippets,
-            select_prompt,
-            relevant_snippet_index,
-            explain_prompt,
-            explanation,
-            overlap_strategy: semantic.overlap_strategy(),
-        });
     };
 
     Ok(Sse::new(stream))
@@ -566,5 +608,31 @@ Answer in GitHub Markdown:",
         let max_tokens = max_tokens.clamp(1, 500);
         info!(%max_tokens, "clamping max tokens");
         self.send(prompt, max_tokens as u32, 0.9).await
+    }
+}
+
+// Measure time between instants statefully
+struct StopWatch {
+    start: Instant,
+}
+
+impl StopWatch {
+    // Start the watch
+    fn start() -> Self {
+        Self {
+            start: Instant::now(),
+        }
+    }
+
+    // Measure the time since start
+    fn measure(&self) -> Duration {
+        self.start.elapsed()
+    }
+
+    // Read the value since the last start, and zero the clock
+    fn lap(&mut self) -> Duration {
+        let duration = self.measure();
+        self.start = Instant::now();
+        duration
     }
 }


### PR DESCRIPTION
in order to accomplish this, the core logic of `answer::handle` has been moved into a helper function: `_handle`. this new `handle` wraps around `_handle` and performs cleanup duties (firing analytics events) when `_handle` early exits, the call stack might look like this:

- (`handle`) receives request
- (`handle`) analytics pipeline is initialized
- (`handle -> _handle`) enter `_handle` to process request
- (`handle -> _handle`) early exit back to `handle`
- (`handle`) track analytics upto the point of exit
- (`handle`) sends response

additionally, this PR adds stage-wise-time-elapsed data to analytics (this might be done better with the tracing-timing crate).  