### PR TITLE
Cloud/tauri analytics

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -7,8 +7,14 @@ import { listen } from '@tauri-apps/api/event';
 import * as tauriOs from '@tauri-apps/api/os';
 import { getVersion } from '@tauri-apps/api/app';
 import ClientApp from '../../../client/src/App';
-import TextSearch from './TextSearch';
 import '../../../client/src/index.css';
+import {
+  DEVICE_ID,
+  getPlainFromStorage,
+  savePlainToStorage,
+} from '../../../client/src/services/storage';
+import { generateUniqueId } from '../../../client/src/utils';
+import TextSearch from './TextSearch';
 
 // let askedToUpdate = false;
 // let intervalId: number;
@@ -89,6 +95,13 @@ function App() {
       .then((res) => {
         if (res) {
           setDeviceId(res.toString().trim());
+        } else {
+          let generatedId = getPlainFromStorage(DEVICE_ID);
+          if (!generatedId) {
+            generatedId = generateUniqueId();
+            savePlainToStorage(DEVICE_ID, generatedId);
+          }
+          setDeviceId(generatedId);
         }
       })
       .catch(console.log);

--- a/client/src/Tab.tsx
+++ b/client/src/Tab.tsx
@@ -38,6 +38,7 @@ function Tab({ deviceContextValue, isActive, tab }: Props) {
         <AnalyticsContextProvider
           deviceId={deviceContextValue.deviceId}
           forceAnalytics={deviceContextValue.forceAnalytics}
+          isSelfServe={deviceContextValue.isSelfServe}
         >
           <DeviceContextProvider deviceContextValue={deviceContextValue}>
             <UIContextProvider>

--- a/client/src/context/providers/AnalyticsContextProvider.tsx
+++ b/client/src/context/providers/AnalyticsContextProvider.tsx
@@ -10,12 +10,14 @@ interface AnalyticsProviderProps {
   children: React.ReactNode;
   deviceId?: string;
   forceAnalytics?: boolean;
+  isSelfServe?: boolean;
 }
 
 export const AnalyticsContextProvider: React.FC<AnalyticsProviderProps> = ({
   children,
   deviceId,
   forceAnalytics,
+  isSelfServe,
 }) => {
   const WRITE_KEY = import.meta.env.PROD
     ? import.meta.env.ANALYTICS_FE_WRITE_KEY_PROD
@@ -45,7 +47,9 @@ export const AnalyticsContextProvider: React.FC<AnalyticsProviderProps> = ({
 
   useEffect(() => {
     if (analyticsLoaded && deviceId) {
-      analytics.identify(deviceId);
+      analytics.identify(deviceId, {
+        isSelfServe: isSelfServe,
+      });
     }
   }, [analyticsLoaded, deviceId]);
 

--- a/client/src/services/storage.ts
+++ b/client/src/services/storage.ts
@@ -22,3 +22,4 @@ export const SEARCH_HISTORY_KEY = 'search_history';
 export const ONBOARDING_DONE_KEY = 'onboarding_done';
 export const IS_ANALYTICS_ALLOWED_KEY = 'is_analytics_allowed';
 export const SESSION_ID_KEY = 'session_id';
+export const DEVICE_ID = 'device_id';


### PR DESCRIPTION
track if a user is using self-serve or tauri in analytics, fallback for device id