### PR TITLE
turn NLQuery filters into exact matches

### DIFF
--- a/server/bleep/src/semantic.rs
+++ b/server/bleep/src/semantic.rs
@@ -326,7 +326,7 @@ fn make_kv_filter(key: &str, value: &str) -> FieldCondition {
     FieldCondition {
         key,
         r#match: Some(Match {
-            match_value: MatchValue::Text(value).into(),
+            match_value: MatchValue::Keyword(value).into(),
         }),
         ..Default::default()
     }


### PR DESCRIPTION
in the future, it would be nice to support full blown regex here, that way an exact match would be achieved by writing a filter of the form repo:/^string$/ and a substring match would be achieved by writing a filter of the form repo:string.