### PR TITLE
Return semantic results when there is no selection

### DIFF
--- a/client/src/hooks/useSearch.tsx
+++ b/client/src/hooks/useSearch.tsx
@@ -77,7 +77,10 @@ export const useSearch = <T,>(
                   error: newData.Err,
                 }));
               } else {
-                setStatus({ loading: false, data: JSON.parse(ev.data), query });
+                const nlAnswer = newData.answer_path
+                  ? ''
+                  : 'One of the the results below could be relevant...';
+                setStatus({ loading: false, data: newData, query, nlAnswer });
               }
             } else {
               setStatus((prev) => ({


### PR DESCRIPTION
Previously we would return an error if the selection failed. Now we return the set of selections.

The `/answer` API has changed slightly - it is now possible for `answer_path` in the response to be `null`. If this is `null`, it signifies a selection failure, and there will be no explanation returned after the initial response object.

Queries that return a selection remain unchanged:

```
data:{"user_id":"test_user","query_id":"590412e5-30f9-4777-aa44-96f18981af0a","snippets":[{"lang":"toml","repo_name":"github.com/calyptobai-test-org/test-repo","repo_ref":"github.com/calyptobai-test-org/test-repo","relative_path":"Cargo.toml","text":"[package]\nname = \"test-repo\"\nversion = \"0.1.0\"\nedition = \"2021\"\n\n# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html\n\n[dependencies]\ntokio = \"1.24.2","start_line":0,"end_line":8,"start_byte":0,"end_byte":193,"score":0.41552293}],"answer_path":"Cargo.toml"}

data:{"Ok":" The repo name is \""}

data:{"Ok":"test-repo\".\n"}

data:{"Ok":"\n"}

data:[DONE]
```

While queries with no selection look like so:

```
data:{"user_id":"test_user","query_id":"ed0ad359-5b24-4869-9d5a-9ff540bdeefb","snippets":[{"lang":"toml","repo_name":"github.com/calyptobai-test-org/test-repo","repo_ref":"github.com/calyptobai-test-org/test-repo","relative_path":"Cargo.toml","text":"[package]\nname = \"test-repo\"\nversion = \"0.1.0\"\nedition = \"2021\"\n\n# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html\n\n[dependencies]\ntokio = \"1.24.2","start_line":0,"end_line":8,"start_byte":0,"end_byte":193,"score":0.05885545}],"answer_path":null}

data:[DONE]
```

Note that `"answer_path":null`, and the lack of messages between the initial JSON object and the finalizing `[DONE]` message.