### PR TITLE
fix: chunker works with special tokens

### DIFF
--- a/server/bleep/src/semantic/chunk.rs
+++ b/server/bleep/src/semantic/chunk.rs
@@ -257,13 +257,13 @@ pub fn by_tokens<'s>(
     debug!("max tokens reduced to {max_tokens}");
 
     // checks whether the token at the given index contains a newline character.
-    let has_nl = |&i: &usize| {
+    let has_nl = |&i: &usize| -> bool {
         if special_tokens_mask[i] != 0 {
-            return false;
+            false
         } else if i + 1 >= special_tokens_mask.len() || special_tokens_mask[i + 1] != 0 {
-            return src[offsets[i].0..offsets[i].1].contains('\n');
+            src[offsets[i].0..offsets[i].1].contains('\n')
         } else {
-            return src[offsets[i].0..offsets[i + 1].0].contains('\n');
+            src[offsets[i].0..offsets[i + 1].0].contains('\n')
         }
     };
 

--- a/server/bleep/src/semantic/chunk.rs
+++ b/server/bleep/src/semantic/chunk.rs
@@ -268,7 +268,7 @@ pub fn by_tokens<'s>(
     };
 
     // checks whether the token immediately after the token at the given index is a partial-word.
-    let has_boundary = |&i| {
+    let has_boundary = |&i: &usize| -> bool {
         !tokenizer
             .id_to_token(ids[i + 1])
             .map_or(false, |s| s.starts_with("##"))

--- a/server/bleep/src/semantic/chunk.rs
+++ b/server/bleep/src/semantic/chunk.rs
@@ -213,6 +213,11 @@ pub fn by_tokens<'s>(
     max_lines: usize,
     strategy: OverlapStrategy,
 ) -> Vec<Chunk<'s>> {
+    if tokenizer.get_truncation().is_some() {
+        error!(
+            "tokenizer is truncating, turn off tokenization with `tokenizer.with_truncation(None)`"
+        )
+    }
     let min_tokens = token_bounds.start;
     // no need to even tokenize files too small to contain our min number of tokens
     if src.len() < min_tokens {

--- a/server/bleep/src/semantic/chunk.rs
+++ b/server/bleep/src/semantic/chunk.rs
@@ -226,6 +226,7 @@ pub fn by_tokens<'s>(
 
     let offsets = encoding.get_offsets();
     let special_tokens_mask = encoding.get_special_tokens_mask();
+    let ids = encoding.get_ids();
     // again, if we have less than our minimum number of tokens, we may skip the file
     if offsets.len() < min_tokens {
         return Vec::new();
@@ -269,7 +270,6 @@ pub fn by_tokens<'s>(
     };
 
     let offsets_len = offsets.len();
-    let ids = encoding.get_ids();
     let mut chunks = Vec::new();
     let mut start = 0;
     let (mut last_line, mut last_byte) = (0, 0);


### PR DESCRIPTION
The chunker uses the huggingface tokenizers library to make sure that chunks have the same number of tokens. However the code was panicking in the case where the tokenized encoding was producing multiple special tokens with offset `(0,0)`. This code makes the chunker more robust to this.

This is caused by padding and truncation being enabled on the tokeniser. If either of these are set then there can be more than one special tokens in the encoding, but the rust code assumes that there is exactly one special token to terminate the encoding.

todos:
- [ ] make unit tests pass
- [ ] add a check that tokenisers passed to the chunker do not have padding or truncation length set.
- [ ] There is a bug: DEDUCT_SPECIAL_TOKENS shouldn't be hardcoded to 2 because there can be multiple special tokens