### PR TITLE
fix: emit an error if chunker is called with a tokenizer with padding

### DIFF
--- a/server/bleep/src/semantic/chunk.rs
+++ b/server/bleep/src/semantic/chunk.rs
@@ -213,6 +213,11 @@ pub fn by_tokens<'s>(
     max_lines: usize,
     strategy: OverlapStrategy,
 ) -> Vec<Chunk<'s>> {
+    if tokenizer.get_padding().is_some() || tokenizer.get_truncation().is_some() {
+        error!(
+            "This code can panic if padding and truncation are not turned off. Please make sure padding is off."
+        );
+    }
     let min_tokens = token_bounds.start;
     // no need to even tokenize files too small to contain our min number of tokens
     if src.len() < min_tokens {


### PR DESCRIPTION
The chunker can panic if called with a tokenizer with padding or truncation enabled. This adds an error message so it is easier to catch this issue in the future.

Previous issue: https://github.com/BloopAI/bloop/pull/253