### PR TITLE
Build dependencies on macOS 11

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -26,11 +26,11 @@ jobs:
             cross: false
 
           - target: x86_64-darwin
-            os: macos-latest
+            os: macos-11
             cross: false
 
           - target: aarch64-darwin
-            os: macos-latest
+            os: macos-11
             cross: true
 
         # Requires python for the build, which in a proper mess
@@ -75,7 +75,7 @@ jobs:
           cp -r $package_path/* ${{ env.PACKAGE_NAME }}_bundle
 
       - name: Copy macOS dynamic dependencies
-        if: matrix.os == 'macos-latest' && ( matrix.package == 'ctags' )
+        if: matrix.os == 'macos-11' && ( matrix.package == 'ctags' )
         env:
           PACKAGE_NAME: ${{ steps.var.outputs.package-name }}
         run: |
@@ -129,11 +129,11 @@ jobs:
             cross: false
 
           - target: x86_64-apple-darwin
-            os: macos-latest
+            os: macos-11
             cross: false
 
           - target: aarch64-apple-darwin
-            os: macos-latest
+            os: macos-11
             cross: true
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
This enables backwards-compatible builds that can run on macOS 11.