### PR TITLE
[BLO-449] Make ingress tls secret optional

### DIFF
--- a/helm/bloop/templates/bloop-ingress.yaml
+++ b/helm/bloop/templates/bloop-ingress.yaml
@@ -33,7 +33,9 @@ spec:
         {{- range .hosts }}
         - {{ . | quote }}
         {{- end }}
+      {{ if .secretName }}
       secretName: {{ .secretName }}
+      {{ end }}
     {{- end }}
   {{- end }}
   rules:


### PR DESCRIPTION
If no secret specified - use default wildcard certificate