### PR TITLE
Fix unnecessary auth token refreshes after first expiry

### DIFF
--- a/server/bleep/src/webserver/aaa.rs
+++ b/server/bleep/src/webserver/aaa.rs
@@ -74,6 +74,11 @@ impl AuthCookie {
         self.member_checked_at = Some(unix_time_sec());
     }
 
+    fn update_token(&mut self, github_token: GithubAuthToken) {
+        self.created_at = unix_time_sec();
+        self.github_token = github_token;
+    }
+
     fn to_cookie(&self) -> Cookie<'static> {
         let mut c = Cookie::new(
             AuthCookie::COOKIE_NAME,
@@ -298,8 +303,9 @@ async fn user_auth(
             .text()
             .await?;
 
-        auth_cookie.github_token =
+        let gh_token =
             serde_json::from_str(&oauth_json).context("failed to deserialize refresh token")?;
+        auth_cookie.update_token(gh_token);
     }
 
     if !member_checked {


### PR DESCRIPTION
Previously, `created_at` was only set once during cookie creation. As this value was never updated, once the initial token expires, the token would remain in a permanent state where it would always want a refresh for every subsequent request.

When in this state, and two requests are launched, this can cause a race condition: both requests will try to refresh the token, and if the earlier request returns later, this will result in a broken cookie. Depending on when this happens in the race, this will usually result in either a credential error or refresh token deserialization error.

In the app, this manifests itself as a `401 Unauthorized` response, requiring the user to log in every expiry period in order to fix the issue (8 hours by default for GitHub Apps).

To fix this, we update `created_at` on token refresh, so that requests do not need to unnecessarily refresh the token after the first expiry.