### PR TITLE
make webserver::answer::grow infallible

### DIFF
--- a/server/bleep/src/webserver/answer.rs
+++ b/server/bleep/src/webserver/answer.rs
@@ -452,6 +452,13 @@ fn grow(doc: &ContentDocument, snippet: &Snippet, size: usize) -> Option<String>
 
     // do not grow if this snippet contains incorrect byte ranges
     if snippet.start_byte >= content.len() || snippet.end_byte >= content.len() {
+        error!(
+            repo = snippet.repo_name,
+            path = snippet.relative_path,
+            start = snippet.start_byte,
+            end = snippet.end_byte,
+            "invalid snippet bounds",
+        );
         return None;
     }
 


### PR DESCRIPTION
`grow` is can panic in 3 locations potentially:

- the index operation in `content[..snippet.start._byte]`
- the index operation in `content[snippet.end_byte..]`
- the index operation in `content[new_start..new_end]`

this PR avoids the first two by verifying bounds before indexing. the last index operation is expected to be infallible already.