### PR TITLE
Up Tauri resource usage

### DIFF
--- a/apps/desktop/src-tauri/src/backend.rs
+++ b/apps/desktop/src-tauri/src/backend.rs
@@ -26,7 +26,7 @@ where
     );
     configuration.qdrant_url = Some("http://127.0.0.1:6334".into());
     configuration.ctags_path = relative_command_path("ctags");
-    configuration.max_threads = bleep::default_parallelism() / 4;
+    configuration.max_threads = bleep::default_parallelism() / 2;
     configuration.model_dir = app
         .path_resolver()
         .resolve_resource("model")


### PR DESCRIPTION
Use `max_threads / 2` in the Tauri app (up from `/ 4`). This will speed up indexing.