### PR TITLE
Log transport errors on GitHub token validation

### DIFF
--- a/client/src/components/PageTemplate/index.tsx
+++ b/client/src/components/PageTemplate/index.tsx
@@ -1,6 +1,17 @@
-import React from 'react';
+import React, { useCallback, useContext, useEffect, useState } from 'react';
 import NavBar from '../NavBar';
 import StatusBar from '../StatusBar';
+import { DeviceContext } from '../../context/deviceContext';
+import { AnalyticsContext } from '../../context/analyticsContext';
+import { UIContext } from '../../context/uiContext';
+import { STEP_KEY } from '../../pages/Home/Onboarding/RemoteServicesStep';
+import GithubConnectStep from '../../pages/Home/Onboarding/GithubConnectStep';
+import SeparateOnboardingStep from '../SeparateOnboardingStep';
+import {
+  IS_ANALYTICS_ALLOWED_KEY,
+  savePlainToStorage,
+} from '../../services/storage';
+import Button from '../Button';
 
 type Props = {
   children: React.ReactNode;
@@ -8,8 +19,49 @@ type Props = {
 
 const mainContainerStyle = { height: 'calc(100vh - 8rem)' };
 const PageTemplate = ({ children }: Props) => {
+  const { isSelfServe } = useContext(DeviceContext);
+  const { isAnalyticsAllowed, setIsAnalyticsAllowed } =
+    useContext(AnalyticsContext);
+  const { isGithubConnected, setOnBoardingState } = useContext(UIContext);
+  const [isModalOpen, setModalOpen] = useState(false);
+
+  useEffect(() => {
+    if (!isGithubConnected && isAnalyticsAllowed && !isSelfServe) {
+      setModalOpen(true);
+    }
+  }, []);
+
+  const saveOptIn = useCallback((optIn: boolean) => {
+    savePlainToStorage(IS_ANALYTICS_ALLOWED_KEY, optIn ? 'true' : 'false');
+    setOnBoardingState((prev) => ({
+      ...prev,
+      [STEP_KEY]: { hasOptedIn: optIn },
+    }));
+    setIsAnalyticsAllowed(optIn);
+  }, []);
+
   return (
     <div className="text-gray-200">
+      <SeparateOnboardingStep isVisible={isModalOpen} top={'5rem'}>
+        <GithubConnectStep
+          handleNext={() => {
+            setModalOpen(false);
+            saveOptIn(true);
+          }}
+          description="We detected an issue with your GitHub credentials, please re-authenticate with GitHub again to enable remote services. Remote services are required to use natural language search. Opting out will disable natural language search."
+          secondaryCTA={
+            <Button
+              onClick={() => {
+                setModalOpen(false);
+                saveOptIn(false);
+              }}
+              variant="secondary"
+            >
+              Opt-Out of Remote Services
+            </Button>
+          }
+        />
+      </SeparateOnboardingStep>
       <NavBar userSigned />
       <div
         className="flex my-16 w-screen overflow-hidden relative z-10"

--- a/client/src/components/SeparateOnboardingStep/index.tsx
+++ b/client/src/components/SeparateOnboardingStep/index.tsx
@@ -4,7 +4,8 @@ import { MODAL_SIDEBAR_APPEAR_ANIMATION } from '../../consts/animations';
 
 type Props = {
   isVisible: boolean;
-  onClose: () => void;
+  onClose?: () => void;
+  top?: string;
 };
 
 const backdropHidden = {
@@ -19,31 +20,34 @@ const backdropVisible = {
   '-webkit-backdrop-filter': 'blur(1px)',
 };
 
-const initialModalStyles = {
-  top: '1rem',
+const initialModalStyles = (top: string) => ({
+  top,
   right: '50%',
   transform: 'translate(50%, 1rem)',
   opacity: 0,
-};
+});
 
-const modalAnimation = {
-  top: '1rem',
+const modalAnimation = (top: string) => ({
+  top,
   right: '50%',
   transform: 'translate(50%, 0%)',
   opacity: 1,
-};
+});
 
 const SeparateOnboardingStep = ({
   onClose,
   children,
   isVisible,
+  top = '1rem',
 }: PropsWithChildren<Props>) => {
   return (
     <>
       <AnimatePresence>
         {isVisible && (
           <motion.div
-            className={`fixed top-0 bottom-0 left-0 right-0 bg-gray-900 bg-opacity-75 cursor-alias z-50`}
+            className={`fixed top-0 bottom-0 left-0 right-0 bg-gray-900 bg-opacity-75 ${
+              onClose ? 'cursor-alias' : ''
+            } z-50`}
             initial={backdropHidden}
             animate={backdropVisible}
             exit={backdropHidden}
@@ -56,9 +60,9 @@ const SeparateOnboardingStep = ({
         {isVisible && (
           <motion.div
             className={`overflow-auto fixed flex flex-col rounded-md drop-shadow-light-bigger bg-gray-900 border border-gray-700 bg-opacity-75 z-70 backdrop-blur-8`}
-            animate={modalAnimation}
-            initial={initialModalStyles}
-            exit={initialModalStyles}
+            animate={modalAnimation(top)}
+            initial={initialModalStyles(top)}
+            exit={initialModalStyles(top)}
             transition={MODAL_SIDEBAR_APPEAR_ANIMATION}
           >
             <div className="p-6 flex flex-col gap-8 w-99 relative max-h-[calc(100vh-13rem)] flex-1">

--- a/client/src/pages/Home/Onboarding/GithubConnectStep/index.tsx
+++ b/client/src/pages/Home/Onboarding/GithubConnectStep/index.tsx
@@ -1,4 +1,10 @@
-import React, { useCallback, useContext, useEffect, useState } from 'react';
+import React, {
+  ReactElement,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+} from 'react';
 import DialogText from '../DialogText';
 import Button from '../../../../components/Button';
 import {
@@ -16,12 +22,16 @@ type Props = {
   handleNext: (e?: any, skipOne?: boolean) => void;
   handleBack?: (e: any) => void;
   forceAnalyticsAllowed?: boolean;
+  description?: string;
+  secondaryCTA?: ReactElement;
 };
 
 const GithubConnectStep = ({
   handleNext,
   handleBack,
   forceAnalyticsAllowed,
+  description,
+  secondaryCTA,
 }: Props) => {
   const {
     code,
@@ -108,11 +118,12 @@ const GithubConnectStep = ({
   return (
     <>
       <DialogText
-        title="GitHub repositories"
+        title="GitHub Login"
         description={
-          isAnalyticsAllowed || forceAnalyticsAllowed
+          description ||
+          (isAnalyticsAllowed || forceAnalyticsAllowed
             ? 'You must be logged into a GitHub account to access remote services. You will also be able to index repos hosted in your GitHub account or GitHub organisations. Enter the code below, when prompted by GitHub.'
-            : `You must log in to sync your GitHub repositories with bloop. GitHub credentials are stored locally and are never sent to our servers. Enter the code below, when prompted by GitHub.`
+            : `You must log in to sync your GitHub repositories with bloop. GitHub credentials are stored locally and are never sent to our servers. Enter the code below, when prompted by GitHub.`)
         }
       />
       <span className="subhead-l text-gray-300 justify-center items-center flex gap-1 -mt-2 h-5">
@@ -141,18 +152,20 @@ const GithubConnectStep = ({
       </span>
       <div className="flex flex-col gap-4">
         {getButton()}
-        {!(isAnalyticsAllowed || forceAnalyticsAllowed) && (
+        {!(isAnalyticsAllowed || forceAnalyticsAllowed) || secondaryCTA ? (
           <>
             <div className="flex items-center">
               <span className="flex-1 h-px bg-gray-800" />
               <span className="text-gray-600 mx-3">or</span>
               <span className="flex-1 h-px bg-gray-800" />
             </div>
-            <Button variant="secondary" onClick={handleSkip}>
-              Setup later <ArrowRight />
-            </Button>
+            {secondaryCTA || (
+              <Button variant="secondary" onClick={handleSkip}>
+                Setup later <ArrowRight />
+              </Button>
+            )}
           </>
-        )}
+        ) : null}
       </div>
       {handleBack ? <GoBackButton handleBack={handleBack} /> : null}
       {tokenExpireIn ? (

--- a/server/bleep/src/remotes.rs
+++ b/server/bleep/src/remotes.rs
@@ -10,7 +10,7 @@ use dashmap::mapref::one::Ref;
 use git2::{Cred, CredentialType, RemoteCallbacks};
 use ignore::WalkBuilder;
 use serde::{Deserialize, Serialize};
-use tracing::{warn, error};
+use tracing::{error, warn};
 
 use crate::{
     remotes,

--- a/server/bleep/src/remotes.rs
+++ b/server/bleep/src/remotes.rs
@@ -10,7 +10,7 @@ use dashmap::mapref::one::Ref;
 use git2::{Cred, CredentialType, RemoteCallbacks};
 use ignore::WalkBuilder;
 use serde::{Deserialize, Serialize};
-use tracing::warn;
+use tracing::{warn, error};
 
 use crate::{
     remotes,
@@ -209,7 +209,20 @@ impl BackendCredential {
         let BackendCredential::Github(auth) = self;
 
         let client = auth.client()?;
-        client.current().user().await?;
+
+        match client.current().user().await {
+            Ok(_) => {}
+            Err(e @ octocrab::Error::GitHub { .. }) => {
+                warn!(?e, "failed to validate GitHub token");
+                return Err(e)?;
+            }
+            Err(e) => {
+                // Don't return an error here - we want to swallow failure and try again on the
+                // next poll.
+                error!(?e, "failed to make GitHub user request");
+            }
+        }
+
         Ok(())
     }
 


### PR DESCRIPTION
Transport errors (`URL`, `Http`, `Json`, `JWT`, etc) are now logged and allowed during the GitHub device token validation check. Previously, any transport error like a bad network connection would result in the token getting wiped from the device. Given that the token is checked every 60 seconds, this means that if a user had a long-running tauri-based session, moving their laptop to a different room could cause their token to be deleted.

Now, only GitHub errors actually delete the token - these mean that GitHub successfully received the request and specifically returned that the token itself is not valid, for other reasons not related to network quality.