### PR TITLE
avoid panics from remotes/github/login endpoint

### DIFF
--- a/server/bleep/src/webserver/github.rs
+++ b/server/bleep/src/webserver/github.rs
@@ -71,12 +71,12 @@ pub(super) async fn login(Extension(app): Extension<Application>) -> impl IntoRe
         .unwrap()
         .add_header(ACCEPT, "application/json".to_string())
         .build()
-        .unwrap();
+        .map_err(|_| Error::internal("failed to build octocrab client"))?;
 
     let codes = github
         .authenticate_as_device(&client_id, ["public_repo", "repo", "read:org"])
         .await
-        .unwrap();
+        .map_err(|_| Error::internal("failed to authenticate as device"))?;
 
     tokio::spawn(poll_for_oauth_token(
         github,


### PR DESCRIPTION
from discussion with @anastasiya1155:
- FE pings this endpoint when displaying certain items of the UI
- this endpoint panics on network errors 

closing the lid probably triggers this alert often.