### PR TITLE
Amend rephrase prompt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,15 +65,6 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "0.6.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81ce3d38065e618af2d7b77e10c5ad9a069859b4be3c2250f674af3840d9c8a5"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "aho-corasick"
 version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
@@ -418,11 +409,10 @@ dependencies = [
  "phf_codegen 0.11.1",
  "pretty_assertions",
  "qdrant-client",
- "rake",
  "rand 0.8.5",
  "rayon",
- "regex 1.7.1",
- "regex-syntax 0.6.28",
+ "regex",
+ "regex-syntax",
  "relative-path",
  "reqwest",
  "reqwest-eventsource",
@@ -975,7 +965,7 @@ dependencies = [
  "prost-types",
  "serde",
  "serde_json",
- "thread_local 1.1.7",
+ "thread_local",
  "tokio",
  "tokio-stream",
  "tonic",
@@ -1105,7 +1095,7 @@ dependencies = [
  "oorandom",
  "plotters",
  "rayon",
- "regex 1.7.1",
+ "regex",
  "serde",
  "serde_derive",
  "serde_json",
@@ -1554,7 +1544,7 @@ dependencies = [
  "atty",
  "humantime",
  "log",
- "regex 1.7.1",
+ "regex",
  "termcolor",
 ]
 
@@ -2181,11 +2171,11 @@ version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "029d74589adefde59de1a0c4f4732695c32805624aec7b68d91503d4dba79afc"
 dependencies = [
- "aho-corasick 0.7.20",
+ "aho-corasick",
  "bstr",
  "fnv",
  "log",
- "regex 1.7.1",
+ "regex",
 ]
 
 [[package]]
@@ -2546,7 +2536,7 @@ dependencies = [
  "phf 0.11.1",
  "phf_codegen 0.11.1",
  "polyglot_tokenizer",
- "regex 1.7.1",
+ "regex",
  "serde",
  "serde_yaml 0.8.26",
  "termcolor",
@@ -2624,9 +2614,9 @@ dependencies = [
  "lazy_static",
  "log",
  "memchr",
- "regex 1.7.1",
+ "regex",
  "same-file",
- "thread_local 1.1.7",
+ "thread_local",
  "walkdir",
  "winapi-util",
 ]
@@ -2670,7 +2660,7 @@ dependencies = [
  "console",
  "lazy_static",
  "number_prefix 0.3.0",
- "regex 1.7.1",
+ "regex",
 ]
 
 [[package]]
@@ -2682,7 +2672,7 @@ dependencies = [
  "console",
  "lazy_static",
  "number_prefix 0.4.0",
- "regex 1.7.1",
+ "regex",
 ]
 
 [[package]]
@@ -4221,7 +4211,7 @@ dependencies = [
  "prettyplease",
  "prost",
  "prost-types",
- "regex 1.7.1",
+ "regex",
  "syn",
  "tempfile",
  "which",
@@ -4296,15 +4286,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
 dependencies = [
  "proc-macro2",
-]
-
-[[package]]
-name = "rake"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5555e13968a316e4d4eb1274246ac197a550f9f8e066ddc7076088494943f805"
-dependencies = [
- "regex 0.2.11",
 ]
 
 [[package]]
@@ -4492,26 +4473,13 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9329abc99e39129fcceabd24cf5d85b4671ef7c29c50e972bc5afe32438ec384"
-dependencies = [
- "aho-corasick 0.6.10",
- "memchr",
- "regex-syntax 0.5.6",
- "thread_local 0.3.6",
- "utf8-ranges",
-]
-
-[[package]]
-name = "regex"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48aaa5748ba571fb95cd2c85c09f629215d3a6ece942baa100950af03a34f733"
 dependencies = [
- "aho-corasick 0.7.20",
+ "aho-corasick",
  "memchr",
- "regex-syntax 0.6.28",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -4520,16 +4488,7 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 dependencies = [
- "regex-syntax 0.6.28",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d707a4fa2637f2dca2ef9fd02225ec7661fe01a53623c1e6515b6916511f7a7"
-dependencies = [
- "ucd-util",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -4899,7 +4858,7 @@ checksum = "3ed6c0254d4cce319800609aa0d41b486ee57326494802045ff27434fc9a2030"
 dependencies = [
  "backtrace",
  "once_cell",
- "regex 1.7.1",
+ "regex",
  "sentry-core",
 ]
 
@@ -5416,7 +5375,7 @@ version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bb26a6b22c84d8be41d99a14016d6f04d30d8d31a2ea411a8ab553af5cc490d"
 dependencies = [
- "aho-corasick 0.7.20",
+ "aho-corasick",
  "arc-swap",
  "async-trait",
  "base64 0.13.1",
@@ -5444,7 +5403,7 @@ dependencies = [
  "oneshot",
  "ownedbytes",
  "rayon",
- "regex 1.7.1",
+ "regex",
  "rust-stemmers",
  "rustc-hash",
  "serde",
@@ -5485,7 +5444,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc3c506b1a8443a3a65352df6382a1fb6a7afe1a02e871cee0d25e2c3d5f3944"
 dependencies = [
  "byteorder",
- "regex-syntax 0.6.28",
+ "regex-syntax",
  "utf8-ranges",
 ]
 
@@ -5497,7 +5456,7 @@ checksum = "343e3ada4c1c480953f6960f8a21ce9c76611480ffdd4f4e230fdddce0fc5331"
 dependencies = [
  "combine",
  "once_cell",
- "regex 1.7.1",
+ "regex",
 ]
 
 [[package]]
@@ -5587,7 +5546,7 @@ dependencies = [
  "percent-encoding",
  "rand 0.8.5",
  "raw-window-handle",
- "regex 1.7.1",
+ "regex",
  "rfd",
  "semver",
  "serde",
@@ -5643,7 +5602,7 @@ dependencies = [
  "png",
  "proc-macro2",
  "quote",
- "regex 1.7.1",
+ "regex",
  "semver",
  "serde",
  "serde_json",
@@ -5823,15 +5782,6 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
-dependencies = [
- "lazy_static",
-]
-
-[[package]]
-name = "thread_local"
 version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
@@ -5909,7 +5859,7 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4ff2dd291eac98dcea13e8cf7a0b28c373a90dc9210ccdab0fa9e69ee0cac69"
 dependencies = [
- "aho-corasick 0.7.20",
+ "aho-corasick",
  "cached-path",
  "clap 2.34.0",
  "derive_builder",
@@ -5926,8 +5876,8 @@ dependencies = [
  "rand 0.8.5",
  "rayon",
  "rayon-cond",
- "regex 1.7.1",
- "regex-syntax 0.6.28",
+ "regex",
+ "regex-syntax",
  "reqwest",
  "serde",
  "serde_json",
@@ -6231,10 +6181,10 @@ dependencies = [
  "matchers",
  "nu-ansi-term",
  "once_cell",
- "regex 1.7.1",
+ "regex",
  "sharded-slab",
  "smallvec",
- "thread_local 1.1.7",
+ "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
@@ -6247,7 +6197,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4423c784fe11398ca91e505cdc71356b07b1a924fc8735cfab5333afe3e18bc"
 dependencies = [
  "cc",
- "regex 1.7.1",
+ "regex",
 ]
 
 [[package]]
@@ -6363,12 +6313,6 @@ name = "ucd-trie"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e79c4d996edb816c91e4308506774452e55e95c3c9de07b6729e17e15a5ef81"
-
-[[package]]
-name = "ucd-util"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abd2fc5d32b590614af8b0a20d837f32eca055edd0bbead59a9cfe80858be003"
 
 [[package]]
 name = "uname"
@@ -6825,7 +6769,7 @@ version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aac48ef20ddf657755fdcda8dfed2a7b4fc7e4581acce6fe9b88c3d64f29dee7"
 dependencies = [
- "regex 1.7.1",
+ "regex",
  "serde",
  "serde_json",
  "thiserror",

--- a/server/bleep/Cargo.toml
+++ b/server/bleep/Cargo.toml
@@ -108,7 +108,6 @@ ort = { git = "https://github.com/bloopai/ort", branch = "merge-upstream" }
 ndarray = "0.15"
 uuid = { version = "1.2.2", features = ["v4", "fast-rng"] }
 jsonwebtoken = { version = "8.2.0", features = ["use_pem"] }
-rake = "0.1"
 
 # telemetry
 sentry = "0.29.2"

--- a/server/bleep/src/webserver/answer.rs
+++ b/server/bleep/src/webserver/answer.rs
@@ -911,7 +911,7 @@ Assistant:<index>",
         let system = format!(
             r#"{}
 =========
-Above, you have an extract from the {} file in the {} repo. This message will be followed by the last few utterances of a conversation with a user. Use the code file to write a concise, precise answer to the question.
+Above, you have an extract from the `{}` file in the `{}` repo. This message will be followed by the last few utterances of a conversation with a user. Use the code file to write a concise, precise answer to the question.
 
 - Format your response in GitHub Markdown. Paths, function names and code extracts should be enclosed in backticks
 - Use markdown bullet points to format lists

--- a/server/bleep/src/webserver/answer.rs
+++ b/server/bleep/src/webserver/answer.rs
@@ -922,7 +922,7 @@ Above, you have an extract from the {} file in the {} repo. This message will be
 - The conversation history can provide context to the user's current question, but sometimes it contains irrelevant information. IGNORE information in the conversation which is irrelevant to the user's current question
 
 Let's think step by step. First carefully refer to the code above, then answer the question with reference to it."#,
-            snippet.repo_name, snippet.relative_path, snippet.text,
+            snippet.text, snippet.relative_path, snippet.repo_name,
         );
 
         let mut messages = vec![api::Message {


### PR DESCRIPTION
Modify rephrase prompt and remove Rake keyword extraction. Now the rephrase prompt generates a keyword search query directly. This should help address the following issues:
- Rephrase step tries to answer the user question
- Regurgitates answers in the conversational history
- Rephrases are too verbose and complicate search

More work is needed here to improve multi-repo performance. 