### PR TITLE
Use GitHub username or id to identify

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,3 @@
 API_URL='required for self-serve only'
-DEVICE_ID='used as user_id in analytics (for self-serve)'
 ONBOARDING='if you want to force onboarding flow'
 

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -43,7 +43,6 @@ async fn main() {
         .setup(backend::bleep)
         .invoke_handler(tauri::generate_handler![
             show_folder_in_finder,
-            get_device_id,
             enable_telemetry,
             disable_telemetry,
         ])
@@ -87,83 +86,4 @@ fn show_folder_in_finder(path: String) {
             .spawn()
             .unwrap();
     }
-}
-
-#[tauri::command]
-#[cfg(target_os = "macos")]
-fn get_device_id() -> String {
-    let ioreg = std::process::Command::new("ioreg")
-        .arg("-d2")
-        .arg("-c")
-        .arg("IOPlatformExpertDevice")
-        .stdout(std::process::Stdio::piped())
-        .spawn()
-        .unwrap();
-    let command = std::process::Command::new("awk")
-        .arg("-F\"")
-        .arg("/IOPlatformUUID/{print $(NF-1)}")
-        .stdin(std::process::Stdio::from(ioreg.stdout.unwrap()))
-        .stdout(std::process::Stdio::piped())
-        .spawn()
-        .unwrap();
-
-    let output = command.wait_with_output().unwrap();
-    let result = std::str::from_utf8(&output.stdout).unwrap();
-    result.into()
-}
-
-#[tauri::command]
-#[cfg(target_os = "linux")]
-fn get_device_id() -> String {
-    use tracing::warn;
-
-    const STANDARD_MACHINE_ID: &str = "/etc/machine-id";
-    const LEGACY_MACHINE_ID: &str = "/var/lib/dbus/machine-id";
-
-    std::fs::read_to_string(STANDARD_MACHINE_ID)
-        .or_else(|_| {
-            warn!(
-                "could not find machine-id at `{}`, looking in `{}`",
-                STANDARD_MACHINE_ID, LEGACY_MACHINE_ID
-            );
-            std::fs::read_to_string(LEGACY_MACHINE_ID)
-        })
-        .unwrap_or_else(|_| {
-            warn!("failed to determine machine-id");
-            "unknown-machine-id".to_owned()
-        })
-}
-
-#[tauri::command]
-#[cfg(target_os = "windows")]
-fn get_device_id() -> String {
-    let command = std::process::Command::new("wmic")
-        .arg("csproduct")
-        .arg("get")
-        .arg("UUID")
-        .stdout(std::process::Stdio::piped())
-        .spawn()
-        .unwrap();
-
-    let output = command.wait_with_output().unwrap();
-
-    // the output contains 3 lines:
-    //
-    //     UUID
-    //     EE134675-518A-8D49-B5E7-2475F745D1E6
-    //     <newline>
-    //
-    // our goal is to preserve only the actual UUID.
-    let result = std::str::from_utf8(&output.stdout)
-        .unwrap()
-        .trim_start_matches("UUID") // remove the initial `UUID` header
-        .trim(); // remove the leading and trailing newlines
-    result.into()
-}
-
-// ensure that the leading header and trailer are stripped
-#[cfg(windows)]
-#[test]
-fn device_id_on_single_line() {
-    assert_eq!(get_device_id().lines().count(), 1)
 }

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -78,7 +78,6 @@ import TextSearch from './TextSearch';
 
 function App() {
   const [homeDirectory, setHomeDir] = useState('');
-  const [deviceId, setDeviceId] = useState('');
   const [indexFolder, setIndexFolder] = useState('');
   const [os, setOs] = useState({
     arch: '',
@@ -91,20 +90,6 @@ function App() {
 
   useEffect(() => {
     homeDir().then(setHomeDir);
-    invoke('get_device_id')
-      .then((res) => {
-        if (res) {
-          setDeviceId(res.toString().trim());
-        } else {
-          let generatedId = getPlainFromStorage(DEVICE_ID);
-          if (!generatedId) {
-            generatedId = generateUniqueId();
-            savePlainToStorage(DEVICE_ID, generatedId);
-          }
-          setDeviceId(generatedId);
-        }
-      })
-      .catch(console.log);
     Promise.all([
       tauriOs.arch(),
       tauriOs.type(),
@@ -134,7 +119,6 @@ function App() {
       chooseFolder: openDialog,
       indexFolder,
       setIndexFolder,
-      deviceId,
       listen,
       os,
       invokeTauriCommand: invoke,
@@ -146,7 +130,7 @@ function App() {
       envConfig: {},
       showNativeMessage: message,
     }),
-    [homeDirectory, indexFolder, deviceId, os, release],
+    [homeDirectory, indexFolder, os, release],
   );
   return (
     <>

--- a/client/src/Tab.tsx
+++ b/client/src/Tab.tsx
@@ -36,7 +36,6 @@ function Tab({ deviceContextValue, isActive, tab }: Props) {
     <div className={`${isActive ? '' : 'hidden'} `}>
       <BrowserRouter>
         <AnalyticsContextProvider
-          deviceId={deviceContextValue.deviceId}
           forceAnalytics={deviceContextValue.forceAnalytics}
           isSelfServe={deviceContextValue.isSelfServe}
           envConfig={deviceContextValue.envConfig}

--- a/client/src/components/CodeBlock/SemanticSearch/Answer/index.tsx
+++ b/client/src/components/CodeBlock/SemanticSearch/Answer/index.tsx
@@ -31,7 +31,7 @@ type Props = {
 };
 
 const Answer = ({ handleRetry, searchId, answer, error }: Props) => {
-  const { deviceId } = useContext(DeviceContext);
+  const { envConfig } = useContext(DeviceContext);
   const { query } = useAppNavigation();
   const [isUpvote, setIsUpvote] = useState(false);
   const [isDownvote, setIsDownvote] = useState(false);
@@ -72,14 +72,14 @@ const Answer = ({ handleRetry, searchId, answer, error }: Props) => {
       setIsDownvote(!isUpvote);
       trackUpvote(isUpvote, query, answer || '', searchId);
       return saveUpvote({
-        unique_id: deviceId,
+        unique_id: envConfig.tracking_id || '',
         is_upvote: isUpvote,
         query: query,
         snippet_id: searchId,
         text: answer || '',
       });
     },
-    [deviceId, query, answer, RiveUpvote, RiveDownvote],
+    [envConfig.tracking_id, query, answer, RiveUpvote, RiveDownvote],
   );
 
   return (

--- a/client/src/components/ReportBugModal/index.tsx
+++ b/client/src/components/ReportBugModal/index.tsx
@@ -34,7 +34,7 @@ const ReportBugModal = ({
   const [serverCrashedMessage, setServerCrashedMessage] = useState('');
   const { onBoardingState, isBugReportModalOpen, setBugReportModalOpen } =
     useContext(UIContext);
-  const { deviceId, listen, os } = useContext(DeviceContext);
+  const { envConfig, listen, os } = useContext(DeviceContext);
 
   useEffect(() => {
     listen('server-crashed', (event) => {
@@ -76,13 +76,13 @@ const ReportBugModal = ({
     if (serverCrashedMessage) {
       saveCrashReport({
         text: form.text,
-        unique_id: deviceId,
+        unique_id: envConfig.tracking_id || '',
         info: serverCrashedMessage,
         metadata: JSON.stringify(os),
       });
     } else {
       const { emailError, ...values } = form;
-      saveBugReport({ ...values, unique_id: deviceId });
+      saveBugReport({ ...values, unique_id: envConfig.tracking_id || '' });
     }
     setSubmitted(true);
     setServerCrashedMessage('');

--- a/client/src/components/Settings/General/Profile/index.tsx
+++ b/client/src/components/Settings/General/Profile/index.tsx
@@ -16,7 +16,7 @@ import { DeviceContext } from '../../../../context/deviceContext';
 
 const ProfileSettings = () => {
   const { onBoardingState, setOnBoardingState } = useContext(UIContext);
-  const { deviceId } = useContext(DeviceContext);
+  const { envConfig } = useContext(DeviceContext);
   const [form, setForm] = useState({
     firstName: '',
     lastName: '',
@@ -57,10 +57,10 @@ const ProfileSettings = () => {
         email: form.email,
         first_name: form.firstName,
         last_name: form.lastName,
-        unique_id: deviceId,
+        unique_id: envConfig.tracking_id || '',
       });
     },
-    [form],
+    [form, envConfig.tracking_id],
   );
 
   return (

--- a/client/src/context/deviceContext.ts
+++ b/client/src/context/deviceContext.ts
@@ -9,7 +9,6 @@ export type DeviceContextType = {
     multiple?: boolean;
   }) => Promise<null | string | string[]>;
   homeDir: string;
-  deviceId: string;
   listen: (
     e: string,
     cb: (event: { payload: { message: string } }) => void,
@@ -30,6 +29,10 @@ export type DeviceContextType = {
     analytics_data_plane?: string;
     analytics_key_fe?: string;
     sentry_dsn_fe?: string;
+    user_login?: string | null;
+    org_name?: string | null;
+    tracking_id?: string;
+    device_id?: string;
   };
   showNativeMessage: (m: string, options?: any) => Promise<void> | void;
 };
@@ -39,7 +42,6 @@ export const DeviceContext = createContext<DeviceContextType>({
   openLink: (p) => {},
   chooseFolder: (conf) => Promise.resolve(null),
   homeDir: '$HOME',
-  deviceId: '',
   listen: () => {},
   os: {
     arch: '',

--- a/client/src/context/providers/AnalyticsContextProvider.tsx
+++ b/client/src/context/providers/AnalyticsContextProvider.tsx
@@ -8,18 +8,20 @@ import {
 
 interface AnalyticsProviderProps {
   children: React.ReactNode;
-  deviceId?: string;
   forceAnalytics?: boolean;
   isSelfServe?: boolean;
   envConfig: {
     analytics_data_plane?: string;
     analytics_key_fe?: string;
+    user_login?: string | null;
+    org_name?: string | null;
+    tracking_id?: string;
+    device_id?: string;
   };
 }
 
 export const AnalyticsContextProvider: React.FC<AnalyticsProviderProps> = ({
   children,
-  deviceId,
   forceAnalytics,
   isSelfServe,
   envConfig,
@@ -55,12 +57,20 @@ export const AnalyticsContextProvider: React.FC<AnalyticsProviderProps> = ({
   };
 
   useEffect(() => {
-    if (analyticsLoaded && deviceId) {
-      analytics.identify(deviceId, {
-        isSelfServe: isSelfServe,
-      });
+    if (analyticsLoaded && envConfig.tracking_id) {
+      analytics.identify(
+        envConfig.tracking_id,
+        {
+          isSelfServe: isSelfServe,
+          githubUsername: envConfig.user_login || '',
+          orgName: envConfig.org_name || '',
+          deviceId: envConfig.device_id?.trim(),
+        },
+        {},
+        () => {},
+      );
     }
-  }, [analyticsLoaded, deviceId]);
+  }, [analyticsLoaded, envConfig.tracking_id]);
 
   useEffect(() => {
     if (isAnalyticsAllowed) {

--- a/client/src/hooks/useSearch.tsx
+++ b/client/src/hooks/useSearch.tsx
@@ -31,7 +31,7 @@ export const useSearch = <T,>(
   const [status, setStatus] = useState<Status<T>>({
     loading: false,
   });
-  const { envConfig, apiUrl } = useContext(DeviceContext);
+  const { apiUrl } = useContext(DeviceContext);
 
   const { setLastQueryTime, searchType } = useContext(SearchContext);
   const { trackSearch } = useAnalytics();
@@ -52,9 +52,7 @@ export const useSearch = <T,>(
       case SearchType.NL:
         prevEventSource?.close();
         const eventSource = new EventSource(
-          `${apiUrl.replace('https:', '')}/answer?q=${query}&user_id=${
-            envConfig.tracking_id
-          }`,
+          `${apiUrl.replace('https:', '')}/answer?q=${query}`,
         );
         prevEventSource = eventSource;
         let i = 0;

--- a/client/src/hooks/useSearch.tsx
+++ b/client/src/hooks/useSearch.tsx
@@ -31,7 +31,7 @@ export const useSearch = <T,>(
   const [status, setStatus] = useState<Status<T>>({
     loading: false,
   });
-  const { deviceId, apiUrl } = useContext(DeviceContext);
+  const { envConfig, apiUrl } = useContext(DeviceContext);
 
   const { setLastQueryTime, searchType } = useContext(SearchContext);
   const { trackSearch } = useAnalytics();
@@ -52,10 +52,9 @@ export const useSearch = <T,>(
       case SearchType.NL:
         prevEventSource?.close();
         const eventSource = new EventSource(
-          `${apiUrl.replace(
-            'https:',
-            '',
-          )}/answer?q=${query}&user_id=${deviceId}`,
+          `${apiUrl.replace('https:', '')}/answer?q=${query}&user_id=${
+            envConfig.tracking_id
+          }`,
         );
         prevEventSource = eventSource;
         let i = 0;

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -11,7 +11,6 @@ ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
         openLink: (p) => window.open(p),
         chooseFolder: (conf) => Promise.resolve(null),
         homeDir: '$HOME',
-        deviceId: import.meta.env.DEVICE_ID || '',
         listen: () => {},
         os: {
           arch: '',

--- a/client/src/pages/NLResults/Message.tsx
+++ b/client/src/pages/NLResults/Message.tsx
@@ -39,7 +39,7 @@ const Message = ({
   currentlyViewedSnippets,
   onViewSnippetsClick,
 }: Props) => {
-  const { deviceId } = useContext(DeviceContext);
+  const { envConfig } = useContext(DeviceContext);
   const { query } = useAppNavigation();
   const [isUpvote, setIsUpvote] = useState(false);
   const [isDownvote, setIsDownvote] = useState(false);
@@ -83,15 +83,16 @@ const Message = ({
       setIsDownvote(!isUpvote);
       trackUpvote(isUpvote, query, answer || '', searchId);
       return saveUpvote({
-        unique_id: deviceId,
+        unique_id: envConfig.tracking_id || '',
         is_upvote: isUpvote,
         query: query,
         snippet_id: searchId,
         text: answer || '',
       });
     },
-    [deviceId, query, RiveUpvote, RiveDownvote],
+    [envConfig.tracking_id, query, RiveUpvote, RiveDownvote],
   );
+
   return (
     <div
       className={`max-w-[80%] w-fit relative group ${

--- a/client/src/pages/NLResults/index.tsx
+++ b/client/src/pages/NLResults/index.tsx
@@ -38,7 +38,7 @@ let prevEventSource: EventSource | undefined;
 
 const ResultsPage = ({ query, threadId }: Props) => {
   const ref = useRef<HTMLDivElement>(null);
-  const { envConfig, apiUrl } = useContext(DeviceContext);
+  const { apiUrl } = useContext(DeviceContext);
   const [isLoading, setIsLoading] = useState(true);
   const [conversation, setConversation] = useState<ConversationMessage[]>(
     conversationsCache[threadId] || [
@@ -114,9 +114,10 @@ const ResultsPage = ({ query, threadId }: Props) => {
     prevEventSource?.close();
     const startTime = Date.now();
     const eventSource = new EventSource(
-      `${apiUrl.replace('https:', '')}/answer?q=${question}&user_id=${
-        envConfig.tracking_id
-      }&thread_id=${threadId}`,
+      `${apiUrl.replace(
+        'https:',
+        '',
+      )}/answer?q=${question}&thread_id=${threadId}`,
     );
     prevEventSource = eventSource;
     setConversation((prev) => {

--- a/client/src/pages/NLResults/index.tsx
+++ b/client/src/pages/NLResults/index.tsx
@@ -38,7 +38,7 @@ let prevEventSource: EventSource | undefined;
 
 const ResultsPage = ({ query, threadId }: Props) => {
   const ref = useRef<HTMLDivElement>(null);
-  const { deviceId, apiUrl } = useContext(DeviceContext);
+  const { envConfig, apiUrl } = useContext(DeviceContext);
   const [isLoading, setIsLoading] = useState(true);
   const [conversation, setConversation] = useState<ConversationMessage[]>(
     conversationsCache[threadId] || [
@@ -114,10 +114,9 @@ const ResultsPage = ({ query, threadId }: Props) => {
     prevEventSource?.close();
     const startTime = Date.now();
     const eventSource = new EventSource(
-      `${apiUrl.replace(
-        'https:',
-        '',
-      )}/answer?q=${question}&user_id=${deviceId}&thread_id=${threadId}`,
+      `${apiUrl.replace('https:', '')}/answer?q=${question}&user_id=${
+        envConfig.tracking_id
+      }&thread_id=${threadId}`,
     );
     prevEventSource = eventSource;
     setConversation((prev) => {

--- a/client/src/pages/Onboarding/DataFormStep/index.tsx
+++ b/client/src/pages/Onboarding/DataFormStep/index.tsx
@@ -28,7 +28,7 @@ const DataFormStep = ({ handleNext }: Props) => {
     emailError: null,
   });
   const { onBoardingState, setOnBoardingState } = useContext(UIContext);
-  const { deviceId } = useContext(DeviceContext);
+  const { envConfig } = useContext(DeviceContext);
 
   useEffect(() => {
     const savedForm = onBoardingState[STEP_KEY];
@@ -49,12 +49,12 @@ const DataFormStep = ({ handleNext }: Props) => {
           email: form.email,
           first_name: form.firstName,
           last_name: form.lastName,
-          unique_id: deviceId,
+          unique_id: envConfig.tracking_id || '',
         });
         handleNext();
       }
     },
-    [form, deviceId],
+    [form, envConfig.tracking_id],
   );
 
   const handleSkip = useCallback(

--- a/server/bleep/benches/indexes.rs
+++ b/server/bleep/benches/indexes.rs
@@ -31,7 +31,7 @@ async fn index(index_dir: &Path) {
 
     index_only.index_only = true;
 
-    let app = Application::initialize(Environment::server(), index_only)
+    let app = Application::initialize(Environment::server(), index_only, None)
         .await
         .unwrap();
     app.run().await.unwrap();
@@ -50,6 +50,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             "index_dir": index_dir.path()
             }))
             .unwrap(),
+            None,
         )
         .await
         .unwrap();

--- a/server/bleep/benches/queries.rs
+++ b/server/bleep/benches/queries.rs
@@ -50,7 +50,7 @@ async fn index(index_dir: &Path) -> Result<()> {
 
     config.index_only = true;
 
-    bleep::Application::initialize(bleep::Environment::server(), config)
+    bleep::Application::initialize(bleep::Environment::server(), config, None)
         .await
         .unwrap()
         .run()
@@ -68,7 +68,7 @@ async fn start_server(index_dir: &Path) -> tokio::task::JoinHandle<anyhow::Resul
     .unwrap();
 
     let handle = tokio::spawn(
-        bleep::Application::initialize(bleep::Environment::server(), config)
+        bleep::Application::initialize(bleep::Environment::server(), config, None)
             .await
             .unwrap()
             .run(),

--- a/server/bleep/src/analytics.rs
+++ b/server/bleep/src/analytics.rs
@@ -60,7 +60,6 @@ pub struct HubOptions {
 impl RudderHub {
     pub fn new(key: String, data_plane: String) -> Arc<Self> {
         let client = RudderAnalytics::load(key, data_plane);
-        info!("Rudder analytics has loaded");
         let hub = Self {
             client,
             options: None,

--- a/server/bleep/src/analytics.rs
+++ b/server/bleep/src/analytics.rs
@@ -60,6 +60,7 @@ pub struct HubOptions {
 impl RudderHub {
     pub fn new(key: String, data_plane: String) -> Arc<Self> {
         let client = RudderAnalytics::load(key, data_plane);
+        info!("Rudder analytics has loaded");
         let hub = Self {
             client,
             options: None,

--- a/server/bleep/src/bin/bleep.rs
+++ b/server/bleep/src/bin/bleep.rs
@@ -7,6 +7,7 @@ async fn main() -> Result<()> {
     let app = Application::initialize(
         Environment::server(),
         Configuration::cli_overriding_config_file()?,
+        None,
     )
     .await?;
 

--- a/server/bleep/src/lib.rs
+++ b/server/bleep/src/lib.rs
@@ -227,7 +227,7 @@ impl Application {
     }
 
     pub fn track_query(&self, event: &analytics::QueryEvent) {
-        tracing::debug!(?event, "tracking event sent");
+        info!(?event, "tracking event sent");
         tokio::task::block_in_place(|| analytics::RudderHub::track_query(event.clone()))
     }
 

--- a/server/bleep/src/lib.rs
+++ b/server/bleep/src/lib.rs
@@ -227,6 +227,7 @@ impl Application {
     }
 
     pub fn track_query(&self, event: &analytics::QueryEvent) {
+        tracing::debug!(?event, "tracking event sent");
         tokio::task::block_in_place(|| analytics::RudderHub::track_query(event.clone()))
     }
 

--- a/server/bleep/src/lib.rs
+++ b/server/bleep/src/lib.rs
@@ -211,11 +211,10 @@ impl Application {
             package_metadata: None,
         };
 
-        info!("initializing analytics ...");
+        info!("configuring analytics ...");
         tokio::task::block_in_place(|| {
             analytics::RudderHub::new_with_options(key.clone(), data_plane.clone(), options)
         });
-        info!("RudderHub::new has run through");
     }
 
     pub fn install_logging() {
@@ -235,7 +234,6 @@ impl Application {
     }
 
     pub fn track_query(&self, event: &analytics::QueryEvent) {
-        info!(?event, "tracking event sent");
         tokio::task::block_in_place(|| analytics::RudderHub::track_query(event.clone()))
     }
 

--- a/server/bleep/src/lib.rs
+++ b/server/bleep/src/lib.rs
@@ -206,8 +206,16 @@ impl Application {
             return;
         };
 
+        let options = analytics::HubOptions {
+            event_filter: Some(Arc::new(Some)),
+            package_metadata: None,
+        };
+
         info!("initializing analytics ...");
-        analytics::RudderHub::new(key.to_owned(), data_plane.to_owned());
+        tokio::task::block_in_place(|| {
+            analytics::RudderHub::new_with_options(key.clone(), data_plane.clone(), options)
+        });
+        info!("RudderHub::new has run through");
     }
 
     pub fn install_logging() {

--- a/server/bleep/src/remotes.rs
+++ b/server/bleep/src/remotes.rs
@@ -219,6 +219,9 @@ impl From<BackendCredential> for BackendEntry {
 
 #[derive(Clone)]
 pub struct Backends {
+    /// If the environment is a Tauri app, or auth is instance-wide,
+    /// This will refresh the correct user.
+    authenticated_user: Arc<tokio::sync::RwLock<Option<String>>>,
     backends: Arc<scc::HashMap<Backend, BackendEntry>>,
 }
 
@@ -229,7 +232,10 @@ impl From<HashMap<Backend, BackendCredential>> for Backends {
             _ = backends.insert(k, v.into());
         }
 
-        Self { backends }
+        Self {
+            backends,
+            authenticated_user: Arc::default(),
+        }
     }
 }
 
@@ -273,6 +279,14 @@ impl Backends {
             .await;
 
         output
+    }
+
+    pub(crate) async fn set_user(&self, user: String) {
+        self.authenticated_user.write().await.replace(user);
+    }
+
+    pub(crate) async fn user(&self) -> Option<String> {
+        self.authenticated_user.read().await.clone()
     }
 }
 

--- a/server/bleep/src/remotes/poll.rs
+++ b/server/bleep/src/remotes/poll.rs
@@ -103,7 +103,12 @@ pub(crate) async fn check_credentials(app: Application) {
 
         if app.env.allow(Feature::GithubDeviceFlow) {
             let expired = if let Some(github) = app.credentials.github() {
-                github.validate().await.is_err()
+                let username = github.validate().await;
+                if let Ok(Some(ref user)) = username {
+                    app.credentials.set_user(user.into()).await;
+                }
+
+                username.is_err()
             } else {
                 true
             };

--- a/server/bleep/src/state.rs
+++ b/server/bleep/src/state.rs
@@ -48,6 +48,8 @@ pub struct StateSource {
     cookie_key: Option<PathBuf>,
 }
 
+/// Unified wrapper to persist state in the central state-store.
+/// Every model is stored in its own file as a pretty-printed json.
 pub struct PersistedState<T> {
     path: PathBuf,
     state: Arc<T>,

--- a/server/bleep/src/state.rs
+++ b/server/bleep/src/state.rs
@@ -9,6 +9,7 @@ use relative_path::RelativePath;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::{
     collections::HashSet,
+    ops::Deref,
     path::{Path, PathBuf},
     sync::Arc,
 };
@@ -47,6 +48,95 @@ pub struct StateSource {
     cookie_key: Option<PathBuf>,
 }
 
+pub struct PersistedState<T> {
+    path: PathBuf,
+    state: Arc<T>,
+}
+
+impl<T: Serialize + DeserializeOwned + Default + Send + Sync> PersistedState<T> {
+    fn load_or_default(name: &'static str, source: &StateSource) -> Result<Self> {
+        let path = source.directory().join(name).with_extension("json");
+        Ok(Self {
+            state: Arc::new(read_file_or_default(&path)?),
+            path,
+        })
+    }
+
+    fn load_or(name: &'static str, source: &StateSource, val: T) -> Self {
+        let path = source.directory().join(name).with_extension("json");
+        Self {
+            state: Arc::new(read_file(&path).unwrap_or(val)),
+            path,
+        }
+    }
+
+    pub fn store(&self) -> Result<()> {
+        Ok(pretty_write_file(&self.path, self.state.as_ref())?)
+    }
+}
+
+impl<T> Deref for PersistedState<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.state
+    }
+}
+
+impl<T> Clone for PersistedState<T> {
+    fn clone(&self) -> Self {
+        Self {
+            path: self.path.clone(),
+            state: self.state.clone(),
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct ApplicationSeed(String);
+
+impl From<Option<String>> for ApplicationSeed {
+    fn from(value: Option<String>) -> Self {
+        match value {
+            Some(val) => ApplicationSeed(val),
+            None => Self::default(),
+        }
+    }
+}
+
+impl ToString for ApplicationSeed {
+    fn to_string(&self) -> String {
+        self.0.to_string()
+    }
+}
+
+impl Default for ApplicationSeed {
+    fn default() -> Self {
+        let seed: [u8; 32] = rand::random();
+        Self(blake3::hash(&seed).to_string())
+    }
+}
+
+/// User-specific configuration
+#[derive(Serialize, Deserialize)]
+pub struct UserState {
+    #[serde(default)]
+    seed: [u8; 32],
+}
+
+impl UserState {
+    pub fn tracking_id(&self) -> String {
+        blake3::hash(&self.seed).to_string()
+    }
+}
+
+impl Default for UserState {
+    fn default() -> Self {
+        let seed = rand::random();
+        Self { seed }
+    }
+}
+
 impl StateSource {
     pub(crate) fn set_default_dir(&mut self, dir: &Path) {
         self.state_file
@@ -67,6 +157,23 @@ impl StateSource {
 
             target
         });
+    }
+
+    pub(crate) fn load_or_default<T: Serialize + DeserializeOwned + Default + Send + Sync>(
+        &self,
+        name: &'static str,
+    ) -> Result<PersistedState<T>> {
+        PersistedState::load_or_default(name, self)
+    }
+
+    pub(crate) fn load_state_or<T: Serialize + DeserializeOwned + Default + Send + Sync>(
+        &self,
+        name: &'static str,
+        val: impl Into<T>,
+    ) -> Result<PersistedState<T>> {
+        let val = PersistedState::load_or(name, self, val.into());
+        val.store()?;
+        Ok(val)
     }
 
     pub(crate) fn repo_dir(&self) -> Option<PathBuf> {
@@ -227,6 +334,11 @@ pub fn pretty_write_file<T: Serialize + ?Sized>(
     std::fs::rename(tmpfile, path)?;
 
     Ok(())
+}
+
+pub fn read_file<T: Default + DeserializeOwned>(path: &Path) -> Result<T, RepoError> {
+    let file = std::fs::File::open(path)?;
+    Ok(serde_json::from_reader::<_, T>(file)?)
 }
 
 pub fn read_file_or_default<T: Default + DeserializeOwned>(path: &Path) -> Result<T, RepoError> {

--- a/server/bleep/src/state.rs
+++ b/server/bleep/src/state.rs
@@ -114,8 +114,7 @@ impl ToString for ApplicationSeed {
 
 impl Default for ApplicationSeed {
     fn default() -> Self {
-        let seed: [u8; 32] = rand::random();
-        Self(blake3::hash(&seed).to_string())
+        Self(uuid::Uuid::new_v4().to_string())
     }
 }
 
@@ -123,19 +122,19 @@ impl Default for ApplicationSeed {
 #[derive(Serialize, Deserialize)]
 pub struct UserState {
     #[serde(default)]
-    seed: [u8; 32],
+    tracking_id: String,
 }
 
 impl UserState {
     pub fn tracking_id(&self) -> String {
-        blake3::hash(&self.seed).to_string()
+        self.tracking_id.clone()
     }
 }
 
 impl Default for UserState {
     fn default() -> Self {
-        let seed = rand::random();
-        Self { seed }
+        let tracking_id = uuid::Uuid::new_v4().to_string();
+        Self { tracking_id }
     }
 }
 

--- a/server/bleep/src/webserver.rs
+++ b/server/bleep/src/webserver.rs
@@ -1,6 +1,5 @@
 use crate::{env::Feature, snippet, Application};
 
-use axum::middleware;
 use axum::{http::StatusCode, response::IntoResponse, routing::get, Extension, Json};
 use std::sync::Arc;
 use std::{borrow::Cow, net::SocketAddr};
@@ -20,6 +19,7 @@ mod github;
 mod hoverable;
 mod index;
 mod intelligence;
+mod middleware;
 mod query;
 mod repos;
 mod semantic;
@@ -28,7 +28,7 @@ pub type Router<S = Application> = axum::Router<S>;
 
 #[allow(unused)]
 pub(in crate::webserver) mod prelude {
-    pub(in crate::webserver) use super::{json, EndpointError, Error, ErrorKind, Result};
+    pub(in crate::webserver) use super::{json, EndpointError, Error, ErrorKind, Result, Router};
     pub(in crate::webserver) use crate::indexes::Indexes;
     pub(in crate::webserver) use axum::{
         extract::Query, http::StatusCode, response::IntoResponse, Extension,
@@ -72,6 +72,10 @@ pub async fn start(app: Application) -> anyhow::Result<()> {
             get(answer::handle).with_state(Arc::new(answer::AnswerState::default())),
         );
 
+    if app.env.allow(Feature::AnyPathScan) {
+        api = api.route("/repos/scan", get(repos::scan_local));
+    }
+
     if app.env.allow(Feature::GithubDeviceFlow) {
         api = api
             .route("/remotes/github/login", get(github::login))
@@ -79,13 +83,12 @@ pub async fn start(app: Application) -> anyhow::Result<()> {
             .route("/remotes/github/status", get(github::status));
     }
 
-    if app.env.allow(Feature::AnyPathScan) {
-        api = api.route("/repos/scan", get(repos::scan_local));
-    }
-
     // Note: all routes above this point must be authenticated.
+    // These middlewares MUST provide the `middleware::User` extension.
     if app.env.allow(Feature::AuthorizationRequired) {
         api = aaa::router(api, app.clone());
+    } else {
+        api = middleware::local_user(api, app.clone());
     }
 
     api = api
@@ -93,7 +96,7 @@ pub async fn start(app: Application) -> anyhow::Result<()> {
         .route("/api-doc/openapi.yaml", get(openapi_yaml::handle))
         .route("/health", get(health));
 
-    let api: Router<()> = api
+    let api = api
         .layer(Extension(app.indexes.clone()))
         .layer(Extension(app.semantic.clone()))
         .layer(Extension(app.clone()))

--- a/server/bleep/src/webserver/answer.rs
+++ b/server/bleep/src/webserver/answer.rs
@@ -666,6 +666,8 @@ async fn _handle(
                 Err(e) => yield Err(e),
             }
         }
+
+        debug!("answer complete, closing SSE");
         let mut event = event.write().await;
         event
             .stages

--- a/server/bleep/src/webserver/config.rs
+++ b/server/bleep/src/webserver/config.rs
@@ -1,14 +1,17 @@
 use axum::extract::State;
 
 use super::{middleware::User, prelude::*};
-use crate::Application;
+use crate::{remotes, Application};
 
 #[derive(Serialize, Debug)]
 pub(super) struct ConfigResponse {
     analytics_data_plane: Option<String>,
     analytics_key_fe: Option<String>,
     sentry_dsn_fe: Option<String>,
-    tracking_id: Option<String>,
+    user_login: Option<String>,
+    org_name: Option<String>,
+    tracking_id: String,
+    device_id: String,
 }
 
 impl super::ApiResponse for ConfigResponse {}
@@ -18,23 +21,34 @@ pub(super) async fn handle(
     Extension(User(user)): Extension<User>,
 ) -> impl IntoResponse {
     let tracking_id = match user {
-        Some(username) => {
+        Some(ref username) => {
             let id = app
                 .user_store
-                .entry(username)
+                .entry(username.clone())
                 .or_default()
                 .get()
                 .tracking_id();
             _ = app.user_store.store();
-            Some(id)
+            id
         }
-        None => Some(app.tracking_seed.to_string()),
+        None => app.tracking_seed.to_string(),
+    };
+
+    let org_name = {
+        let cred = app.credentials.github().unwrap();
+        match cred.auth {
+            remotes::github::Auth::App { org, .. } => Some(org),
+            _ => None,
+        }
     };
 
     json(ConfigResponse {
         analytics_data_plane: app.config.analytics_data_plane.clone(),
         analytics_key_fe: app.config.analytics_key_fe.clone(),
         sentry_dsn_fe: app.config.sentry_dsn_fe.clone(),
+        device_id: app.tracking_seed.to_string(),
+        user_login: user,
+        org_name,
         tracking_id,
     })
 }

--- a/server/bleep/src/webserver/config.rs
+++ b/server/bleep/src/webserver/config.rs
@@ -1,4 +1,6 @@
-use super::prelude::*;
+use axum::extract::State;
+
+use super::{middleware::User, prelude::*};
 use crate::Application;
 
 #[derive(Serialize, Debug)]
@@ -6,14 +8,19 @@ pub(super) struct ConfigResponse {
     analytics_data_plane: Option<String>,
     analytics_key_fe: Option<String>,
     sentry_dsn_fe: Option<String>,
+    tracking_id: Option<String>,
 }
 
 impl super::ApiResponse for ConfigResponse {}
 
-pub(super) async fn handle(Extension(app): Extension<Application>) -> impl IntoResponse {
+pub(super) async fn handle(
+    State(app): State<Application>,
+    Extension(User(user)): Extension<User>,
+) -> impl IntoResponse {
     json(ConfigResponse {
         analytics_data_plane: app.config.analytics_data_plane.clone(),
         analytics_key_fe: app.config.analytics_key_fe.clone(),
         sentry_dsn_fe: app.config.sentry_dsn_fe.clone(),
+        tracking_id: user,
     })
 }

--- a/server/bleep/src/webserver/config.rs
+++ b/server/bleep/src/webserver/config.rs
@@ -17,10 +17,24 @@ pub(super) async fn handle(
     State(app): State<Application>,
     Extension(User(user)): Extension<User>,
 ) -> impl IntoResponse {
+    let tracking_id = match user {
+        Some(username) => {
+            let id = app
+                .user_store
+                .entry(username)
+                .or_default()
+                .get()
+                .tracking_id();
+            _ = app.user_store.store();
+            Some(id)
+        }
+        None => Some(app.tracking_seed.to_string()),
+    };
+
     json(ConfigResponse {
         analytics_data_plane: app.config.analytics_data_plane.clone(),
         analytics_key_fe: app.config.analytics_key_fe.clone(),
         sentry_dsn_fe: app.config.sentry_dsn_fe.clone(),
-        tracking_id: user,
+        tracking_id,
     })
 }

--- a/server/bleep/src/webserver/middleware.rs
+++ b/server/bleep/src/webserver/middleware.rs
@@ -1,0 +1,28 @@
+use super::prelude::*;
+use crate::Application;
+
+use axum::{
+    extract::State,
+    http::Request,
+    middleware::{from_fn_with_state, Next},
+    response::Response,
+};
+
+#[derive(Clone)]
+pub struct User(pub Option<String>);
+
+pub fn local_user(router: Router, app: Application) -> Router {
+    router.layer(from_fn_with_state(app, local_user_mw))
+}
+
+async fn local_user_mw<B>(
+    State(app): State<Application>,
+    mut request: Request<B>,
+    next: Next<B>,
+) -> Response {
+    request
+        .extensions_mut()
+        .insert(User(app.credentials.user().await));
+
+    next.run(request).await
+}


### PR DESCRIPTION
This adds a persistent tracking_id that's user-aware. The core of the logic is in `webserver/config.rs`, and would be good to get another pair of eyes if this is what we want.

This also opens the opporunity to potentially reset this in the future on a per-user basis, but that's unimplemented currently.