### PR TITLE
attach package metadata to analytics pipeline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -468,6 +468,7 @@ dependencies = [
  "anyhow",
  "bleep",
  "color-eyre",
+ "git-version",
  "nix",
  "once_cell",
  "qdrant-client",
@@ -2070,6 +2071,28 @@ dependencies = [
  "libc",
  "system-deps 6.0.3",
  "winapi",
+]
+
+[[package]]
+name = "git-version"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6b0decc02f4636b9ccad390dcbe77b722a77efedfa393caf8379a51d5c61899"
+dependencies = [
+ "git-version-macro",
+ "proc-macro-hack",
+]
+
+[[package]]
+name = "git-version-macro"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe69f1cbdb6e28af2bac214e943b99ce8a0a06b447d15d3e61161b0423139f3f"
+dependencies = [
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -27,6 +27,7 @@ color-eyre = "0.6.2"
 once_cell = "1.17.0"
 sentry = "0.29.2"
 qdrant-client = "0.11.6"
+git-version = "0.3.5"
 
 [target.'cfg(unix)'.dependencies]
 nix = { version = "0.26.2", default-features = false, features = [ "resource" ] }

--- a/apps/desktop/src-tauri/src/backend.rs
+++ b/apps/desktop/src-tauri/src/backend.rs
@@ -82,6 +82,10 @@ pub fn initialize_rudder_analytics(key: String, data_plane: String) {
             true => Some(event),
             false => None,
         })),
+        package_metadata: Some(analytics::PackageMetadata {
+            name: env!("CARGO_CRATE_NAME"),
+            version: env!("CARGO_PKG_VERSION"),
+        }),
     };
     tokio::task::block_in_place(|| {
         analytics::RudderHub::new_with_options(key, data_plane, options)

--- a/apps/desktop/src-tauri/src/backend.rs
+++ b/apps/desktop/src-tauri/src/backend.rs
@@ -85,6 +85,7 @@ pub fn initialize_rudder_analytics(key: String, data_plane: String) {
         package_metadata: Some(analytics::PackageMetadata {
             name: env!("CARGO_CRATE_NAME"),
             version: env!("CARGO_PKG_VERSION"),
+            git_rev: git_version::git_version!(fallback = "unknown"),
         }),
     };
     tokio::task::block_in_place(|| {

--- a/server/bleep/src/analytics.rs
+++ b/server/bleep/src/analytics.rs
@@ -36,6 +36,12 @@ pub struct Stage {
     pub time_elapsed: Option<u128>,
 }
 
+#[derive(Debug, serde::Serialize)]
+pub struct PackageMetadata {
+    pub name: &'static str,
+    pub version: &'static str,
+}
+
 static HUB: OnceCell<Arc<RudderHub>> = OnceCell::new();
 
 pub struct RudderHub {
@@ -46,6 +52,7 @@ pub struct RudderHub {
 #[derive(Default)]
 pub struct HubOptions {
     pub event_filter: Option<Arc<dyn Fn(QueryEvent) -> Option<QueryEvent> + Send + Sync + 'static>>,
+    pub package_metadata: Option<PackageMetadata>,
 }
 
 impl RudderHub {
@@ -85,16 +92,19 @@ impl RudderHub {
                                 "query_id": ev.query_id,
                                 "overlap_strategy": ev.overlap_strategy,
                                 "stages": ev.stages,
+                                "package_metadata": options.package_metadata,
                             })),
                             ..Default::default()
                         })) {
                             info!("failed to send analytics event: {:?}", e);
+                        } else {
+                            info!("sent analytics event ...");
+                            return;
                         }
                     }
                 }
             }
         }
-        info!("sent analytics event ...");
     }
 }
 

--- a/server/bleep/src/analytics.rs
+++ b/server/bleep/src/analytics.rs
@@ -100,7 +100,6 @@ impl RudderHub {
                             info!("failed to send analytics event: {:?}", e);
                         } else {
                             info!("sent analytics event ...");
-                            return;
                         }
                     }
                 }

--- a/server/bleep/src/analytics.rs
+++ b/server/bleep/src/analytics.rs
@@ -40,6 +40,7 @@ pub struct Stage {
 pub struct PackageMetadata {
     pub name: &'static str,
     pub version: &'static str,
+    pub git_rev: &'static str,
 }
 
 static HUB: OnceCell<Arc<RudderHub>> = OnceCell::new();


### PR DESCRIPTION
package metadata in the format: `{name: "bloop", version: "0.2.3"}` wil automatically be baked into the tauri app at compile-time. note that this metadata is only attached to analytics from the desktop app currently, events from independent server analytics will contain empty package metadata.