### PR TITLE
Initial pass at LLM chunk summary

### DIFF
--- a/server/bleep/src/background.rs
+++ b/server/bleep/src/background.rs
@@ -163,7 +163,7 @@ impl IndexWriter {
             }
             _ => {
                 repo_pool.get_mut(reporef).unwrap().value_mut().sync_status = Indexing;
-                let indexed = repo.index(&key, &writers).await;
+                let indexed = repo.index(&key, &writers, self.0.clone()).await;
                 let state = match &indexed {
                     Ok(state) => Some(state.clone()),
                     _ => None,
@@ -207,8 +207,8 @@ impl IndexWriter {
             Some(creds) => creds.clone(),
             None => {
                 let Some(path) = repo.local_path() else {
-		    bail!("no keys for backend {:?}", backend)
-		};
+                    bail!("no keys for backend {:?}", backend)
+                };
 
                 if !app.allow_path(path) {
                     bail!("path not authorized {repo:?}")

--- a/server/bleep/src/indexes/repo.rs
+++ b/server/bleep/src/indexes/repo.rs
@@ -11,7 +11,7 @@ use tantivy::{
 use tracing::info;
 
 use super::Indexable;
-use crate::repo::{RepoMetadata, RepoRef, Repository};
+use crate::{Application, repo::{RepoMetadata, RepoRef, Repository}};
 
 pub struct Repo {
     schema: Schema,
@@ -66,12 +66,13 @@ impl Repo {
 
 #[async_trait]
 impl Indexable for Repo {
-    fn index_repository(
+    async fn index_repository(
         &self,
         repo_ref: &RepoRef,
         repo: &Repository,
         _metadata: &RepoMetadata,
         writer: &IndexWriter,
+        app: Application,
     ) -> Result<()> {
         // Make sure we delete any stale references to this repository when indexing.
         self.delete_by_repo(writer, repo);

--- a/server/bleep/src/webserver/answer.rs
+++ b/server/bleep/src/webserver/answer.rs
@@ -467,7 +467,7 @@ struct AnswerAPIClient<'s> {
 }
 
 #[derive(Error, Debug)]
-enum AnswerAPIError {
+pub enum AnswerAPIError {
     #[error("max retry attempts reached {0}")]
     MaxAttemptsReached(usize),
 


### PR DESCRIPTION
***DRAFT***: This is not yet ready to merge. This current iteration of the code presents a mixed set of results, although generally positive, depending on the repositories tested, and the use of our previous OpenAI provider vs Anthropic. Some of the prompting logic might benefit from an update, to avoid the model generating information beyond the requested summary. It is yet to be determined how this may be improved.

The results that successfully return an answer appear to show a decent improvement to queries that depend on implicit information, like project structure. The queries that fail to generate an answer still have to be investigated; this may be due to bad prompting.

---

The general strategy here is to use a LLM to summarize each indexed file, by providing it with the file path, and the first several lines (~50). This allows the model to use its knowledge of typical file structures in order to encode what a file means, in the context of a repository.

With some file types, like a Python `requirements.txt`, it may not be obvious to our local retrieval model what type of data is stored. This can result in sub-par retrieval results, and oftentimes miss important files altogether.

Below we have some test results across 2 branches with 2 providers, `main` and `ml-summary-retrieval`, both tested with OpenAI and Anthropic. The test repository used is [`lightly`](https://github.com/lightly-ai/lightly):

# `main` (no summary), Anthropic:

## What dependencies does the main package use?

`"answer_path":"lightly/core.py"`

The main package uses the following dependencies:
- numpy
- yaml
- os
- lightly.cli (for train_cli and embed_cli functions)

The train_model_and_embed_images and train_embedding_model functions use these dependencies to load config files, add keyword arguments, call the train_cli and embed_cli functions, and return the appropriate outputs.


## Where are the main package dependencies listed?

`"answer_path":"setup.py"`

The main package dependencies are listed in setup.py under install_requires.

## What are the main dependencies for?

`"answer_path":"README.md"`

The main dependencies for lightly are:
- hydra-core>=1.0.0
- numpy>=1.18.1
- pytorch_lightning>=1.5
- requests>=2.23.0
- torchvision
- tqdm

## What types of dependencies does the main package use?

`"answer_path":"setup.py"`

The main package uses install_requires to specify its dependencies.

# `main` (no summary), OpenAI

## What dependencies does the main package use?

`"answer_path":"setup.py"`

The main package uses the dependencies listed in the setup.py file, including setuptools, lightly, and the requirements listed in the base.txt, video.txt, and dev.txt files.

## Where are the main package dependencies listed?

`"answer_path":"requirements/base.txt"`

The main package dependencies are listed in the requirements/base.txt file.

## What are the main dependencies for?

`"answer_path":"setup.py"`

The main dependencies for the setup.py file are listed in the 'base.txt', 'video.txt', and 'dev.txt' files in the path_dir/requirements/ directory.

## What types of dependencies does the main package use?

None of the snippets help answer the question

# `ml-summary-retrieval` (with summary), OpenAI

## What dependencies does the main package use?

`"answer_path":"requirements/base.txt"`

The main package uses certifi>=14.05.14, hydra-core>=1.0.0, lightly_utils~=0.0.0, numpy>=1.18.1, python_dateutil>=2.5.3, requests>=2.23.0, setuptools>=21.0.0,<=65.5.1, six>=1.10, torchvision, tqdm>=4.44, urllib3>=1.15.1, and pytorch_lightning>=1.0.4 as dependencies.

## Where are the main package dependencies listed?

`"answer_path":"requirements/base.txt"`

The main package dependencies are listed in the requirements/base.txt file.

## What are the main dependencies for?

`"answer_path":"requirements/base.txt"`

The main dependencies for the requirements/base.txt file are certifi>=14.05.14, hydra-core>=1.0.0, lightly_utils~=0.0.0, numpy>=1.18.1, python_dateutil>=2.5.3, requests>=2.23.0, setuptools>=21.0.0,<=65.5.1, six>=1.10, torchvision, tqdm>=4.44, urllib3>=1.15.1, and pytorch_lightning>=1.0.4.

## What types of dependencies does the main package use?

`"answer_path":"lightly/openapi_generated/requirements.txt"`

The main package uses certifi >= 14.05.14, six >= 1.10, python_dateutil >= 2.5.3, setuptools >= 21.0.0, and urllib3 >= 1.15.1 as its dependencies.

# `ml-summary-retrieval` (with summary), Anthropic

What dependencies does the main package use?

`"answer_path":"requirements/base.txt"`

The main package uses certifi, hydra-core, lightly_utils, numpy, python_dateutil, requests, setuptools, six, torchvision, tqdm, urllib3, and pytorch_lightning as dependencies.

Where are the main package dependencies listed?

`"answer_path":"requirements/base.txt"`

The main package dependencies are listed in requirements/base.txt.

What are the main dependencies for?
None of the snippets help answer the question

What types of dependencies does the main package use?
None of the snippets help answer the question