### PR TITLE
Increase size of persistent volumes

### DIFF
--- a/helm/bloop/values.yaml
+++ b/helm/bloop/values.yaml
@@ -80,7 +80,7 @@ affinity: {}
 
 persistence:
   accessModes: ["ReadWriteOnce"]
-  size: 1Gi
+  size: 10Gi
   storageClassName: gp3
 
 qdrant:
@@ -161,7 +161,7 @@ qdrant:
 
   persistence:
     accessModes: ["ReadWriteOnce"]
-    size: 1Gi
+    size: 10Gi
     storageClassName: gp3
 
   #only supported for single node qdrant clusters.


### PR DESCRIPTION
This increases the size of persistent volumes from `1Gi` to `10Gi`, both for the `bloop-app` and `bloop-qdrant` services. 