### PR TITLE
Prevent form submission during Japanese input composition

### DIFF
--- a/client/src/components/SearchInput/SearchTextInput.tsx
+++ b/client/src/components/SearchInput/SearchTextInput.tsx
@@ -90,11 +90,15 @@ const SearchTextInput = forwardRef(function TextInputWithRef(
   const { isSelfServe } = useContext(DeviceContext);
   const { isGithubConnected } = useContext(UIContext);
   const { isAnalyticsAllowed } = useContext(AnalyticsContext);
+  const [composing, setComposition] = useState(false);
+  const startComposition = () => setComposition(true);
+  const endComposition = () => setComposition(false);
 
   const handleEnter = (
     e: KeyboardEvent<HTMLInputElement | HTMLTextAreaElement>,
   ) => {
     if (e.key === 'Enter' && onSubmit) {
+      if(composing) return;
       e.preventDefault();
       onSubmit(e);
     }
@@ -214,6 +218,8 @@ const SearchTextInput = forwardRef(function TextInputWithRef(
             type === 'email' ? 'px-1' : 'pl-2.5'
           } transition-all duration-300 ease-in-bounce outline-none outline-0 pr-9`}
           onKeyDown={handleEnter}
+          onCompositionStart={startComposition}
+          onCompositionEnd={endComposition}
         />
         {value ? (
           <ClearButton

--- a/client/src/components/SearchInput/SearchTextInput.tsx
+++ b/client/src/components/SearchInput/SearchTextInput.tsx
@@ -98,7 +98,7 @@ const SearchTextInput = forwardRef(function TextInputWithRef(
     e: KeyboardEvent<HTMLInputElement | HTMLTextAreaElement>,
   ) => {
     if (e.key === 'Enter' && onSubmit) {
-      if(composing) return;
+      if (composing) return;
       e.preventDefault();
       onSubmit(e);
     }


### PR DESCRIPTION
Made improvements to the handling of Japanese input by using the onCompositionStart and onCompositionEnd events to prevent form submission during the composition phase. Specifically, I added a composing state and modified the handleEnter function to check this state before allowing form submission. This ensures that the form is not submitted until the user has finished composing their input.

reference: [Element: compositionstart event \- Web APIs \| MDN](https://developer.mozilla.org/en-US/docs/Web/API/Element/compositionstart_event)