### PR TITLE
Rename OpenAI to LLM error

### DIFF
--- a/server/bleep/src/webserver/answer.rs
+++ b/server/bleep/src/webserver/answer.rs
@@ -51,8 +51,8 @@ pub mod api {
 
     #[derive(thiserror::Error, Debug, Deserialize)]
     pub enum Error {
-        #[error("bad OpenAI request")]
-        BadOpenAiRequest,
+        #[error("bad LLM request")]
+        BadLlmRequest,
     }
 
     pub type Result = std::result::Result<String, Error>;


### PR DESCRIPTION
Since we now support multiple LLM providers, this change renames the `BadOpenAiRequest` error to the generic `BadLlmRequest`