### PR TITLE
shorten prompt completion by referencing code

### DIFF
--- a/client/src/components/CodeBlock/SemanticSearch/Answer/index.tsx
+++ b/client/src/components/CodeBlock/SemanticSearch/Answer/index.tsx
@@ -35,6 +35,7 @@ const Answer = ({ handleRetry, nlQuery, searchId }: Props) => {
   const [isUpvote, setIsUpvote] = useState(false);
   const [isDownvote, setIsDownvote] = useState(false);
   const [answer, setAnswer] = useState('');
+  const [relevantCode, setRelevantCode] = useState('');
   const [error, setError] = useState('');
   const { trackUpvote } = useAnalytics();
   const RiveUpvote = useRive({
@@ -47,6 +48,10 @@ const Answer = ({ handleRetry, nlQuery, searchId }: Props) => {
   });
 
   const highlightedAnswer = useMemo(() => md.render(answer), [answer]);
+  const highlightedCode = useMemo(
+    () => md.render(relevantCode),
+    [relevantCode],
+  );
 
   useEffect(() => {
     let eventSource: EventSource;
@@ -63,7 +68,11 @@ const Answer = ({ handleRetry, nlQuery, searchId }: Props) => {
         if (newData.Err) {
           setError(newData.Err);
         } else if (i !== 0) {
-          setAnswer((prev) => prev + newData.Ok);
+          if (i === 1) {
+            setRelevantCode(newData.Ok);
+          } else {
+            setAnswer((prev) => prev + newData.Ok);
+          }
         }
         i++;
       };
@@ -118,6 +127,7 @@ const Answer = ({ handleRetry, nlQuery, searchId }: Props) => {
         dangerouslySetInnerHTML={{
           __html:
             highlightedAnswer +
+            (highlightedCode || '') +
             (error ? (
               <p className="text-danger-500">An error occurred: {error}</p>
             ) : (

--- a/client/src/components/CodeBlock/SemanticSearch/index.tsx
+++ b/client/src/components/CodeBlock/SemanticSearch/index.tsx
@@ -9,6 +9,7 @@ type Props = {
     repoName: string;
     lang: string;
     line: number;
+    subSnippets: { text: string; range: { start: number; end: number } }[];
   }[];
   onClick: ResultClick;
   handleRetry: () => void;
@@ -29,9 +30,11 @@ const SemanticSearch = ({
       {snippets.map((item, index) => (
         <span key={index} className={`${index ? 'mt-5' : ''}`}>
           <CodeBlockSearch
-            snippets={[
-              { code: item.code, highlights: [], lineStart: item.line },
-            ]}
+            snippets={item.subSnippets.map((ss) => ({
+              code: ss.text,
+              highlights: [],
+              lineStart: ss.range.start,
+            }))}
             language={item.lang}
             filePath={item.path}
             branch={''}

--- a/client/src/hooks/useSearch.tsx
+++ b/client/src/hooks/useSearch.tsx
@@ -24,6 +24,8 @@ interface SearchResponse<T> extends Status<T> {
   ) => void;
 }
 
+let prevEventSource: EventSource;
+
 export const useSearch = <T,>(
   query?: string,
   page: number = 0,
@@ -50,12 +52,14 @@ export const useSearch = <T,>(
 
     switch (currentSearchType) {
       case SearchType.NL:
+        prevEventSource?.close();
         const eventSource = new EventSource(
           `${apiUrl.replace(
             'https:',
             '',
           )}/answer?q=${query}&user_id=${deviceId}`,
         );
+        prevEventSource = eventSource;
         eventSource.onmessage = (ev) => {
           const queryTime = Date.now() - startTime;
           setLastQueryTime(queryTime);

--- a/client/src/pages/NLResults/index.tsx
+++ b/client/src/pages/NLResults/index.tsx
@@ -116,6 +116,7 @@ const ResultsPage = ({ resultsData, loading, handleRetry, nlQuery }: Props) => {
           repoName: item.repo_name,
           lang: item.lang,
           line: item.start_line,
+          subSnippets: item.sub_snippets,
         }))}
         searchId={resultsData.query_id}
         nlQuery={nlQuery}

--- a/client/src/types/api.ts
+++ b/client/src/types/api.ts
@@ -207,6 +207,7 @@ export interface NLSnippet {
   text: string;
   lang: string;
   start_line: number;
+  sub_snippets: { text: string; range: { start: number; end: number } }[];
 }
 
 export interface NLSearchResponse {

--- a/server/bleep/Cargo.toml
+++ b/server/bleep/Cargo.toml
@@ -102,7 +102,7 @@ once_cell = "1.17.0"
 relative-path = "1.7.3"
 qdrant-client = { version = "0.11.6", default-features = false }
 tokenizers = "0.13.2"
-ort = { git = "https://github.com/bloopai/ort", branch = "build-rs-fix" , features = ["prefer-compile-strategy", "compile-static"] }
+ort = { git = "https://github.com/bloopai/ort", branch = "build-rs-fix" }
 ndarray = "0.15"
 uuid = { version = "1.2.2", features = ["v4", "fast-rng"] }
 jsonwebtoken = { version = "8.2.0", features = ["use_pem"] }

--- a/server/bleep/src/webserver/answer.rs
+++ b/server/bleep/src/webserver/answer.rs
@@ -378,13 +378,13 @@ async fn _handle(
                 _ => {}
             };
 
-            if line == 1 {
+            if line == 0 {
                 // collect the first line
                 first_line.push_str(result.as_ref().map(|o| o.as_str()).unwrap_or(""));
                 // do not send events from the first line
                 continue 'stream;
 
-            } else if line == 2 {
+            } else if line == 1 {
                 // we have hit L2, L1 contains json by now
                 let line_nrs = serde_json::from_str::<Vec<Vec<usize>>>(
                     first_line.trim_start_matches(|c: char| c.is_numeric() || c == '\n' || c == '.' || c == ' '),
@@ -423,7 +423,7 @@ async fn _handle(
 
                 yield Ok(initial_event);
 
-                line = 3;
+                line = 2;
             }
 
             yield Ok(Event::default()
@@ -658,6 +658,7 @@ Answer:
 =========
 
 Question: {}
+Answer:
 ", snippet_with_nr , self.query);
         prompt
     }


### PR DESCRIPTION
the number of tokens produced in by the completion can be reduced by referencing to code by line numbers rather than generating code blocks.