### PR TITLE
add `error` stage to pipeline

### DIFF
--- a/server/bleep/src/analytics.rs
+++ b/server/bleep/src/analytics.rs
@@ -99,7 +99,7 @@ impl RudderHub {
 }
 
 impl Stage {
-    pub fn new<T: serde::Serialize>(name: &'static str, data: &T) -> Self {
+    pub fn new<T: serde::Serialize>(name: &'static str, data: T) -> Self {
         let data = serde_json::to_value(data).unwrap();
         let _type = match data {
             Value::Null => "null",

--- a/server/bleep/src/webserver.rs
+++ b/server/bleep/src/webserver.rs
@@ -182,6 +182,13 @@ impl Error {
             })),
         }
     }
+
+    fn message(&self) -> &str {
+        match &self.body {
+            Json(Response::Error(EndpointError { message, .. })) => message.as_ref(),
+            _ => "",
+        }
+    }
 }
 
 impl From<anyhow::Error> for Error {

--- a/server/bleep/src/webserver/answer.rs
+++ b/server/bleep/src/webserver/answer.rs
@@ -148,10 +148,11 @@ pub(super) async fn handle(
 
         // add error stage to pipeline
         let mut ev = event.write().await;
-        ev.stages.push(Stage::new("error", e.message()));
+        ev.stages
+            .push(Stage::new("error", &(e.status.as_u16(), e.message())));
 
         // send to rudderstack
-        app.track_query(dbg!(&ev));
+        app.track_query(&ev);
     } else {
         // the analytics event is fired when the stream is consumed
     }

--- a/server/bleep/src/webserver/answer.rs
+++ b/server/bleep/src/webserver/answer.rs
@@ -141,13 +141,20 @@ pub(super) async fn handle(
     let response = _handle(&state, params, app.clone(), Arc::clone(&event)).await;
 
     if response.is_err() {
-        // send event to rudderstack
-        let event = event.read().await;
-        app.track_query(&event);
+        // Result<impl IntoResponse> does not implement `Debug`, `unwrap_err` is unavailable
+        let Err(e) = response.as_ref() else {
+            unreachable!();
+        };
+
+        // add error stage to pipeline
+        let mut ev = event.write().await;
+        ev.stages.push(Stage::new("error", e.message()));
+
+        // send to rudderstack
+        app.track_query(dbg!(&ev));
     } else {
         // the analytics event is fired when the stream is consumed
     }
-
     response
 }
 


### PR DESCRIPTION
this pr adds a new stage to the analytics pipeline on early exits:

for a response like so:
```
λ http :7878/api/answer q=="what is the response from the intelligence endpoint?"
HTTP/1.1 401 Unauthorized
access-control-allow-origin: *
access-control-expose-headers: *
content-length: 48
content-type: application/json
date: Fri, 03 Mar 2023 07:39:51 GMT
vary: origin
vary: access-control-request-method
vary: access-control-request-headers

{
    "kind": "user",
    "message": "missing Github token"
}
```

a stage, like so, is added to the pipeline:

```
Stage {
    name: "error",
    _type: "string",
    data: [Number(401), String("missing Github token")],
    time_elapsed: None,
},
```