### PR TITLE
Remove repositories from indexes

### DIFF
--- a/server/bleep/src/background.rs
+++ b/server/bleep/src/background.rs
@@ -146,8 +146,9 @@ impl IndexWriter {
             Removed => {
                 let deleted = self.delete_repo_indexes(&repo, &writers).await;
                 if deleted.is_ok() {
-                    writers.rollback()?;
+                    writers.commit().await?;
                     repo_pool.remove(reporef);
+                    config.source.save_pool(repo_pool.clone())?;
                 }
                 return deleted;
             }

--- a/server/bleep/src/background.rs
+++ b/server/bleep/src/background.rs
@@ -4,7 +4,7 @@ use tracing::{debug, error, info};
 use crate::{
     indexes,
     remotes::RemoteError,
-    state::{RepoRef, RepoRemote, Repository, SyncStatus},
+    state::{RepoRef, Repository, SyncStatus},
     Application, Configuration,
 };
 
@@ -260,7 +260,7 @@ impl IndexWriter {
         }
 
         repo.delete_file_cache(&config.index_dir)?;
-        if !matches!(repo.remote, RepoRemote::None) {
+        if !reporef.is_local() {
             tokio::fs::remove_dir_all(&repo.disk_path).await?;
         }
 

--- a/server/bleep/src/webserver.rs
+++ b/server/bleep/src/webserver.rs
@@ -180,6 +180,12 @@ impl Error {
     }
 }
 
+impl From<anyhow::Error> for Error {
+    fn from(value: anyhow::Error) -> Self {
+        Error::internal(value.to_string())
+    }
+}
+
 impl IntoResponse for Error {
     fn into_response(self) -> axum::response::Response {
         (self.status, self.body).into_response()

--- a/server/bleep/src/webserver/repos.rs
+++ b/server/bleep/src/webserver/repos.rs
@@ -147,6 +147,7 @@ pub(super) async fn delete_by_id(
     match app.repo_pool.get_mut(&reporef) {
         Some(mut result) => {
             result.value_mut().delete();
+            app.write_index().queue_sync_and_index(vec![reporef]);
             Ok(json(ReposResponse::Deleted))
         }
         None => Err(Error::new(ErrorKind::NotFound, "Can't find repository")),


### PR DESCRIPTION
Instead of `commit()`ing the changes in `delete_repo_indexes`, previously we rolled them back. The state changes were also never persisted to disk. This patch leaves the indexes in consistent state.