### PR TITLE
Use bearer token to authenticate with Answer API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -999,6 +999,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "cookie_store"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e4b6aa369f41f5faa04bb80c9b1f4216ea81646ed6124d76ba5c49a7aafd9cd"
+dependencies = [
+ "cookie",
+ "idna 0.2.3",
+ "log",
+ "publicsuffix",
+ "serde",
+ "serde_json",
+ "time 0.3.17",
+ "url",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2537,6 +2553,17 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "idna"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
+dependencies = [
+ "matches",
+ "unicode-bidi",
+ "unicode-normalization",
+]
 
 [[package]]
 name = "idna"
@@ -4204,6 +4231,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "psl-types"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac"
+
+[[package]]
+name = "publicsuffix"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96a8c1bda5ae1af7f99a2962e49df150414a43d62404644d98dd5c3a93d07457"
+dependencies = [
+ "idna 0.3.0",
+ "psl-types",
+]
+
+[[package]]
 name = "qdrant-client"
 version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4471,6 +4514,8 @@ checksum = "21eed90ec8570952d53b772ecf8f206aa1ec9a3d76b2521c56c42973f2d91ee9"
 dependencies = [
  "base64 0.21.0",
  "bytes",
+ "cookie",
+ "cookie_store",
  "encoding_rs",
  "futures-core",
  "futures-util",
@@ -6410,7 +6455,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643"
 dependencies = [
  "form_urlencoded",
- "idna",
+ "idna 0.3.0",
  "percent-encoding",
  "serde",
 ]

--- a/server/bleep/Cargo.toml
+++ b/server/bleep/Cargo.toml
@@ -71,7 +71,7 @@ tower-http = { version = "0.3.5", features = ["auth", "cors", "catch-panic", "fs
 
 # api integrations
 octocrab = { git = "https://github.com/bloopai/octocrab", default-features = false, features = ["rustls"] }
-reqwest = { version = "0.11.14", features = ["rustls-tls", "rustls"], default-features = false }
+reqwest = { version = "0.11.14", features = ["rustls-tls", "rustls", "cookies"], default-features = false }
 reqwest-eventsource = "0.4.0"
 secrecy = { version = "0.8.0", features = ["serde"] }
 

--- a/server/bleep/src/remotes/github.rs
+++ b/server/bleep/src/remotes/github.rs
@@ -77,10 +77,10 @@ impl Auth {
 
     pub async fn check_repo(&self, repo: &Repository) -> Result<()> {
         let RepoRemote::Git(GitRemote {
-	    ref address, ..
-	}) = repo.remote else {
-	    return Err(RemoteError::NotSupported("github without git backend"));
-	};
+            ref address, ..
+        }) = repo.remote else {
+            return Err(RemoteError::NotSupported("github without git backend"));
+        };
 
         let (org, reponame) = address
             .split_once('/')

--- a/server/bleep/src/webserver.rs
+++ b/server/bleep/src/webserver.rs
@@ -2,6 +2,7 @@ use crate::{env::Feature, snippet, state, Application};
 
 use axum::middleware;
 use axum::{http::StatusCode, response::IntoResponse, routing::get, Extension, Json};
+use std::sync::Arc;
 use std::{borrow::Cow, net::SocketAddr};
 use tower::Service;
 use tower_http::services::{ServeDir, ServeFile};
@@ -63,7 +64,10 @@ pub async fn start(app: Application) -> anyhow::Result<()> {
         // misc
         .route("/file/*ref", get(file::handle))
         .route("/semantic/chunks", get(semantic::raw_chunks))
-        .route("/answer", get(answer::handle));
+        .route(
+            "/answer",
+            get(answer::handle).with_state(Arc::new(answer::AnswerState::default())),
+        );
 
     if app.env.allow(Feature::GithubDeviceFlow) {
         api = api

--- a/server/bleep/src/webserver/answer.rs
+++ b/server/bleep/src/webserver/answer.rs
@@ -5,11 +5,13 @@ use std::{
 };
 
 use axum::{
-    extract::Query,
+    extract::{Query, State},
+    http::StatusCode,
     response::{sse::Event, IntoResponse, Sse},
     Extension,
 };
 use futures::{Stream, StreamExt, TryStreamExt};
+use secrecy::ExposeSecret;
 use thiserror::Error;
 use tokio::sync::RwLock;
 use tracing::{debug, error, info, warn};
@@ -17,10 +19,12 @@ use utoipa::ToSchema;
 
 use crate::{
     analytics::{QueryEvent, Stage},
+    env::Feature,
     indexes::reader::ContentDocument,
     query::parser,
+    remotes::{self, BackendCredential},
     semantic::Semantic,
-    state::RepoRef,
+    state::{Backend, RepoRef},
     Application,
 };
 
@@ -100,15 +104,33 @@ impl From<AnswerResponse> for super::Response<'static> {
 
 const SNIPPET_COUNT: usize = 13;
 
+pub(super) struct AnswerState {
+    client: reqwest::Client,
+}
+
+impl Default for AnswerState {
+    fn default() -> Self {
+        Self {
+            client: reqwest::Client::builder()
+                .cookie_store(true)
+                .build()
+                // This should never fail, the only default properties we change are enabling
+                // cookies.
+                .unwrap(),
+        }
+    }
+}
+
 pub(super) async fn handle(
     Query(params): Query<Params>,
+    State(state): State<Arc<AnswerState>>,
     Extension(app): Extension<Application>,
 ) -> Result<impl IntoResponse> {
     // create a new analytics event for this query
     let event = Arc::new(RwLock::new(QueryEvent::default()));
 
     // populate analytics event
-    let response = _handle(params, app.clone(), Arc::clone(&event)).await;
+    let response = _handle(&state, params, app.clone(), Arc::clone(&event)).await;
 
     if response.is_err() {
         // send event to rudderstack
@@ -122,6 +144,7 @@ pub(super) async fn handle(
 }
 
 async fn _handle(
+    state: &AnswerState,
     params: Params,
     app: Application,
     event: Arc<RwLock<QueryEvent>>,
@@ -242,8 +265,38 @@ async fn _handle(
         info!("Semantic search returned {} snippets", snippets.len());
     }
 
+    let answer_bearer = if app.env.allow(Feature::GithubDeviceFlow) {
+        let Some(cred) = app.credentials.get(&Backend::Github) else {
+            return Err(Error::user(
+                "missing Github token",
+            ).with_status(StatusCode::UNAUTHORIZED));
+        };
+
+        match &*cred {
+            BackendCredential::Github(remotes::github::Auth::OAuth {
+                access_token: token,
+                ..
+            }) => Some(token.expose_secret().clone()),
+
+            BackendCredential::Github(remotes::github::Auth::App { .. }) => {
+                return Err(
+                    Error::user("cannot connect to answer API using installation token")
+                        .with_status(StatusCode::UNAUTHORIZED),
+                )
+            }
+        }
+    } else {
+        None
+    };
+
     let answer_api_host = format!("{}/q", app.config.answer_api_url);
-    let answer_api_client = semantic.build_answer_api_client(answer_api_host.as_str(), target, 5);
+    let answer_api_client = semantic.build_answer_api_client(
+        state,
+        answer_api_host.as_str(),
+        target,
+        5,
+        answer_bearer.clone(),
+    );
 
     let select_prompt = answer_api_client.build_select_prompt(&snippets);
 
@@ -394,11 +447,12 @@ fn grow(doc: &ContentDocument, snippet: &Snippet, size: usize) -> String {
 }
 
 struct AnswerAPIClient<'s> {
-    client: reqwest::Client,
     host: String,
     query: String,
     semantic: &'s Semantic,
     max_attempts: usize,
+    bearer_token: Option<String>,
+    client: reqwest::Client,
 }
 
 #[derive(Error, Debug)]
@@ -432,16 +486,21 @@ impl From<AnswerAPIError> for Error {
 impl Semantic {
     fn build_answer_api_client<'s>(
         &'s self,
+        state: &AnswerState,
         host: &str,
         query: &str,
         max_attempts: usize,
+        bearer_token: Option<String>,
     ) -> AnswerAPIClient<'s> {
         AnswerAPIClient {
-            client: reqwest::Client::new(),
             host: host.to_owned(),
             query: query.to_owned(),
             semantic: self,
             max_attempts,
+            // Internally, cookies are shared between `reqwest` client instances via a shared lock.
+            // Cloning the client here just creates a new handle to the same lock.
+            client: state.client.clone(),
+            bearer_token,
         }
     }
 }
@@ -454,13 +513,19 @@ impl<'s> AnswerAPIClient<'s> {
         temperature: f32,
     ) -> Result<impl Stream<Item = Result<String, AnswerAPIError>>, AnswerAPIError> {
         let mut stream = Box::pin(
-            reqwest_eventsource::EventSource::new(self.client.post(self.host.as_str()).json(
-                &api::Request {
+            reqwest_eventsource::EventSource::new({
+                let mut builder = self.client.post(self.host.as_str());
+
+                if let Some(bearer) = &self.bearer_token {
+                    builder = builder.bearer_auth(bearer);
+                }
+
+                builder.json(&api::Request {
                     prompt: prompt.to_string(),
                     max_tokens: Some(max_tokens),
                     temperature: Some(temperature),
-                },
-            ))
+                })
+            })
             // We don't have a `Stream` body so this can't fail.
             .expect("couldn't clone requestbuilder")
             // `reqwest_eventsource` returns an error to signify a stream end, instead of simply ending


### PR DESCRIPTION
This commit adds an `Authorization` header as newly requested by the Answer API on certain configurations. A `reqwest` client is configured to store cookies that are received from the server, allowing us to make use of the Answer API token validation caching mechanism.