### PR TITLE
Percentage indicator for individual repositories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -388,6 +388,7 @@ dependencies = [
  "directories",
  "dunce",
  "either",
+ "erased-serde",
  "expect-test",
  "flume",
  "futures",
@@ -1551,6 +1552,15 @@ dependencies = [
  "log",
  "regex",
  "termcolor",
+]
+
+[[package]]
+name = "erased-serde"
+version = "0.3.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f2b0c2380453a92ea8b6c8e5f64ecaafccddde8ceab55ff7a8ac1029f894569"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/server/bleep/Cargo.toml
+++ b/server/bleep/Cargo.toml
@@ -113,6 +113,7 @@ jsonwebtoken = { version = "8.2.0", features = ["use_pem"] }
 sentry = "0.29.2"
 rudderanalytics = "1.1.2"
 async-stream = "0.3.3"
+erased-serde = "0.3.25"
 
 [target.'cfg(windows)'.dependencies]
 dunce = "1.0.3"

--- a/server/bleep/src/indexes.rs
+++ b/server/bleep/src/indexes.rs
@@ -26,6 +26,7 @@ use crate::{
     Configuration,
 };
 
+pub type Progress = (RepoRef, usize, u8);
 pub type GlobalWriteHandleRef<'a> = [IndexWriteHandle<'a>];
 
 pub struct GlobalWriteHandle<'a> {
