### PR TITLE
Enable all cores for the Tauri app

### DIFF
--- a/apps/desktop/src-tauri/src/backend.rs
+++ b/apps/desktop/src-tauri/src/backend.rs
@@ -26,7 +26,7 @@ where
     );
     configuration.qdrant_url = Some("http://127.0.0.1:6334".into());
     configuration.ctags_path = relative_command_path("ctags");
-    configuration.max_threads = bleep::default_parallelism() / 4;
+    configuration.max_threads = bleep::default_parallelism();
     configuration.model_dir = app
         .path_resolver()
         .resolve_resource("model")


### PR DESCRIPTION
The Tauri app has been throttled, as indexing can take up significant resources. This patch tentatively removes the throttle to speed up indexing, and allows us to re-test with semantic search.