### PR TITLE
Prompt user to update bloop, when bloop is already open

### DIFF
--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -17,7 +17,7 @@ tauri-build = { version = "1.2.1", features = [] }
 [dependencies]
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
-tauri = { version = "1.2.4", features = ["dialog-open", "fs-all", "http-all", "native-tls-vendored", "os-all", "path-all", "shell-all", "updater", "window-all"] }
+tauri = { version = "1.2.4", features = ["dialog-open", "fs-all", "http-all", "native-tls-vendored", "os-all", "path-all", "shell-all", "updater", "window-all", "process-all"] }
 bleep = { path = "../../../server/bleep", package = "bleep" }
 anyhow = "1.0.68"
 tokio = { version = "1.24.2", features = ["rt-multi-thread"] }

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -32,6 +32,9 @@
       },
       "path": {
         "all": true
+      },
+      "process": {
+        "all": true
       }
     },
     "bundle": {
@@ -81,7 +84,7 @@
       "endpoints": [
         "https://api.bloop.ai/releases/{{target}}/{{current_version}}"
       ],
-      "dialog": true,
+      "dialog": false,
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDNGQkQ2RjRBNEM3OURFQ0IKUldUTDNubE1TbSs5UDVIMms5dTU2cVk4cGt4Zzl3bkRXU2UvSzliZktUQTQ5TXFWcmpwb1RvYXMK"
     },
     "windows": [

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -2,13 +2,75 @@ import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { invoke } from '@tauri-apps/api';
 import { open } from '@tauri-apps/api/shell';
 import { homeDir } from '@tauri-apps/api/path';
-import { open as openDialog } from '@tauri-apps/api/dialog';
+import { ask, message, open as openDialog } from '@tauri-apps/api/dialog';
 import { listen } from '@tauri-apps/api/event';
 import * as tauriOs from '@tauri-apps/api/os';
 import { getVersion } from '@tauri-apps/api/app';
+import { checkUpdate, installUpdate } from '@tauri-apps/api/updater';
+import { relaunch } from '@tauri-apps/api/process';
 import ClientApp from '../../../client/src/App';
 import TextSearch from './TextSearch';
 import '../../../client/src/index.css';
+
+let askedToUpdate = false;
+let intervalId: number;
+
+listen(
+  'tauri://update-status',
+  async function (res: { payload: { status: string; error: Error | null } }) {
+    if (res.payload.status === 'DONE') {
+      const agreedToRestart = await ask(
+        `The installation was successful, do you want to restart the application now?`,
+        {
+          title: 'Ready to Restart',
+        },
+      );
+      if (agreedToRestart) {
+        relaunch();
+      }
+    } else if (res.payload.status === 'ERROR') {
+      await message(
+        'There was a problem updating bloop' +
+          (res.payload.error?.message || res.payload.error),
+        {
+          title: 'Update failed to install',
+          type: 'error',
+        },
+      );
+    }
+  },
+);
+
+const checkUpdateAndInstall = async (currentVersion: string) => {
+  try {
+    if (askedToUpdate) {
+      return;
+    }
+    const { shouldUpdate, manifest } = await checkUpdate();
+    if (shouldUpdate) {
+      const agreedToUpdate = await ask(
+        `bloop ${manifest?.version} is now available -- you have ${currentVersion}
+        
+Would you like to install it now?
+
+Release notes:
+${manifest?.body}`,
+        {
+          title: 'A new version of bloop is available!',
+        },
+      );
+      askedToUpdate = true;
+      if (intervalId) {
+        clearInterval(intervalId);
+      }
+      if (agreedToUpdate) {
+        installUpdate();
+      }
+    }
+  } catch (error) {
+    console.log(error);
+  }
+};
 
 function App() {
   const [homeDirectory, setHomeDir] = useState('');
@@ -41,6 +103,11 @@ function App() {
     ]).then(([arch, type, platform, version, appVersion]) => {
       setOs({ arch, type, platform, version });
       setRelease(appVersion);
+      checkUpdateAndInstall(appVersion);
+      intervalId = window.setInterval(
+        () => checkUpdateAndInstall(appVersion),
+        1000 * 60 * 60,
+      );
     });
     if (import.meta.env.SENTRY_DSN_BE) {
       invoke('initialize_sentry', {


### PR DESCRIPTION
Manually check for app updates every hour (until the user agrees or refuses to update the app). The flow is almost the same as standard Tauri updater flow, but we additionally check for updates every hour.