### PR TITLE
[BLO-529] Recreate bloop pod before starting new one

### DIFF
--- a/helm/bloop/templates/bloop-deployment.yaml
+++ b/helm/bloop/templates/bloop-deployment.yaml
@@ -8,6 +8,8 @@ metadata:
     {{- include "bloop.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       {{- include "bloop.selectorLabels" . | nindent 6 }}


### PR DESCRIPTION
Fix the issue with failing persistent storage attachment on the update