### PR TITLE
do not unwrap on fallible canonicalize

### DIFF
--- a/server/bleep/src/ctags.rs
+++ b/server/bleep/src/ctags.rs
@@ -49,12 +49,8 @@ fn find_files(path: &Path) -> Vec<String> {
             }
         })
         .filter(|de| matches!(de.file_type(), Some(ft) if ft.is_file()))
-        .map(|de| {
-            crate::canonicalize(de.path())
-                .unwrap()
-                .to_string_lossy()
-                .to_string()
-        })
+        .filter_map(|de| crate::canonicalize(de.path()).ok())
+        .map(|path| path.to_string_lossy().to_string())
         .collect()
 }
 

--- a/server/bleep/src/indexes/file.rs
+++ b/server/bleep/src/indexes/file.rs
@@ -256,7 +256,7 @@ impl Indexable for File {
             })
             // Preliminarily ignore files that are very large, without reading the contents.
             .filter(|de| matches!(de.metadata(), Ok(meta) if meta.len() < MAX_FILE_LEN))
-            .map(|de| crate::canonicalize(de.into_path()).unwrap())
+            .filter_map(|de| crate::canonicalize(de.into_path()).ok())
             .filter(|p| should_index(&p.strip_prefix(&repo.disk_path).unwrap()))
             .collect::<Vec<PathBuf>>();
 

--- a/server/bleep/src/remotes.rs
+++ b/server/bleep/src/remotes.rs
@@ -172,7 +172,11 @@ pub(crate) fn gather_repo_roots(
         .filter_entry(move |entry| {
             exclude
                 .as_ref()
-                .map(|path| !crate::canonicalize(entry.path()).unwrap().starts_with(path))
+                .and_then(|path| {
+                    crate::canonicalize(entry.path())
+                        .ok()
+                        .map(|canonical_path| !canonical_path.starts_with(path))
+                })
                 .unwrap_or(true)
         })
         .build()


### PR DESCRIPTION
`fs::canonicalize` can fail when attempting to follow broken symlinks, as in the case of this symlink in the tauri project: https://github.com/tauri-apps/tauri/blob/dev/core/tests/restart/LICENSE_APACHE-2.0. 