### PR TITLE
Increase initial delay seconds

### DIFF
--- a/helm/bloop/values.yaml
+++ b/helm/bloop/values.yaml
@@ -128,16 +128,16 @@ qdrant:
 
   livenessProbe:
     enabled: true
-    initialDelaySeconds: 5
-    periodSeconds: 10
+    initialDelaySeconds: 50
+    periodSeconds: 30
     timeoutSeconds: 1
     failureThreshold: 3
     successThreshold: 1
 
   readinessProbe:
     enabled: true
-    initialDelaySeconds: 5
-    periodSeconds: 10
+    initialDelaySeconds: 60
+    periodSeconds: 30
     timeoutSeconds: 1
     failureThreshold: 3
     successThreshold: 1

--- a/helm/bloop/values.yaml
+++ b/helm/bloop/values.yaml
@@ -129,7 +129,7 @@ qdrant:
   livenessProbe:
     enabled: true
     initialDelaySeconds: 50
-    periodSeconds: 30
+    periodSeconds: 10
     timeoutSeconds: 1
     failureThreshold: 3
     successThreshold: 1
@@ -137,7 +137,7 @@ qdrant:
   readinessProbe:
     enabled: true
     initialDelaySeconds: 60
-    periodSeconds: 30
+    periodSeconds: 10
     timeoutSeconds: 1
     failureThreshold: 3
     successThreshold: 1

--- a/helm/bloop/values.yaml
+++ b/helm/bloop/values.yaml
@@ -128,7 +128,7 @@ qdrant:
 
   livenessProbe:
     enabled: true
-    initialDelaySeconds: 50
+    initialDelaySeconds: 60
     periodSeconds: 10
     timeoutSeconds: 1
     failureThreshold: 3


### PR DESCRIPTION
When there are many documents in Qdrant, it starts longer but get killed after failing liveness/readiness probes