### PR TITLE
fix typo in scopes.scm

### DIFF
--- a/server/bleep/src/intelligence/language/rust/scopes.scm
+++ b/server/bleep/src/intelligence/language/rust/scopes.scm
@@ -326,7 +326,7 @@
 ;; if let _ = a {}
 ;;
 ;; the ident following the `=` is a ref
-;; the ident preceeding the `=` is a def
+;; the ident preceding the `=` is a def
 ;; while let _ = a {}
 (let_condition 
   "="


### PR DESCRIPTION
preceeding -> preceding