### PR TITLE
implement snippet deduplication using MMR

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -418,7 +418,7 @@ dependencies = [
  "bincode",
  "blake3",
  "chrono",
- "clap 4.2.0",
+ "clap 4.2.1",
  "color-eyre",
  "compact_str",
  "console-subscriber",
@@ -827,9 +827,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.2.0"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6efb5f0a41b5ef5b50c5da28c07609c20091df0c1fc33d418fa2a7e693c2b624"
+checksum = "046ae530c528f252094e4a77886ee1374437744b2bff1497aa898bbddbbb29b3"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -838,9 +838,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.2.0"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "671fcaa5debda4b9a84aa7fde49c907c8986c0e6ab927e04217c9cb74e7c8bc9"
+checksum = "223163f58c9a40c3b0a43e1c4b50a9ce09f007ea2cb1ec258a687945b4b7929f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -4718,9 +4718,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.37.4"
+version = "0.37.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c348b5dc624ecee40108aa2922fed8bad89d7fcc2b9f8cb18f632898ac4a37f9"
+checksum = "0e78cc525325c06b4a7ff02db283472f3c042b7ff0c391f96c6d5ac6f4f91b75"
 dependencies = [
  "bitflags",
  "errno",

--- a/server/bleep/src/semantic.rs
+++ b/server/bleep/src/semantic.rs
@@ -10,12 +10,13 @@ use ort::{
 use qdrant_client::{
     prelude::{QdrantClient, QdrantClientConfig},
     qdrant::{
-        r#match::MatchValue, vectors_config, with_payload_selector::SelectorOptions,
+        r#match::MatchValue, vectors_config, with_payload_selector, with_vectors_selector,
         CollectionOperationResponse, CreateCollection, Distance, FieldCondition, Filter, Match,
         PointId, PointStruct, ScoredPoint, SearchPoints, VectorParams, VectorsConfig,
-        WithPayloadSelector,
+        WithPayloadSelector, WithVectorsSelector,
     },
 };
+
 use rayon::prelude::*;
 use thiserror::Error;
 use tracing::{debug, info, trace, warn};
@@ -197,11 +198,14 @@ impl Semantic {
                 limit,
                 vector: self.embed(query)?,
                 with_payload: Some(WithPayloadSelector {
-                    selector_options: Some(SelectorOptions::Enable(true)),
+                    selector_options: Some(with_payload_selector::SelectorOptions::Enable(true)),
                 }),
                 filter: Some(Filter {
                     must: filters,
                     ..Default::default()
+                }),
+                with_vectors: Some(WithVectorsSelector {
+                    selector_options: Some(with_vectors_selector::SelectorOptions::Enable(true)),
                 }),
                 ..Default::default()
             })
@@ -326,4 +330,67 @@ fn make_kv_filter(key: &str, value: &str) -> FieldCondition {
         }),
         ..Default::default()
     }
+}
+
+fn dot(a: &[f32], b: &[f32]) -> f32 {
+    a.iter().zip(b.iter()).map(|(ai, bi)| ai * bi).sum()
+}
+
+fn norm(a: &[f32]) -> f32 {
+    dot(a, a)
+}
+
+fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
+    dot(a, b) / (norm(a) * norm(b))
+}
+
+// returns a list of indices to preserve from `snippets`
+//
+// query_embedding: the embedding of the query terms
+// embeddings: the list of embeddings to select from
+// lambda: MMR is a weighted selection of two opposing factors:
+//    - relevance to the query
+//    - "novelty" or, the measure of how minimal the similarity is
+//      to existing documents in the selection
+//      The value of lambda skews the weightage in favor of either relevance or novelty.
+//  k: the number of embeddings to select
+pub fn deduplicate_with_mmr(
+    query_embedding: &[f32],
+    embeddings: &[&[f32]],
+    lambda: f32,
+    k: usize,
+) -> Vec<usize> {
+    let mut idxs = vec![];
+
+    if embeddings.len() < k {
+        return (0..embeddings.len()).collect();
+    }
+
+    while idxs.len() < k {
+        let mut best_score = f32::NEG_INFINITY;
+        let mut idx_to_add = None;
+
+        for (i, emb) in embeddings.iter().enumerate() {
+            if idxs.contains(&i) {
+                continue;
+            }
+            let first_part = cosine_similarity(query_embedding, emb);
+            let mut second_part = 0.;
+            for j in idxs.iter() {
+                let cos_sim = cosine_similarity(emb, &embeddings[*j]);
+                if cos_sim > second_part {
+                    second_part = cos_sim;
+                }
+            }
+            let equation_score = lambda * first_part - (1. - lambda) * second_part;
+            if equation_score > best_score {
+                best_score = equation_score;
+                idx_to_add = Some(i);
+            }
+        }
+        if let Some(i) = idx_to_add {
+            idxs.push(i);
+        }
+    }
+    idxs
 }

--- a/server/bleep/src/semantic.rs
+++ b/server/bleep/src/semantic.rs
@@ -377,7 +377,7 @@ pub fn deduplicate_with_mmr(
             let first_part = cosine_similarity(query_embedding, emb);
             let mut second_part = 0.;
             for j in idxs.iter() {
-                let cos_sim = cosine_similarity(emb, &embeddings[*j]);
+                let cos_sim = cosine_similarity(emb, embeddings[*j]);
                 if cos_sim > second_part {
                     second_part = cos_sim;
                 }


### PR DESCRIPTION
- deduplication is on par with `main`
- `main` refuses to collect more than 4 snippets from the same file, MMR does not have an artificial limit.