### PR TITLE
Revert "Rename OpenAI to LLM error"

### DIFF
--- a/server/bleep/src/webserver/answer.rs
+++ b/server/bleep/src/webserver/answer.rs
@@ -51,8 +51,8 @@ pub mod api {
 
     #[derive(thiserror::Error, Debug, Deserialize)]
     pub enum Error {
-        #[error("bad LLM request")]
-        BadLlmRequest,
+        #[error("bad OpenAI request")]
+        BadOpenAiRequest,
     }
 
     pub type Result = std::result::Result<String, Error>;


### PR DESCRIPTION
Reverts BloopAI/bloop#241