### PR TITLE
Github repos transitioning into local ones

### DIFF
--- a/server/bleep/src/remotes.rs
+++ b/server/bleep/src/remotes.rs
@@ -15,7 +15,7 @@ use tracing::{error, warn};
 
 use crate::{
     remotes,
-    repo::{Backend, RepoRef, Repository, SyncStatus},
+    repo::{Backend, RepoError, RepoRef, Repository, SyncStatus},
     Application,
 };
 
@@ -50,6 +50,9 @@ pub(crate) enum RemoteError {
 
     #[error("operation not supported: {0}")]
     NotSupported(&'static str),
+
+    #[error("persistence error: {0}")]
+    Repo(#[from] RepoError),
 
     #[error("IO error: {0}")]
     IO(#[from] std::io::Error),
@@ -329,6 +332,7 @@ impl BackendCredential {
             .await
             .unwrap();
 
+        app.config.source.save_pool(app.repo_pool.clone())?;
         synced
     }
 }

--- a/server/bleep/src/state.rs
+++ b/server/bleep/src/state.rs
@@ -146,6 +146,7 @@ impl StateSource {
                         .or_insert_with(|| Repository::local_from(&reporef));
                 }
 
+                self.save_pool(state.clone())?;
                 Ok(state)
             }
             (None, None) => Err(RepoError::NoSourceGiven),


### PR DESCRIPTION
The issue here seems to be that we only persist the state sometimes during the processing pipeline, which allows us losing information: If the user quits the app after the initial git sync, but before indexing completes, there's a chance we will not have saved the repo status.

Adding explicit persistence to these synchronization points should fix this.