### PR TITLE
prevent re-indexing from creating duplicates in qdrant

### DIFF
--- a/server/bleep/src/semantic.rs
+++ b/server/bleep/src/semantic.rs
@@ -177,24 +177,11 @@ impl Semantic {
             anyhow::bail!("no search target for query");
         };
 
-        let make_kv_filter = |key, value| {
-            FieldCondition {
-                key,
-                r#match: Some(Match {
-                    match_value: MatchValue::Text(value).into(),
-                }),
-                ..Default::default()
-            }
-            .into()
-        };
-
         let repo_filter = nl_query
             .repo()
-            .map(|r| make_kv_filter("repo_name".to_string(), r.to_string()));
+            .map(|r| make_kv_filter("repo_name", r).into());
 
-        let lang_filter = nl_query
-            .lang()
-            .map(|l| make_kv_filter("lang".to_string(), l.to_string()));
+        let lang_filter = nl_query.lang().map(|l| make_kv_filter("lang", l).into());
 
         let filters = [repo_filter, lang_filter]
             .into_iter()
@@ -230,6 +217,8 @@ impl Semantic {
         buffer: &str,
         lang_str: &str,
     ) {
+        self.delete_points_by_path(repo_ref, relative_path).await;
+
         let chunks = chunk::by_tokens(
             repo_name,
             relative_path,
@@ -241,6 +230,7 @@ impl Semantic {
         );
         let repo_plus_file = repo_name.to_owned() + "\t" + relative_path + "\n";
         debug!(chunk_count = chunks.len(), "found chunks");
+
         let datapoints = chunks
             .par_iter()
             .filter_map(
@@ -283,6 +273,19 @@ impl Semantic {
         }
     }
 
+    pub async fn delete_points_by_path(&self, repo_ref: &str, relative_path: &str) {
+        let conditions = vec![
+            make_kv_filter("repo_ref", repo_ref).into(),
+            make_kv_filter("relative_path", relative_path).into(),
+        ];
+        let selector = Filter {
+            must: conditions,
+            ..Default::default()
+        }
+        .into();
+        let _ = self.qdrant.delete_points(COLLECTION_NAME, &selector).await;
+    }
+
     pub fn gpt2_token_count(&self, input: &str) -> usize {
         self.gpt2_tokenizer
             .encode(input, false)
@@ -294,5 +297,17 @@ impl Semantic {
         self.config
             .overlap
             .unwrap_or(chunk::OverlapStrategy::Partial(0.5))
+    }
+}
+
+fn make_kv_filter(key: &str, value: &str) -> FieldCondition {
+    let key = key.to_owned();
+    let value = value.to_owned();
+    FieldCondition {
+        key,
+        r#match: Some(Match {
+            match_value: MatchValue::Text(value).into(),
+        }),
+        ..Default::default()
     }
 }


### PR DESCRIPTION
fixes a critical bug that reduced the accuracy of `/api/answer` over time. 

previous behaviour:
- upon re-index, a new set of points are added to qdrant and the old points are not invalidated
- upsert would normally handle this, but we currently do not have a way of uniquely identifying a point 
- as every new set of points is similar (cosine-similarity) to the original set, the results of retrieval contained duplicates and thus reduced the performance of `/api/answer`.

updated behaviour:
- upon re-index, any existing points for a re-indexed file are removed from qdrant, and a new set of points for that file are calculated and inserted
- if the file is removed from the index altogether, the points corresponding to that file are removed

--- 
testing:

1. setup the repo like so:
    -  initialize a file, say `a.rs` (non-empty), and `git init && git add .`
    - measure the point count thus far: say, `N` using: `curl "http://localhost:6333/collections/documents" | jq '.result.point_count'`

2. test point addition:
    - duplicate the contents of `a.rs` into `a.rs` itself and check the change into git
    - measure the point count again, it should be `2 * N` (and not `3 * N`, which is the result without this patchset, calculated as `N (original) + 2 * N (reindexed)`)

3. test point deletion:
    - delete `a.rs` and check the change into git
    - measure the point count, it should be zero and not non-zero.