@@ -63,7 +64,7 @@ pub struct Indexes {
     pub file: Indexer<File>,
     write_mutex: tokio::sync::Mutex<()>,
 
-    progress: tokio::sync::broadcast::Sender<(RepoRef, u8, u8)>,
+    progress: tokio::sync::broadcast::Sender<Progress>,
 }
 
 impl Indexes {
@@ -101,12 +102,15 @@ impl Indexes {
         debug!(id, "lock acquired");
 
         Ok(GlobalWriteHandle {
-            handles: vec![self.repo.write_handle()?, self.file.write_handle()?],
+            handles: vec![
+                self.repo.write_handle(0, self.progress.clone())?,
+                self.file.write_handle(1, self.progress.clone())?,
+            ],
             _write_lock,
         })
     }
 
-    pub fn subscribe(&self) -> tokio::sync::broadcast::Receiver<(RepoRef, u8, u8)> {
+    pub fn subscribe(&self) -> tokio::sync::broadcast::Receiver<Progress> {
         self.progress.subscribe()
     }
 }
@@ -119,6 +123,7 @@ pub trait Indexable: Send + Sync {
         repo: &Repository,
         metadata: &RepoMetadata,
         writer: &IndexWriter,
+        progress: &(dyn Fn(u8) + Sync),
     ) -> Result<()>;
 
     fn delete_by_repo(&self, writer: &IndexWriter, repo: &Repository);
@@ -154,6 +159,7 @@ pub struct IndexWriteHandle<'a> {
     index: &'a tantivy::Index,
     reader: &'a RwLock<IndexReader>,
     writer: IndexWriter,
+    progress: Box<dyn Fn(RepoRef, u8) + Send + Sync>,
 }
 
 impl<'a> IndexWriteHandle<'a> {
@@ -173,7 +179,9 @@ impl<'a> IndexWriteHandle<'a> {
         metadata: &RepoMetadata,
     ) -> Result<()> {
         self.source
-            .index_repository(reporef, repo, metadata, &self.writer)
+            .index_repository(reporef, repo, metadata, &self.writer, &|p: u8| {
+                (self.progress)(reporef.clone(), p)
+            })
     }
 
     pub async fn commit(&mut self) -> Result<()> {
@@ -201,7 +209,11 @@ pub struct Indexer<T> {
 }
 
 impl<T: Indexable> Indexer<T> {
-    fn write_handle(&self) -> Result<IndexWriteHandle<'_>> {
+    fn write_handle(
+        &self,
+        id: usize,
+        progress: tokio::sync::broadcast::Sender<Progress>,
+    ) -> Result<IndexWriteHandle<'_>> {
         Ok(IndexWriteHandle {
             source: &self.source,
             index: &self.index,
@@ -209,6 +221,9 @@ impl<T: Indexable> Indexer<T> {
             writer: self
                 .index
                 .writer_with_num_threads(self.reindex_threads, self.reindex_buffer_size)?,
+            progress: Box::new(move |reporef, status| {
+                _ = progress.send((reporef, id, status));
+            }),
         })
     }
 

--- a/server/bleep/src/indexes/repo.rs
+++ b/server/bleep/src/indexes/repo.rs
@@ -72,6 +72,7 @@ impl Indexable for Repo {
         repo: &Repository,
         _metadata: &RepoMetadata,
         writer: &IndexWriter,
+        progress: &(dyn Fn(u8) + Sync),
     ) -> Result<()> {
         // Make sure we delete any stale references to this repository when indexing.
         self.delete_by_repo(writer, repo);
@@ -84,6 +85,8 @@ impl Indexable for Repo {
             self.raw_name => repo_ref.indexed_name().as_bytes(),
             self.repo_ref => repo_ref.to_string(),
         ))?;
+
+        progress(100);
 
         info!(
             ?repo.disk_path,

--- a/server/bleep/src/repo.rs
+++ b/server/bleep/src/repo.rs
@@ -242,7 +242,7 @@ impl Repository {
     pub(crate) async fn index(
         &self,
         reporef: &RepoRef,
-        writers: &indexes::GlobalWriteHandleRef<'_>,
+        writers: &indexes::GlobalWriteHandle<'_>,
     ) -> Result<Arc<RepoMetadata>, RepoError> {
         use rayon::prelude::*;
         let metadata = get_repo_metadata(&self.disk_path).await;

--- a/server/bleep/src/webserver.rs
+++ b/server/bleep/src/webserver.rs
@@ -49,6 +49,7 @@ pub async fn start(app: Application) -> anyhow::Result<()> {
         .route("/index", get(index::handle))
         // repo management
         .route("/repos", get(repos::available))
+        .route("/repos/index-status", get(repos::index_status))
         .route(
             "/repos/indexed",
             get(repos::indexed).put(repos::set_indexed),

--- a/server/bleep/src/webserver.rs
+++ b/server/bleep/src/webserver.rs
@@ -124,7 +124,7 @@ pub async fn start(app: Application) -> anyhow::Result<()> {
     Ok(())
 }
 
-pub(in crate::webserver) fn json<'a, T>(val: T) -> Json<Response<'a>>
+fn json<'a, T>(val: T) -> Json<Response<'a>>
 where
     Response<'a>: From<T>,
 {
@@ -231,75 +231,27 @@ enum ErrorKind {
     Custom,
 }
 
+trait ApiResponse: erased_serde::Serialize {}
+erased_serde::serialize_trait_object!(ApiResponse);
+
 /// Every endpoint exposes a Response type
 #[derive(serde::Serialize)]
 #[serde(untagged)]
 #[non_exhaustive]
-pub(in crate::webserver) enum Response<'a> {
-    Github(github::GithubResponse),
-    Repositories(repos::ReposResponse),
-    Query(query::QueryResponse),
-    Autocomplete(autocomplete::AutocompleteResponse),
-    Hoverable(hoverable::HoverableResponse),
-    Intelligence(intelligence::TokenInfoResponse),
-    File(file::FileResponse),
-    Semantic(semantic::SemanticResponse),
-    Answer(answer::AnswerResponse),
-    /// A blanket error response
+enum Response<'a> {
+    Ok(Box<dyn erased_serde::Serialize + Send + Sync + 'static>),
     Error(EndpointError<'a>),
 }
 
-impl<'a> From<github::GithubResponse> for Response<'a> {
-    fn from(r: github::GithubResponse) -> Response<'a> {
-        Response::Github(r)
-    }
-}
-
-impl<'a> From<repos::ReposResponse> for Response<'a> {
-    fn from(r: repos::ReposResponse) -> Response<'a> {
-        Response::Repositories(r)
-    }
-}
-
-impl<'a> From<query::QueryResponse> for Response<'a> {
-    fn from(r: query::QueryResponse) -> Response<'a> {
-        Response::Query(r)
-    }
-}
-
-impl<'a> From<autocomplete::AutocompleteResponse> for Response<'a> {
-    fn from(r: autocomplete::AutocompleteResponse) -> Response<'a> {
-        Response::Autocomplete(r)
-    }
-}
-
-impl<'a> From<hoverable::HoverableResponse> for Response<'a> {
-    fn from(r: hoverable::HoverableResponse) -> Response<'a> {
-        Response::Hoverable(r)
-    }
-}
-
-impl<'a> From<intelligence::TokenInfoResponse> for Response<'a> {
-    fn from(r: intelligence::TokenInfoResponse) -> Response<'a> {
-        Response::Intelligence(r)
-    }
-}
-
-impl<'a> From<file::FileResponse> for Response<'a> {
-    fn from(r: file::FileResponse) -> Response<'a> {
-        Response::File(r)
-    }
-}
-
-impl<'a> From<semantic::SemanticResponse> for Response<'a> {
-    fn from(r: semantic::SemanticResponse) -> Response<'a> {
-        Response::Semantic(r)
+impl<T: ApiResponse + Send + Sync + 'static> From<T> for Response<'static> {
+    fn from(value: T) -> Self {
+        Self::Ok(Box::new(value))
     }
 }
 
 impl<'a> From<EndpointError<'a>> for Response<'a> {
-    fn from(r: EndpointError<'a>) -> Response<'a> {
-        Response::Error(r)
+    fn from(value: EndpointError<'a>) -> Self {
+        Self::Error(value)
     }
 }
 

--- a/server/bleep/src/webserver/answer.rs
+++ b/server/bleep/src/webserver/answer.rs
@@ -104,11 +104,7 @@ pub struct AnswerResponse {
     pub answer_path: Option<String>,
 }
 
-impl From<AnswerResponse> for super::Response<'static> {
-    fn from(res: AnswerResponse) -> super::Response<'static> {
-        super::Response::Answer(res)
-    }
-}
+impl super::ApiResponse for AnswerResponse {}
 
 const SNIPPET_COUNT: usize = 13;
 

--- a/server/bleep/src/webserver/autocomplete.rs
+++ b/server/bleep/src/webserver/autocomplete.rs
@@ -117,6 +117,8 @@ pub(super) struct AutocompleteResponse {
     data: Vec<QueryResult>,
 }
 
+impl super::ApiResponse for AutocompleteResponse {}
+
 const QUERY_FLAGS: &[&str; 8] = &[
     "repo", "path", "content", "symbol", "lang", "case", "or", "open",
 ];

--- a/server/bleep/src/webserver/file.rs
+++ b/server/bleep/src/webserver/file.rs
@@ -18,6 +18,8 @@ pub struct FileResponse {
     contents: String,
 }
 
+impl super::ApiResponse for FileResponse {}
+
 pub async fn handle(
     Path(path): Path<String>,
     Query(params): Query<Params>,

--- a/server/bleep/src/webserver/github.rs
+++ b/server/bleep/src/webserver/github.rs
@@ -13,14 +13,16 @@ use tracing::{error, warn};
 
 use std::time::{Duration, Instant};
 
-#[derive(Serialize, Deserialize, ToSchema)]
+#[derive(Serialize, ToSchema)]
 #[serde(rename_all = "snake_case")]
 pub(super) enum GithubResponse {
     AuthenticationNeeded { url: String, code: String },
     Status(GithubCredentialStatus),
 }
 
-#[derive(Serialize, Deserialize, ToSchema)]
+impl super::ApiResponse for GithubResponse {}
+
+#[derive(Serialize, ToSchema)]
 #[serde(rename_all = "snake_case")]
 pub(super) enum GithubCredentialStatus {
     Ok,

--- a/server/bleep/src/webserver/hoverable.rs
+++ b/server/bleep/src/webserver/hoverable.rs
@@ -23,6 +23,8 @@ pub(super) struct HoverableResponse {
     ranges: Vec<TextRange>,
 }
 
+impl super::ApiResponse for HoverableResponse {}
+
 #[utoipa::path(
     get,
     path = "/hoverable",

--- a/server/bleep/src/webserver/intelligence.rs
+++ b/server/bleep/src/webserver/intelligence.rs
@@ -47,6 +47,8 @@ pub(super) enum TokenInfoResponse {
     },
 }
 
+impl super::ApiResponse for TokenInfoResponse {}
+
 #[derive(Debug, Serialize, ToSchema)]
 pub(super) struct FileSymbols {
     // FIXME: choose a better name

--- a/server/bleep/src/webserver/query.rs
+++ b/server/bleep/src/webserver/query.rs
@@ -170,6 +170,8 @@ pub struct QueryResponse {
     stats: ResultStats,
 }
 
+impl super::ApiResponse for QueryResponse {}
+
 /// Metadata pertaining to the query response, such as paging info
 #[derive(Default, Serialize, ToSchema)]
 pub(super) struct PagingMetadata {

--- a/server/bleep/src/webserver/repos.rs
+++ b/server/bleep/src/webserver/repos.rs
@@ -80,6 +80,8 @@ pub(super) enum ReposResponse {
     Deleted,
 }
 
+impl super::ApiResponse for ReposResponse {}
+
 /// Retrieve all indexed repositories
 //
 #[utoipa::path(get, path = "/repos/indexed",

--- a/server/bleep/src/webserver/semantic.rs
+++ b/server/bleep/src/webserver/semantic.rs
@@ -16,6 +16,8 @@ pub(super) struct SemanticResponse {
     chunks: Vec<serde_json::Value>,
 }
 
+impl super::ApiResponse for SemanticResponse {}
+
 /// Get details of an indexed repository based on their id
 //
 #[utoipa::path(get, path = "/repos/indexed/:ref",


### PR DESCRIPTION
It's going to be on the front-end to calculate the proper numbers, as the raw data will look like this:

```
   ["repo/reference", 0, 42]
     |                |   |=> percentage 0-100
     | reporef        |=> indexing step (0/1)
```

So a calculation as to what the progress of `repo/reference` is would be (42+69)/2 for the 2 indexing stages.

In reality, however, indexing stage 0 (repo index) will take a trivial amount of time, and we may want to discard that data completely.

You can retrieve the SSE stream through `/repos/index-status`. Note that the server will never close this stream, so if this is closed, something's definitely wrong. Realistically we could plug more events in here later, too.