### PR TITLE
fix spelling error in onboarding repos steps descriptions

### DIFF
--- a/client/src/pages/Home/Onboarding/GithubReposStep/index.tsx
+++ b/client/src/pages/Home/Onboarding/GithubReposStep/index.tsx
@@ -125,7 +125,7 @@ const GithubReposStep = ({ handleNext, handleBack, disableSkip }: Props) => {
     <>
       <DialogText
         title="Sync GitHub repositories"
-        description="Select the GitHub repositories you want to add to bloop. You can always sync, unsync or removed unwanted repositories later."
+        description="Select the GitHub repositories you want to add to bloop. You can always sync, unsync or remove unwanted repositories later."
       />
       <div className="flex flex-col overflow-auto">
         <SearchableRepoList

--- a/client/src/pages/Home/Onboarding/LocalReposStep/index.tsx
+++ b/client/src/pages/Home/Onboarding/LocalReposStep/index.tsx
@@ -126,7 +126,7 @@ const LocalReposStep = ({ handleNext, handleBack }: Props) => {
     <>
       <DialogText
         title="Sync local repositories"
-        description="Select the folders you want to add to bloop. You can always sync, unsync or removed unwanted repositories later."
+        description="Select the folders you want to add to bloop. You can always sync, unsync or remove unwanted repositories later."
       />
       <div className="flex flex-col overflow-auto h-full">
         <SearchableRepoList


### PR DESCRIPTION
Title is self-explanatory I guess.

`FolderSelectStep` component has the same description, but not the error, so it remains unchanged, FYI. https://github.com/BloopAI/bloop/blob/9cae59fecc89440677bc7b37f03189fda63672a4/client/src/pages/Home/Onboarding/FolderSelectStep/index.tsx#L68 