### PR TITLE
Install qdrant before starting tauri

### DIFF
--- a/apps/desktop/build.sh
+++ b/apps/desktop/build.sh
@@ -9,16 +9,5 @@ QDRANT_RELEASE=qdrant
 TARGET_TRIPLET="$(rustc -Vv |grep host |cut -d\  -f2)"
 QDRANT_LINK=qdrant-$TARGET_TRIPLET
 
-COMMAND=$1 
-case "$COMMAND" in
-	build|dev) ;;
-	*) 
-		echo "build.sh <build|dev>"
-	       	exit 1
-esac
-
-
 cargo install --git https://github.com/qdrant/qdrant --tag $QDRANT_VERSION --locked --root $ROOTDIR qdrant || true
 (cd $BINDIR; test -f $QDRANT_LINK || ln -sf $QDRANT_RELEASE $QDRANT_LINK)
-
-pnpm build $COMMAND

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -9,8 +9,9 @@
     "build": "npm-run-all tsc vite-build",
     "preview": "vite preview",
     "tauri": "tauri",
-    "tauri-dev": "tauri dev",
-    "tauri-build": "tauri build"
+    "build-qdrant": "./build.sh",
+    "tauri-dev": "npm-run-all build-qdrant \"tauri dev\"",
+    "tauri-build": "npm-run-all build-qdrant \"tauri build\""
   },
   "dependencies": {
     "@bloop/client": "workspace:*",

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,8 +1,8 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/schema.json",
   "build": {
-    "beforeBuildCommand": "./build.sh build",
-    "beforeDevCommand": "./build.sh dev",
+    "beforeBuildCommand": "npm run build",
+    "beforeDevCommand": "npm run dev",
     "devPath": "http://localhost:5173",
     "distDir": "../dist"
   },


### PR DESCRIPTION
Changed the order of running commands, now the flow is as follows:
- `npm run start-app` or `npm run build-app`
- command is forwarded to app/desktop `tauri-dev` or `tauri-build` script
- `build-qdrant` script in run (call to ./build.sh), if successful...
- `tauri dev` or `tauri build` is executed
- Tauri CLI looks into tauri.conf.json for beforeDevCommand or beforeBuildCommand
- Vite builds JS for dev or prod usage