### PR TITLE
Implement tool-based answer module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -470,6 +470,7 @@ dependencies = [
  "time 0.3.20",
  "tokenizers",
  "tokio",
+ "tokio-stream",
  "tower",
  "tower-http",
  "tracing",

--- a/server/bleep/Cargo.toml
+++ b/server/bleep/Cargo.toml
@@ -115,6 +115,7 @@ async-stream = "0.3.3"
 erased-serde = "0.3.25"
 scc = { version= "1.2.0", features = ["serde"] }
 sentry-tracing = "0.30.0"
+tokio-stream = "0.1.12"
 
 [target.'cfg(windows)'.dependencies]
 dunce = "1.0.3"

--- a/server/bleep/src/indexes/file.rs
+++ b/server/bleep/src/indexes/file.rs
@@ -35,11 +35,12 @@ use {
 };
 
 use super::{
-    reader::{ContentDocument, ContentReader},
+    reader::{ContentDocument, ContentReader, FileDocument, FileReader},
     DocumentRead, Indexable, Indexer,
 };
 use crate::{
     intelligence::TreeSitterFile,
+    query::{compiler::Compiler, parser::Query},
     repo::{FileCache, RepoMetadata, RepoRef, Repository},
     semantic::Semantic,
     symbol::SymbolLocations,
@@ -384,6 +385,49 @@ impl Indexer<File> {
                 Err(anyhow::Error::msg("multiple paths returned"))
             }
         }
+    }
+
+    /// Search this index for paths partially matching a given string.
+    ///
+    /// For example, the string `Cargo` can return documents whose path is `foo/Cargo.toml`,
+    /// or `bar/Cargo.lock`.
+    pub async fn partial_path_match(
+        &self,
+        repo_ref: &RepoRef,
+        relative_path: &str,
+    ) -> impl Iterator<Item = FileDocument> + '_ {
+        let reader = self.reader.read().await;
+        let searcher = reader.searcher();
+
+        let file_index = searcher.index();
+        let file_source = &self.source;
+
+        let mut compiler = Compiler::new().literal(self.source.repo_ref, |q| q.repo.clone());
+
+        if !relative_path.is_empty() {
+            compiler = compiler.literal(self.source.relative_path, |q| q.path.clone());
+        }
+
+        let query = Query {
+            path: Some(crate::query::parser::Literal::Plain(relative_path.into())),
+            repo: Some(crate::query::parser::Literal::Plain(
+                repo_ref.to_string().into(),
+            )),
+            ..Default::default()
+        };
+
+        let query = compiler.compile([&query].into_iter(), file_index).unwrap();
+        let collector = TopDocs::with_limit(1000);
+        searcher
+            .search(&query, &collector)
+            .expect("failed to search index")
+            .into_iter()
+            .map(move |(_, doc_addr)| {
+                let retrieved_doc = searcher
+                    .doc(doc_addr)
+                    .expect("failed to get document by address");
+                FileReader.read_document(file_source, retrieved_doc)
+            })
     }
 
     pub async fn by_path(

--- a/server/bleep/src/lib.rs
+++ b/server/bleep/src/lib.rs
@@ -22,6 +22,7 @@ use console_subscriber as _;
 #[cfg(target_os = "windows")]
 use dunce::canonicalize;
 use scc::hash_map::Entry;
+use secrecy::SecretString;
 use state::PersistedState;
 #[cfg(not(target_os = "windows"))]
 use std::fs::canonicalize;
@@ -317,6 +318,35 @@ impl Application {
     /// clear the conversation history for a user
     pub fn purge_prior_conversation(&self, user_id: &str) {
         self.prior_conversational_store.remove(user_id);
+    }
+
+    pub fn github_token(&self) -> Result<Option<SecretString>> {
+        Ok(if self.env.allow(env::Feature::GithubDeviceFlow) {
+            let Some(cred) = self.credentials.github() else {
+                bail!("missing Github token");
+            };
+
+            use remotes::github::{Auth, State};
+            match cred {
+                State {
+                    auth:
+                        Auth::OAuth {
+                            access_token: token,
+                            ..
+                        },
+                    ..
+                } => Some(token),
+
+                State {
+                    auth: Auth::App { .. },
+                    ..
+                } => {
+                    bail!("cannot connect to answer API using installation token");
+                }
+            }
+        } else {
+            None
+        })
     }
 }
 

--- a/server/bleep/src/webserver.rs
+++ b/server/bleep/src/webserver.rs
@@ -1,7 +1,6 @@
 use crate::{env::Feature, snippet, Application};
 
 use axum::{http::StatusCode, response::IntoResponse, routing::get, Extension, Json};
-use std::sync::Arc;
 use std::{borrow::Cow, net::SocketAddr};
 use tower::Service;
 use tower_http::services::{ServeDir, ServeFile};
@@ -67,10 +66,7 @@ pub async fn start(app: Application) -> anyhow::Result<()> {
         // misc
         .route("/file/*ref", get(file::handle))
         .route("/semantic/chunks", get(semantic::raw_chunks))
-        .route(
-            "/answer",
-            get(answer::handle).with_state(Arc::new(answer::AnswerState::default())),
-        );
+        .route("/answer", answer::endpoint());
 
     if app.env.allow(Feature::AnyPathScan) {
         api = api.route("/repos/scan", get(repos::scan_local));
@@ -186,13 +182,6 @@ impl Error {
                 kind: ErrorKind::User,
                 message: message.to_string().into(),
             })),
-        }
-    }
-
-    fn message(&self) -> &str {
-        match &self.body {
-            Json(Response::Error(EndpointError { message, .. })) => message.as_ref(),
-            _ => "",
         }
     }
 }

--- a/server/bleep/src/webserver/answer.rs
+++ b/server/bleep/src/webserver/answer.rs
@@ -209,7 +209,7 @@ impl Conversation {
                     .app
                     .indexes
                     .file
-                    .partial_path_match(&self.repo_ref, &search)
+                    .fuzzy_path_match(&self.repo_ref, &search, /* limit */ 50)
                     .await
                     .map(|c| c.relative_path)
                     .map(|p| format!("{}, {p}", self.path_alias(&p)))

--- a/server/bleep/src/webserver/answer.rs
+++ b/server/bleep/src/webserver/answer.rs
@@ -1,1008 +1,584 @@
-use std::{
-    sync::Arc,
-    time::{Duration, Instant},
-};
+use std::{borrow::Cow, collections::HashMap, mem, sync::Arc};
 
+use anyhow::{anyhow, bail, Context, Result};
 use axum::{
     extract::{Query, State},
-    http::StatusCode,
-    response::{sse::Event, IntoResponse, Sse},
+    response::{
+        sse::{self, Sse},
+        IntoResponse,
+    },
+    routing::MethodRouter,
     Extension,
 };
-use futures::{stream, Stream, StreamExt, TryStreamExt};
-use qdrant_client::qdrant::{vectors, ScoredPoint};
+use futures::{
+    future::Either,
+    stream::{self, BoxStream},
+    StreamExt, TryStreamExt,
+};
+use once_cell::sync::Lazy;
+use regex::Regex;
+use reqwest::StatusCode;
 use secrecy::ExposeSecret;
-use thiserror::Error;
-use tokio::sync::RwLock;
-use tracing::{debug, error, info, warn};
-use utoipa::ToSchema;
+use tokio::sync::mpsc::Sender;
+use tracing::trace;
 
+use super::middleware::User;
 use crate::{
-    analytics::{QueryEvent, Stage},
-    env::Feature,
-    indexes::reader::ContentDocument,
-    query::parser,
-    remotes,
+    query::parser::{self, NLQuery},
     repo::RepoRef,
-    semantic::{self, Semantic},
     Application,
 };
 
-use super::{middleware::User, prelude::*};
+mod llm_gateway;
+mod prompts;
 
-/// Mirrored from `answer_api/lib.rs` to avoid private dependency.
-pub mod api {
-    use serde::Deserialize;
-
-    #[derive(serde::Serialize, serde::Deserialize, Debug, Clone)]
-    pub struct Message {
-        pub role: String,
-        pub content: String,
-    }
-
-    #[derive(serde::Serialize, serde::Deserialize, Debug, Clone)]
-    pub struct Messages {
-        pub messages: Vec<Message>,
-    }
-
-    #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-    #[serde(rename_all = "lowercase")]
-    pub enum Provider {
-        OpenAi,
-        Anthropic,
-    }
-
-    impl Provider {
-        pub fn token_limit(&self) -> usize {
-            match self {
-                Self::OpenAi => 8192,
-                Self::Anthropic => 8000,
-            }
-        }
-    }
-
-    #[derive(Debug, serde::Serialize, serde::Deserialize)]
-    pub struct Request {
-        pub messages: Messages,
-        pub max_tokens: Option<u32>,
-        pub temperature: Option<f32>,
-        pub provider: Provider,
-        pub extra_stop_sequences: Vec<String>,
-    }
-
-    #[derive(thiserror::Error, Debug, Deserialize)]
-    pub enum Error {
-        #[error("bad OpenAI request")]
-        BadOpenAiRequest,
-    }
-
-    pub type Result = std::result::Result<String, Error>;
-}
-
-#[derive(Debug, serde::Serialize, serde::Deserialize, Clone, Default)]
-pub struct Snippet {
-    pub lang: String,
-    pub repo_name: String,
-    pub repo_ref: String,
-    pub relative_path: String,
-    pub text: String,
-    pub start_line: usize,
-    pub end_line: usize,
-    pub start_byte: usize,
-    pub end_byte: usize,
-    pub score: f32,
-
-    /// the vector embeddings for each chunk.
-    ///
-    /// this is used to eliminate duplicate chunks using MMR, see semantic::deduplicate_with_mmr
-    #[serde(skip)]
-    pub embedding: Vec<f32>,
-}
-
-fn default_limit() -> u64 {
-    20
-}
-
-fn default_user_id() -> String {
-    String::from("test_user")
+#[derive(Default)]
+pub struct RouteState {
+    conversations: scc::HashMap<ConversationId, Conversation>,
 }
 
 #[derive(Clone, Debug, serde::Deserialize)]
 pub struct Params {
     pub q: String,
+    pub repo_ref: RepoRef,
+    #[serde(default = "default_thread_id")]
     pub thread_id: String,
-    #[serde(default = "default_limit")]
-    pub limit: u64,
 }
 
-#[derive(serde::Serialize, ToSchema, Debug)]
-pub struct AnswerResponse {
-    pub user_id: String,
-    pub session_id: String,
-    pub query_id: uuid::Uuid,
-    pub snippets: Option<AnswerSnippets>,
+fn default_thread_id() -> String {
+    uuid::Uuid::new_v4().to_string()
 }
 
-#[derive(serde::Serialize, ToSchema, Debug)]
-pub struct AnswerSnippets {
-    pub matches: Vec<Snippet>,
-    pub answer_path: String,
-}
-
-impl super::ApiResponse for AnswerResponse {}
-
-const SNIPPET_COUNT: usize = 20;
-
-pub(super) struct AnswerState {
-    client: reqwest::Client,
-}
-
-impl Default for AnswerState {
-    fn default() -> Self {
-        Self {
-            client: reqwest::Client::builder()
-                .cookie_store(true)
-                .build()
-                // This should never fail, the only default properties we change are enabling
-                // cookies.
-                .unwrap(),
-        }
-    }
+pub(super) fn endpoint<S>() -> MethodRouter<S> {
+    let state = Arc::new(RouteState::default());
+    axum::routing::post(handle).with_state(state)
 }
 
 pub(super) async fn handle(
     Query(params): Query<Params>,
-    State(state): State<Arc<AnswerState>>,
+    State(state): State<Arc<RouteState>>,
     Extension(app): Extension<Application>,
     Extension(user): Extension<User>,
-) -> Result<impl IntoResponse> {
-    // create a new analytics event for this query
-    let event = Arc::new(RwLock::new(QueryEvent::default()));
+) -> super::Result<impl IntoResponse> {
+    let conversation_id = ConversationId {
+        user_id: user
+            .0
+            .ok_or_else(|| super::Error::user("didn't have user ID"))?,
+        thread_id: params.thread_id,
+    };
 
-    let user = user.0.unwrap_or_else(default_user_id);
-
-    // populate analytics event
-    let response = _handle(&state, params, app.clone(), Arc::clone(&event), user).await;
-
-    if response.is_err() {
-        // Result<impl IntoResponse> does not implement `Debug`, `unwrap_err` is unavailable
-        let Err(e) = response.as_ref() else {
-            unreachable!();
-        };
-
-        // add error stage to pipeline
-        let mut ev = event.write().await;
-        ev.stages
-            .push(Stage::new("error", (e.status.as_u16(), e.message())));
-
-        // send to rudderstack
-        app.track_query(&ev);
-    } else {
-        // the analytics event is fired when the stream is consumed
-    }
-    response
-}
-
-fn parse_query(query: &str) -> Result<String, Error> {
-    Ok(parser::parse_nl(query)
-        .map_err(Error::user)?
-        .target()
-        .ok_or_else(|| Error::user("empty search"))?
-        .to_string())
-}
-
-const MAX_HISTORY: usize = 3;
-
-#[derive(Debug)]
-enum AnswerProgress {
-    // Need to rephrase the query. The contained string is the prompt for rephrasing
-    Rephrase(String),
-    // Got a query to search
-    Search(String),
-    // Explain the results
-    Explain(String),
-}
-
-async fn search_snippets(
-    semantic: &Semantic,
-    raw_query: &str,
-    rephrased_query: &str,
-) -> Result<Vec<Snippet>, Error> {
-    let mut parsed_query = &mut parser::parse_nl(raw_query).map_err(Error::user)?;
-
-    parsed_query.target = Some(parser::Literal::Plain(rephrased_query.into()));
-
-    let all_snippets: Vec<Snippet> = semantic
-        .search(parsed_query, 4 * SNIPPET_COUNT as u64) // heuristic
+    let mut conversation: Conversation = state
+        .conversations
+        .read_async(&conversation_id, |_k, v| v.clone())
         .await
-        .map_err(Error::internal)?
-        .into_iter()
-        .map(|r| {
-            use qdrant_client::qdrant::{value::Kind, Value};
+        .unwrap_or_else(|| Conversation::new(params.repo_ref));
 
-            // TODO: Can we merge with webserver/semantic.rs:L63?
-            fn value_to_string(value: Value) -> String {
-                match value.kind.unwrap() {
-                    Kind::StringValue(s) => s,
-                    _ => panic!("got non-string value"),
+    let ctx = AppContext::new(app)
+        .map_err(|e| super::Error::user(e).with_status(StatusCode::UNAUTHORIZED))?;
+    let q = params.q;
+    let stream = async_stream::try_stream! {
+        let mut action_stream = Action::Query(q).into()?;
+
+        loop {
+            // The main loop. Here, we create two streams that operate simultaneously; the update
+            // stream, which sends updates back to the HTTP event stream response, and the action
+            // stream, which returns a single item when there is a new action available to execute.
+            // Both of these operate together, and we repeat the process for every new action.
+
+            use futures::future::FutureExt;
+
+            let (update_tx, update_rx) = tokio::sync::mpsc::channel(10);
+
+            let left_stream = tokio_stream::wrappers::ReceiverStream::new(update_rx)
+                .map(Either::Left);
+
+            let right_stream = conversation
+                .step(&ctx, action_stream, update_tx)
+                .into_stream()
+                .map(Either::Right);
+
+            let mut next = None;
+            for await item in stream::select(left_stream, right_stream) {
+                match item {
+                    Either::Left(upd) => yield upd,
+                    Either::Right(n) => next = n?,
                 }
             }
 
-            fn extract_vector(point: &ScoredPoint) -> Vec<f32> {
-                if let Some(vectors) = &point.vectors {
-                    if let Some(vectors::VectorsOptions::Vector(v)) = &vectors.vectors_options {
-                        return v.data.clone();
-                    }
-                }
-                panic!("got non-vector value");
+            match next {
+                Some(a) => action_stream = a,
+                None => break,
             }
+        }
 
-            let embedding = extract_vector(&r);
+        // Storing the conversation here allows us to make subsequent requests.
+        state.conversations
+            .entry_async(conversation_id)
+            .await
+            .insert_entry(conversation);
+    };
 
-            let mut s = r.payload;
+    let stream = stream
+        .map(|upd: Result<_>| sse::Event::default().json_data(upd.map_err(|e| e.to_string())))
+        .chain(futures::stream::once(async {
+            Ok(sse::Event::default().data("[DONE]"))
+        }));
 
-            Snippet {
-                lang: value_to_string(s.remove("lang").unwrap()),
-                repo_name: value_to_string(s.remove("repo_name").unwrap()),
-                repo_ref: value_to_string(s.remove("repo_ref").unwrap()),
-                relative_path: value_to_string(s.remove("relative_path").unwrap()),
-                text: value_to_string(s.remove("snippet").unwrap()),
-
-                start_line: value_to_string(s.remove("start_line").unwrap())
-                    .parse::<usize>()
-                    .unwrap(),
-                end_line: value_to_string(s.remove("end_line").unwrap())
-                    .parse::<usize>()
-                    .unwrap(),
-                start_byte: value_to_string(s.remove("start_byte").unwrap())
-                    .parse::<usize>()
-                    .unwrap(),
-                end_byte: value_to_string(s.remove("end_byte").unwrap())
-                    .parse::<usize>()
-                    .unwrap(),
-                score: r.score,
-                embedding,
-            }
-        })
-        .collect();
-
-    Ok(all_snippets)
+    Ok(Sse::new(stream))
 }
 
-fn deduplicate_snippets(all_snippets: Vec<Snippet>, query_embedding: Vec<f32>) -> Vec<Snippet> {
-    let lambda = 0.5;
-    let k = SNIPPET_COUNT; // number of snippets
-    let embeddings = all_snippets
-        .iter()
-        .map(|s| s.embedding.as_slice())
-        .collect::<Vec<_>>();
-    let idxs = semantic::deduplicate_with_mmr(&query_embedding, &embeddings, lambda, k);
-    let mut snippets = vec![];
-    info!("preserved idxs after MMR are {:?}", idxs);
-    for i in idxs {
-        let item = all_snippets[i].clone();
-        snippets.push(item);
+#[derive(Hash, PartialEq, Eq)]
+struct ConversationId {
+    thread_id: String,
+    user_id: String,
+}
+
+#[derive(Clone, Debug)]
+struct Conversation {
+    history: Vec<llm_gateway::api::Message>,
+    path_aliases: Vec<String>,
+    repo_ref: RepoRef,
+}
+
+impl Conversation {
+    fn new(repo_ref: RepoRef) -> Self {
+        // We start of with a conversation describing the operations that the LLM can perform, and
+        // an initial (hidden) prompt that we pose to the user.
+
+        Self {
+            history: vec![
+                llm_gateway::api::Message::system(prompts::SYSTEM),
+                llm_gateway::api::Message::assistant(prompts::INITIAL_PROMPT),
+            ],
+            path_aliases: Vec::new(),
+            repo_ref,
+        }
     }
-    snippets
-}
 
-// we use this internally to check whether the first token (skipping whitespace) is a
-// number or something else
-enum FirstToken {
-    Number(usize),
-    Other(String),
-    None,
-}
-
-async fn grow_snippet(
-    relevant_snippet: &Snippet,
-    semantic: &Semantic,
-    app: &Application,
-) -> Result<Snippet, Error> {
-    // grow the snippet by 60 lines above and below, we have sufficient space
-    // to grow this snippet by 10 times its original size (15 to 150)
-    let repo_ref = &relevant_snippet
-        .repo_ref
-        .parse::<RepoRef>()
-        .map_err(Error::internal)?;
-
-    let doc = app
-        .indexes
-        .file
-        .by_path(repo_ref, &relevant_snippet.relative_path)
-        .await
-        .map_err(Error::internal)?;
-
-    let mut grow_size = 40;
-    let grown_text = loop {
-        if let Some(grown_text) = grow(&doc, relevant_snippet, grow_size) {
-            let token_count = semantic.gpt2_token_count(&grown_text);
-            info!(%grow_size, %token_count, "growing ...");
-            if token_count > 6000 || grow_size > 100 {
-                break grown_text;
-            } else {
-                grow_size += 10;
-            }
+    fn path_alias(&mut self, path: &str) -> usize {
+        if let Some(i) = self.path_aliases.iter().position(|p| *p == path) {
+            i
         } else {
-            break relevant_snippet.text.clone();
+            let i = self.path_aliases.len();
+            self.path_aliases.push(path.to_owned());
+            i
         }
-    };
+    }
 
-    Ok(Snippet {
-        lang: relevant_snippet.lang.clone(),
-        repo_name: relevant_snippet.repo_name.clone(),
-        repo_ref: relevant_snippet.repo_ref.clone(),
-        relative_path: relevant_snippet.relative_path.clone(),
-        text: grown_text,
-        start_line: relevant_snippet.start_line,
-        end_line: relevant_snippet.end_line,
-        start_byte: relevant_snippet.start_byte,
-        end_byte: relevant_snippet.end_byte,
-        score: relevant_snippet.score,
-        embedding: relevant_snippet.embedding.clone(),
-    })
-}
+    async fn step(
+        &mut self,
+        ctx: &AppContext,
+        action_stream: ActionStream,
+        update: Sender<Update>,
+    ) -> Result<Option<ActionStream>> {
+        let (action, raw_response) = action_stream.load(&update).await?;
 
-async fn handle_inner(
-    query: &str,
-    thread_id: &str,
-    state: &AnswerState,
-    params: Arc<Params>,
-    app: Arc<Application>,
-    event: Arc<RwLock<QueryEvent>>,
-    mut stop_watch: StopWatch,
-) -> Result<(
-    Option<Vec<Snippet>>,
-    StopWatch,
-    std::pin::Pin<Box<dyn Stream<Item = Result<String, AnswerAPIError>> + Send>>,
-)> {
-    let query = query.to_string(); // TODO: Sort out query handling
-
-    event
-        .write()
-        .await
-        .stages
-        .push(Stage::new("parsed_query", &query).with_time(stop_watch.lap()));
-
-    let mut snippets = None;
-
-    let answer_bearer = if app.env.allow(Feature::GithubDeviceFlow) {
-        let Some(cred) = app.credentials.github() else {
-            return Err(Error::user(
-                "missing Github token",
-            ).with_status(StatusCode::UNAUTHORIZED));
-        };
-
-        use remotes::github::{Auth, State};
-        match cred {
-            State {
-                auth:
-                    Auth::OAuth {
-                        access_token: token,
-                        ..
-                    },
-                ..
-            } => Some(token.expose_secret().clone()),
-
-            State {
-                auth: Auth::App { .. },
-                ..
-            } => {
-                return Err(
-                    Error::user("cannot connect to answer API using installation token")
-                        .with_status(StatusCode::UNAUTHORIZED),
-                )
-            }
+        if !matches!(action, Action::Query(..)) {
+            self.history
+                .push(llm_gateway::api::Message::assistant(&raw_response));
+            trace!("handling raw action: {raw_response}");
         }
-    } else {
-        None
-    };
 
-    let semantic = app
-        .semantic
-        .clone()
-        .ok_or_else(|| Error::new(ErrorKind::Configuration, "Qdrant not configured"))?;
+        let question = match action {
+            Action::Query(s) => parser::parse_nl(&s)?
+                .target
+                .context("query was empty")?
+                .as_plain()
+                .context("user query was not plain text")?
+                .clone()
+                .into_owned(),
 
-    let answer_api_client = semantic.build_answer_api_client(
-        state,
-        format!("{}/v1/q", app.config.answer_api_url).as_str(),
-        5,
-        answer_bearer.clone(),
-    );
-
-    let mut progress = app
-        .with_prior_conversation(thread_id, |history| {
-            if history.is_empty() {
-                None
-            } else {
-                Some(query.clone())
+            Action::Prompt(_) => {
+                return Ok(None);
             }
-        })
-        .map(AnswerProgress::Rephrase)
-        .unwrap_or(AnswerProgress::Rephrase(query.clone()));
 
-    loop {
-        let stream_params = match &progress {
-            AnswerProgress::Rephrase(query) => {
-                let prompt = app.with_prior_conversation(thread_id, |history| {
-                    let n = history.len().saturating_sub(MAX_HISTORY);
-                    build_rephrase_query_prompt(query, history.get(n..).unwrap_or_default())
-                });
-                (prompt, 20, 0.0, vec![])
+            Action::Answer(_) => {
+                let r: Result<ActionStream> = Action::Prompt(prompts::CONTINUE.to_owned()).into();
+                return Ok(Some(r?));
             }
-            AnswerProgress::Search(rephrased_query) => {
-                // TODO: Clean up this query handling logic
-                let all_snippets = search_snippets(&semantic, &params.q, rephrased_query).await?;
-                info!("Retrieved {} snippets", all_snippets.len());
 
-                event.write().await.stages.push(
-                    Stage::new("semantic_results", &all_snippets).with_time(stop_watch.lap()),
-                );
-
-                let query_embedding = semantic.embed(rephrased_query).map_err(|e| {
-                    error!("failed to embed query: {}", e);
-                    Error::internal(e)
-                })?;
-                let filtered_snippets = deduplicate_snippets(all_snippets, query_embedding);
-
-                event.write().await.stages.push(
-                    Stage::new("filtered_semantic_results", &filtered_snippets)
-                        .with_time(stop_watch.lap()),
-                );
-
-                if filtered_snippets.is_empty() {
-                    warn!("Semantic search returned no snippets");
-                    let selection_fail_stream = Box::pin(stream::once(async {
-                        Ok("Sorry, I could not find any results matching your query. \
-                            Please try again with different keywords or refine your search."
-                            .to_string())
-                    }));
-                    return Ok((snippets, stop_watch, selection_fail_stream));
-                }
-
-                let prompt =
-                    answer_api_client.build_select_prompt(rephrased_query, &filtered_snippets);
-                snippets = Some(filtered_snippets);
-
-                event
-                    .write()
+            Action::Path(search) => {
+                let paths = ctx
+                    .app
+                    .indexes
+                    .file
+                    .partial_path_match(&self.repo_ref, &search)
                     .await
-                    .stages
-                    .push(Stage::new("select_prompt", &prompt).with_time(stop_watch.lap()));
+                    .map(|c| c.relative_path)
+                    .map(|p| format!("{}, {p}", self.path_alias(&p)));
 
-                (prompt, 10, 0.0, vec!["</index>".into()])
+                Some("§alias, path".to_owned())
+                    .into_iter()
+                    .chain(paths)
+                    .collect::<Vec<_>>()
+                    .join("\n")
             }
-            AnswerProgress::Explain(query) => {
-                let prompt = if let Some(snippet) = snippets.as_ref().unwrap().first() {
-                    let grown = grow_snippet(snippet, &semantic, &app).await?;
-                    app.with_prior_conversation(thread_id, |conversation| {
-                        answer_api_client.build_explain_prompt(&grown, conversation, query)
-                    })
-                } else {
-                    api::Messages {
-                        messages: vec![api::Message {
-                            role: "user".into(),
-                            content: "Apologize for not finding a suitable code snippet, \
-                        while expressing hope that one of the snippets may still be useful"
-                                .to_string(),
-                        }],
-                    }
+
+            Action::File(file_ref) => {
+                // Retrieve the contents of a file.
+
+                let path = match &file_ref {
+                    FileRef::Alias(idx) => self
+                        .path_aliases
+                        .get(*idx)
+                        .with_context(|| format!("unknown path alias {idx}"))?,
+
+                    FileRef::Path(p) => p,
                 };
-                let tokens_used =
-                    semantic.gpt2_token_count(&prompt.messages.first().unwrap().content);
-                info!(%tokens_used, "input prompt token count");
-                let max_tokens = 8000u32.saturating_sub(tokens_used as u32);
-                if max_tokens == 0 {
-                    // our prompt has overshot the token count, log an error for now
-                    // TODO: this should propagte to sentry
-                    error!(%tokens_used, "prompt overshot token limit");
-                }
-                // do not let the completion cross 250 tokens
-                let max_tokens = max_tokens.clamp(1, 250);
-                info!(%max_tokens, "clamping max tokens");
 
-                event
-                    .write()
-                    .await
-                    .stages
-                    .push(Stage::new("explain_prompt", &prompt).with_time(stop_watch.lap()));
+                ctx.app
+                    .indexes
+                    .file
+                    .by_path(&self.repo_ref, path)
+                    .await?
+                    .content
+            }
 
-                (prompt, max_tokens, 0.9, vec![])
+            Action::Code(query) => {
+                // Semantic search.
+
+                let nl_query = NLQuery {
+                    target: Some(parser::Literal::Plain(Cow::Owned(query))),
+                    ..Default::default()
+                };
+
+                let chunks = ctx
+                    .app
+                    .semantic
+                    .as_ref()
+                    .context("semantic search is not enabled")?
+                    .search(&nl_query, 10)
+                    .await?
+                    .into_iter()
+                    .map(|v| {
+                        v.payload
+                            .into_iter()
+                            .map(|(k, v)| (k, super::semantic::kind_to_value(v.kind)))
+                            .collect::<HashMap<_, _>>()
+                    })
+                    .map(|chunk| {
+                        let relative_path = chunk["relative_path"].as_str().unwrap();
+                        serde_json::json!({
+                            "path": relative_path,
+                            "§ALIAS": self.path_alias(relative_path),
+                            "snippet": chunk["snippet"],
+                            "start": chunk["start_line"].as_str().unwrap().parse::<u32>().unwrap(),
+                            "end": chunk["end_line"].as_str().unwrap().parse::<u32>().unwrap(),
+                        })
+                    })
+                    .collect::<Vec<_>>();
+
+                serde_json::to_string(&chunks).unwrap()
+            }
+
+            Action::Check(question, path_aliases) => {
+                self.check(ctx, question, path_aliases).await?
             }
         };
 
-        // This strange extraction of parameters from a tuple is due to lifetime issues. This
-        // function should probably be refactored, but at the time of writing this is left as-is
-        // due to time constraints.
-        let mut stream = Box::pin(
-            answer_api_client
-                .send_until_success(
-                    stream_params.0,
-                    stream_params.1,
-                    stream_params.2,
-                    api::Provider::OpenAi,
-                    stream_params.3,
-                )
-                .await?,
-        );
+        self.history.push(llm_gateway::api::Message::user(
+            &(question + "\n\nAnswer only with a JSON action."),
+        ));
 
-        if let AnswerProgress::Rephrase(_) = &progress {
-            let rephrased_query: String = stream.try_collect().await?;
-            info!("Rephrased query: {:?}", &rephrased_query);
-            if rephrased_query.trim() == "N/A" {
-                let rephrase_fail_stream = Box::pin(stream::once(async {
-                    Ok(
-                        "I'm not sure what you mean. Try asking a technical question about the codebase."
-                            .to_string(),
-                    )
-                }));
-                return Ok((None, stop_watch, rephrase_fail_stream));
-            }
-            event
-                .write()
+        let stream = ctx.llm_gateway.chat(&self.history).await?.boxed();
+        let action_stream = ActionStream {
+            tokens: String::new(),
+            action: Either::Left(stream),
+        };
+
+        Ok(Some(action_stream))
+    }
+
+    async fn check(
+        &mut self,
+        ctx: &AppContext,
+        question: String,
+        path_aliases: Vec<usize>,
+    ) -> Result<String> {
+        let paths = path_aliases
+            .into_iter()
+            .map(|i| self.path_aliases.get(i).ok_or(i))
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|i| anyhow!("invalid path alias {i}"))?;
+
+        let question = &question;
+        let ctx = &ctx.clone().model("gpt-3.5-turbo");
+        let repo_ref = &self.repo_ref;
+        let chunks = stream::iter(paths).map(|path| async move {
+            let lines = ctx
+                .app
+                .indexes
+                .file
+                .by_path(repo_ref, path)
                 .await
-                .stages
-                .push(Stage::new("rephrased_query", &rephrased_query));
-            progress = AnswerProgress::Search(rephrased_query);
-            continue;
-        }
+                .with_context(|| format!("failed to read path: {path}"))?
+                .content
+                .split('\n')
+                .enumerate()
+                .map(|(i, line)| format!("{}: {line}", i + 1))
+                .collect::<Vec<_>>();
 
-        let mut collected = FirstToken::None;
-        while let Some(token) = stream.try_next().await? {
-            if let Ok(i) = token.trim().parse::<usize>() {
-                collected = FirstToken::Number(i);
-                break;
-            } else if !token.bytes().all(|b| b.is_ascii_whitespace()) {
-                collected = FirstToken::Other(token);
-                break;
+            // We store the lines separately, so that we can reference them later to trim
+            // this snippet by line number.
+            let contents = lines.join("\n");
+
+            let prompt = prompts::file_explanation(question, path, &contents);
+
+            let json = ctx
+                .llm_gateway
+                .chat(&[llm_gateway::api::Message::system(&prompt)])
+                .await?
+                .try_collect::<String>()
+                .await?;
+
+            #[derive(serde::Deserialize)]
+            struct Range {
+                start: usize,
+                end: usize,
+                answer: String,
             }
-        }
 
-        match collected {
-            FirstToken::Number(n) => {
-                progress = match progress {
-                    AnswerProgress::Search(_) => {
-                        let Some(index) = n.checked_sub(1) else {
-                            let selection_fail_stream = Box::pin(stream::once(async {
-                                Ok("I'm not sure. One of these snippets might be relevant".to_string())
-                            }));
-                            return Ok((snippets, stop_watch, selection_fail_stream));
-                        };
-                        snippets.as_mut().unwrap().swap(index, 0);
-                        AnswerProgress::Explain(query.clone())
-                    }
-                    e => e,
-                }
-            }
-            FirstToken::Other(token) => {
-                return Ok((
-                    snippets,
-                    stop_watch,
-                    Box::pin(stream::once(async move { Ok(token) }).chain(stream)),
-                ));
-            }
-            FirstToken::None => {
-                return Ok((
-                    snippets,
-                    stop_watch,
-                    Box::pin(stream::once(async move { Ok("".to_string()) }).chain(stream)),
-                ));
-            }
-        }
-    }
-}
+            let explanations = serde_json::from_str::<Vec<Range>>(&json)?
+                .into_iter()
+                .filter(|r| r.start > 0 && r.end > 0)
+                .map(|r| {
+                    let end = r.end.min(r.start + 10);
 
-async fn _handle(
-    state: &AnswerState,
-    params: Params,
-    app: Application,
-    event: Arc<RwLock<QueryEvent>>,
-    user: String,
-) -> Result<impl IntoResponse> {
-    let query_id = uuid::Uuid::new_v4();
-
-    info!("Raw query: {:?}", &params.q);
-
-    {
-        let mut analytics_event = event.write().await;
-        analytics_event.user_id = user.clone();
-        analytics_event.query_id = query_id;
-        analytics_event.session_id = params.thread_id.clone();
-        if let Some(semantic) = app.semantic.as_ref() {
-            analytics_event.overlap_strategy = semantic.overlap_strategy();
-        }
-        analytics_event
-            .stages
-            .push(Stage::new("raw_query", &params.q));
-    }
-
-    let query = parse_query(&params.q)?;
-    info!("Parsed query target: {:?}", &query);
-
-    let stop_watch = StopWatch::start();
-    let params = Arc::new(params);
-    let mut app = Arc::new(app);
-    let (snippets, mut stop_watch, mut text) = handle_inner(
-        &query,
-        &params.thread_id,
-        state,
-        Arc::clone(&params),
-        Arc::clone(&app),
-        Arc::clone(&event),
-        stop_watch,
-    )
-    .await?;
-    Arc::make_mut(&mut app).add_conversation_entry(params.thread_id.clone(), query);
-    let initial_event = Event::default()
-        .json_data(super::Response::<'static>::from(AnswerResponse {
-            query_id,
-            session_id: params.thread_id.clone(),
-            user_id: user.clone(),
-            snippets: snippets.as_ref().map(|matches| AnswerSnippets {
-                matches: matches.clone(),
-                answer_path: matches
-                    .first()
-                    .map(|s| &s.relative_path)
-                    .cloned()
-                    .unwrap_or_default(),
-            }),
-        }))
-        .map_err(Error::internal)?;
-
-    let mut expl = String::new();
-
-    let wrapped_stream = async_stream::stream! {
-        yield Ok(initial_event);
-        while let Some(result) = text.next().await {
-            if let Ok(fragment) = &result {
-                app.extend_conversation_answer(params.thread_id.clone(), fragment.trim_end())
-            }
-            yield Ok(Event::default()
-                .json_data(result.as_ref().map_err(|e| e.to_string()))
-                .unwrap());
-
-            match result {
-                Ok(s) => expl += &s,
-                Err(e) => yield Err(e),
-            }
-        }
-
-        debug!("answer complete, closing SSE");
-        let mut event = event.write().await;
-        event
-            .stages
-            .push(Stage::new("answer", &expl).with_time(stop_watch.lap()));
-        app.track_query(&event);
-    };
-
-    Ok(Sse::new(wrapped_stream.chain(futures::stream::once(
-        async { Ok(Event::default().data("[DONE]")) },
-    ))))
-}
-
-// grow the text of this snippet by `size` and return the new text
-fn grow(doc: &ContentDocument, snippet: &Snippet, size: usize) -> Option<String> {
-    let content = &doc.content;
-
-    // do not grow if this snippet contains incorrect byte ranges
-    if snippet.start_byte >= content.len() || snippet.end_byte >= content.len() {
-        error!(
-            repo = snippet.repo_name,
-            path = snippet.relative_path,
-            start = snippet.start_byte,
-            end = snippet.end_byte,
-            "invalid snippet bounds",
-        );
-        return None;
-    }
-
-    // skip upwards `size` number of lines
-    let new_start_byte = content
-        .get(..snippet.start_byte)?
-        .rmatch_indices('\n')
-        .map(|(idx, _)| idx)
-        .nth(size)
-        .unwrap_or(0);
-
-    // skip downwards `size` number of lines
-    let new_end_byte = content
-        .get(snippet.end_byte..)?
-        .match_indices('\n')
-        .map(|(idx, _)| idx)
-        .nth(size)
-        .map(|s| s.saturating_add(snippet.end_byte)) // the index is off by `snippet.end_byte`
-        .unwrap_or(content.len());
-
-    content
-        .get(new_start_byte..new_end_byte)
-        .map(ToOwned::to_owned)
-}
-
-struct AnswerAPIClient<'s> {
-    host: String,
-    semantic: &'s Semantic,
-    max_attempts: u64,
-    bearer_token: Option<String>,
-    client: reqwest::Client,
-}
-
-#[derive(Error, Debug)]
-enum AnswerAPIError {
-    #[error("max retry attempts reached {0}")]
-    MaxAttemptsReached(u64),
-
-    #[error("event source error {0}")]
-    EventSource(#[from] reqwest_eventsource::Error),
-
-    #[error("failed to open stream")]
-    StreamFail,
-
-    #[error("message deserialization error {0}")]
-    MessageFormat(#[from] serde_json::Error),
-
-    #[error("answer API error {0}")]
-    BadRequest(#[from] api::Error),
-}
-
-impl From<AnswerAPIError> for Error {
-    fn from(e: AnswerAPIError) -> Error {
-        sentry::capture_message(
-            format!("answer-api failed to respond: {e}").as_str(),
-            sentry::Level::Error,
-        );
-        Error::new(ErrorKind::UpstreamService, e.to_string())
-    }
-}
-
-impl Semantic {
-    fn build_answer_api_client<'s>(
-        &'s self,
-        state: &AnswerState,
-        host: &str,
-        max_attempts: u64,
-        bearer_token: Option<String>,
-    ) -> AnswerAPIClient<'s> {
-        AnswerAPIClient {
-            host: host.to_owned(),
-            semantic: self,
-            max_attempts,
-            // Internally, cookies are shared between `reqwest` client instances via a shared lock.
-            // Cloning the client here just creates a new handle to the same lock.
-            client: state.client.clone(),
-            bearer_token,
-        }
-    }
-}
-
-impl<'s> AnswerAPIClient<'s> {
-    async fn send(
-        &self,
-        messages: api::Messages,
-        max_tokens: u32,
-        temperature: f32,
-        provider: api::Provider,
-        extra_stop_sequences: Vec<String>,
-    ) -> Result<impl Stream<Item = Result<String, AnswerAPIError>>, AnswerAPIError> {
-        let mut stream = Box::pin(
-            reqwest_eventsource::EventSource::new({
-                let mut builder = self.client.post(self.host.as_str());
-
-                if let Some(bearer) = &self.bearer_token {
-                    builder = builder.bearer_auth(bearer);
-                }
-
-                builder.json(&api::Request {
-                    messages,
-                    max_tokens: Some(max_tokens),
-                    temperature: Some(temperature),
-                    provider,
-                    extra_stop_sequences,
+                    serde_json::json!({
+                        "start": r.start,
+                        "answer": r.answer,
+                        "end": end,
+                        "relevant_code": lines[r.start..end].join("\n"),
+                    })
                 })
-            })
-            // We don't have a `Stream` body so this can't fail.
-            .expect("couldn't clone requestbuilder")
-            // `reqwest_eventsource` returns an error to signify a stream end, instead of simply ending
-            // the stream. So we catch the error here and close the stream.
-            .take_while(|result| {
-                let is_end = matches!(result, Err(reqwest_eventsource::Error::StreamEnded));
-                async move { !is_end }
-            }),
-        );
+                .collect::<Vec<_>>();
 
-        match stream.next().await {
-            Some(Ok(reqwest_eventsource::Event::Open)) => {}
-            Some(Err(e)) => return Err(AnswerAPIError::EventSource(e)),
-            _ => return Err(AnswerAPIError::StreamFail),
-        }
-
-        Ok(stream
-            .filter_map(|result| async move {
-                match result {
-                    Ok(reqwest_eventsource::Event::Message(msg)) => Some(Ok(msg.data)),
-                    Ok(reqwest_eventsource::Event::Open) => None,
-                    Err(reqwest_eventsource::Error::StreamEnded) => None,
-                    Err(e) => Some(Err(e)),
-                }
-            })
-            .map(|result| match result {
-                Ok(s) => Ok(serde_json::from_str::<api::Result>(&s)??),
-                Err(e) => Err(AnswerAPIError::EventSource(e)),
+            Ok::<_, anyhow::Error>(serde_json::json!({
+                "explanations": explanations,
+                "path": path,
             }))
-    }
-
-    #[allow(dead_code)]
-    async fn send_until_success(
-        &self,
-        messages: api::Messages,
-        max_tokens: u32,
-        temperature: f32,
-        provider: api::Provider,
-        extra_stop_sequences: Vec<String>,
-    ) -> Result<impl Stream<Item = Result<String, AnswerAPIError>>, AnswerAPIError> {
-        const DELAY: [Duration; 5] = [
-            Duration::from_secs(0),
-            Duration::from_secs(2),
-            Duration::from_secs(4),
-            Duration::from_secs(8),
-            Duration::from_secs(16),
-        ];
-
-        for attempt in 0..self.max_attempts {
-            warn!(%attempt, "delaying by {:?}", DELAY[attempt as usize % 5]);
-            tokio::time::sleep(DELAY[attempt as usize % 5]).await;
-
-            let result = self
-                .send(
-                    messages.clone(),
-                    max_tokens,
-                    temperature,
-                    provider.clone(),
-                    extra_stop_sequences.clone(),
-                )
-                .await;
-
-            match result {
-                Ok(r) => return Ok(r),
-                Err(e) => warn!(%attempt, "answer-api returned {e:?} ... retrying"),
-            }
-        }
-        Err(AnswerAPIError::MaxAttemptsReached(self.max_attempts))
-    }
-}
-
-const DELIMITER: &str = "=========";
-impl<'a> AnswerAPIClient<'a> {
-    fn build_select_prompt(&self, query: &str, snippets: &[Snippet]) -> api::Messages {
-        // snippets are 1-indexed so we can use index 0 where no snippets are relevant
-        let token_count = self
-            .semantic
-            .gpt2_token_count(include_str!("../prompt/select.txt"));
-        let mut system = snippets
-            .iter()
-            .enumerate()
-            .map(|(i, snippet)| {
-                format!(
-                    "Repository: {}\nPath: {}\nLanguage: {}\nIndex: {}\n\n{}\n{DELIMITER}\n",
-                    snippet.repo_name,
-                    snippet.relative_path,
-                    snippet.lang,
-                    i + 1,
-                    snippet.text
-                )
-            })
-            .fold(
-                (token_count, String::default()),
-                |(count, mut prompt), entry| {
-                    let new_count = count + self.semantic.gpt2_token_count(&entry);
-                    if new_count < api::Provider::OpenAi.token_limit() {
-                        prompt.push_str(&entry);
-                        (new_count, prompt)
-                    } else {
-                        debug!("evicting a snippet!");
-                        (count, prompt)
-                    }
-                },
-            )
-            .1;
-
-        // the example question/answer pair helps reinforce that we want exactly a single
-        // number in the output, with no spaces or punctuation such as fullstops.
-        system += &format!(
-            include_str!("../prompt/select.txt"),
-            COUNT = snippets.len(),
-            QUERY = &query,
-            DELIMITER = DELIMITER,
-        );
-
-        let messages = vec![api::Message {
-            role: "user".into(),
-            content: system.clone(),
-        }];
-
-        let tokens_used = self.semantic.gpt2_token_count(&system);
-        debug!(%tokens_used, "select prompt token count");
-
-        api::Messages { messages }
-    }
-
-    fn build_explain_prompt(
-        &self,
-        snippet: &Snippet,
-        conversation: &[(String, String)],
-        query: &str,
-    ) -> api::Messages {
-        let system = format!(
-            include_str!("../prompt/explain.txt"),
-            TEXT = snippet.text,
-            PATH = snippet.relative_path,
-            REPO = snippet.repo_name,
-        );
-
-        let mut messages = vec![api::Message {
-            role: "system".to_string(),
-            content: system,
-        }];
-
-        for (question, answer) in conversation {
-            messages.push(api::Message {
-                role: "user".to_string(),
-                content: question.clone(),
-            });
-            messages.push(api::Message {
-                role: "assistant".to_string(),
-                content: answer.clone(),
-            });
-        }
-
-        messages.push(api::Message {
-            role: "user".to_string(),
-            content: query.to_string(),
         });
 
-        api::Messages { messages }
+        let out = chunks
+            // This box seems unnecessary, but it avoids a compiler bug:
+            // https://github.com/rust-lang/rust/issues/64552
+            .boxed()
+            .buffered(5)
+            .filter_map(|res| async { res.ok() })
+            .collect::<Vec<_>>()
+            .await;
+
+        Ok(serde_json::to_string(&out)?)
     }
 }
 
-fn build_rephrase_query_prompt(query: &str, conversation: &[(String, String)]) -> api::Messages {
-    let mut system = include_str!("../prompt/rephrase.txt").to_string();
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
+enum Action {
+    /// A user-provided query.
+    Query(String),
 
-    for (question, answer) in conversation {
-        system.push_str(&format!("User: {}\n", question.clone()));
-        system.push_str(&format!("Assistant: {}\n", answer.clone()));
-    }
-    system.push_str(&format!("User: {}\n", query));
-    system.push_str("Query: ");
-
-    let messages = vec![api::Message {
-        role: "system".to_string(),
-        content: system,
-    }];
-
-    api::Messages { messages }
+    #[serde(rename = "ask")]
+    Prompt(String),
+    Path(String),
+    Answer(String),
+    Code(String),
+    File(FileRef),
+    Check(String, Vec<usize>),
 }
 
-// Measure time between instants statefully
-struct StopWatch {
-    start: Instant,
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[serde(untagged)]
+enum FileRef {
+    Path(String),
+    Alias(usize),
 }
 
-impl StopWatch {
-    // Start the watch
-    fn start() -> Self {
-        Self {
-            start: Instant::now(),
+impl Action {
+    /// Map this action to a summary update.
+    fn update(&self) -> Update {
+        match self {
+            Self::Answer(s) => Update::Answer(s.clone()),
+            Self::Prompt(s) => Update::Prompt(s.clone()),
+            Self::Query(..) => Update::ProcessingQuery,
+            Self::Code(..) => Update::SearchingFiles,
+            Self::Path(..) => Update::SearchingFiles,
+            Self::File(..) => Update::LoadingFiles,
+            Self::Check(..) => Update::Answering,
         }
     }
 
-    // Measure the time since start
-    fn measure(&self) -> Duration {
-        self.start.elapsed()
+    /// Deserialize this action from the GPT-tagged enum variant format.
+    ///
+    /// We convert:
+    ///
+    /// ```
+    /// ["type", "value"]
+    /// ["type", "arg1", "arg2"]
+    /// ```
+    ///
+    /// To:
+    ///
+    /// ```
+    /// {"type":"value"}
+    /// {"type":["arg1", "arg2"]}
+    /// ```
+    ///
+    /// So that we can deserialize using the serde-provided "tagged" enum representation.
+    fn deserialize_gpt(s: &str) -> Result<Self> {
+        let mut array = serde_json::from_str::<Vec<serde_json::Value>>(s)
+            .with_context(|| format!("model response was not a JSON array: {s}"))?;
+
+        if array.is_empty() {
+            bail!("model returned an empty array");
+        }
+
+        let action = array.remove(0);
+        let action = action.as_str().context("model action was not a string")?;
+
+        let value = if array.len() < 2 {
+            array.pop().unwrap_or(serde_json::Value::Null)
+        } else {
+            array.into()
+        };
+
+        let mut obj = serde_json::Map::new();
+        obj.insert(action.into(), value);
+        Ok(serde::Deserialize::deserialize(serde_json::Value::Object(
+            obj,
+        ))?)
     }
 
-    // Read the value since the last start, and zero the clock
-    fn lap(&mut self) -> Duration {
-        let duration = self.measure();
-        self.start = Instant::now();
-        duration
+    /// The inverse of `deserialize_gpt`; serializes this action into a format described by our
+    /// prompt.
+    fn serialize_gpt(&self) -> Result<String> {
+        let mut obj = serde_json::to_value(self)?;
+        let mut fields = mem::take(
+            obj.as_object_mut()
+                .context("action was not serialized as an object")?,
+        )
+        .into_iter()
+        .collect::<Vec<_>>();
+
+        if fields.len() != 1 {
+            bail!("action serialized to multiple keys");
+        }
+
+        let (k, v) = fields.pop().unwrap();
+        let k = k.into();
+        let array = match v {
+            serde_json::Value::Null => vec![k],
+            serde_json::Value::Array(a) => [vec![k], a].concat(),
+            other => vec![k, other],
+        };
+
+        Ok(serde_json::to_string(&array)?)
+    }
+}
+
+#[derive(serde::Serialize)]
+enum Update {
+    Prompt(String),
+    Answer(String),
+    ProcessingQuery,
+    SearchingFiles,
+    Answering,
+    LoadingFiles,
+}
+
+/// An action that may not have finished loading yet.
+struct ActionStream {
+    tokens: String,
+    action: Either<BoxStream<'static, Result<String>>, Action>,
+}
+
+impl ActionStream {
+    /// Load this action, partially parsing it if applicable, and pushing updates along the way.
+    async fn load(mut self, update: &Sender<Update>) -> Result<(Action, String)> {
+        static TAG_REGEX: Lazy<Regex> = Lazy::new(|| Regex::new(r#"\["(\w+)"#).unwrap());
+
+        let mut stream = match self.action {
+            Either::Left(stream) => stream,
+            Either::Right(action) => {
+                update
+                    .send(action.update())
+                    .await
+                    .or(Err(anyhow!("failed to send update")))?;
+                return Ok((action, self.tokens));
+            }
+        };
+
+        let tag = loop {
+            match TAG_REGEX.captures(&self.tokens) {
+                None => {
+                    self.tokens += &stream.next().await.context("stream ended early")??;
+                }
+
+                Some(m) => break m[1].to_owned(),
+            }
+        };
+
+        while let Some(token) = stream.next().await {
+            self.tokens += &token?;
+
+            // Stream partially-parsed answer strings.
+            //
+            // TODO: This is placed here temporarily, until we implement structured partial
+            // parsing.
+            if tag == "answer" {
+                static ANSWER_REGEX: Lazy<Regex> =
+                    Lazy::new(|| Regex::new(r#"^\["answer",\s*"(.*[^\\"\]])"#).unwrap());
+
+                if let Some(s) = ANSWER_REGEX.captures(&self.tokens) {
+                    update
+                        .send(Update::Answer(s[1].to_owned()))
+                        .await
+                        .map_err(|_| anyhow!("failed to send update"))?;
+                }
+            }
+        }
+
+        let action = Action::deserialize_gpt(&self.tokens)?;
+        update
+            .send(action.update())
+            .await
+            .or(Err(anyhow!("failed to send update")))?;
+
+        Ok((action, self.tokens))
+    }
+}
+
+impl From<Action> for Result<ActionStream> {
+    fn from(action: Action) -> Self {
+        Ok(ActionStream {
+            tokens: action.serialize_gpt()?,
+            action: Either::Right(action),
+        })
+    }
+}
+
+#[derive(Clone)]
+struct AppContext {
+    app: Application,
+    llm_gateway: llm_gateway::Client,
+}
+
+impl AppContext {
+    fn new(app: Application) -> Result<Self> {
+        let llm_gateway = llm_gateway::Client::new(&app.config.answer_api_url)
+            .temperature(0.0)
+            .bearer(app.github_token()?.map(|s| s.expose_secret().clone()));
+
+        Ok(Self { app, llm_gateway })
+    }
+
+    fn model(mut self, model: &str) -> Self {
+        if model.is_empty() {
+            self.llm_gateway.model = None;
+        } else {
+            self.llm_gateway.model = Some(model.to_owned());
+        }
+
+        self
     }
 }

--- a/server/bleep/src/webserver/answer/llm_gateway.rs
+++ b/server/bleep/src/webserver/answer/llm_gateway.rs
@@ -1,0 +1,165 @@
+//! A Rust-friendly interface to Bloop's LLM Gateway service.
+
+use anyhow::bail;
+use futures::{Stream, StreamExt};
+use reqwest_eventsource::EventSource;
+
+pub mod api {
+    #[derive(serde::Serialize, serde::Deserialize, Debug, Clone)]
+    pub struct Message {
+        pub role: String,
+        pub content: String,
+    }
+
+    #[derive(serde::Serialize, serde::Deserialize, Debug, Clone)]
+    pub struct Messages {
+        pub messages: Vec<Message>,
+    }
+
+    #[derive(Debug, serde::Serialize, serde::Deserialize)]
+    pub struct Request {
+        pub messages: Messages,
+        pub provider: Provider,
+        pub max_tokens: Option<u32>,
+        pub temperature: Option<f32>,
+        pub model: Option<String>,
+        #[serde(default)]
+        pub extra_stop_sequences: Vec<String>,
+    }
+
+    #[derive(Debug, Copy, Clone, serde::Serialize, serde::Deserialize)]
+    #[serde(rename_all = "lowercase")]
+    pub enum Provider {
+        OpenAi,
+        Anthropic,
+    }
+
+    #[derive(thiserror::Error, Debug, serde::Deserialize)]
+    pub enum Error {
+        #[error("bad OpenAI request")]
+        BadOpenAiRequest,
+
+        #[error("incorrect configuration")]
+        BadConfiguration,
+    }
+
+    pub type Result = std::result::Result<String, Error>;
+}
+
+impl api::Message {
+    pub fn new(role: &str, content: &str) -> Self {
+        Self {
+            role: role.to_owned(),
+            content: content.to_owned(),
+        }
+    }
+
+    pub fn system(content: &str) -> Self {
+        Self::new("system", content)
+    }
+
+    pub fn user(content: &str) -> Self {
+        Self::new("user", content)
+    }
+
+    pub fn assistant(content: &str) -> Self {
+        Self::new("assistant", content)
+    }
+}
+
+#[derive(Clone)]
+pub struct Client {
+    http: reqwest::Client,
+    pub base_url: String,
+
+    pub bearer_token: Option<String>,
+    pub temperature: Option<f32>,
+    pub max_tokens: Option<u32>,
+    pub provider: api::Provider,
+    pub model: Option<String>,
+}
+
+impl Client {
+    pub fn new(base_url: &str) -> Self {
+        Self {
+            http: reqwest::Client::new(),
+            base_url: base_url.to_owned(),
+
+            bearer_token: None,
+            provider: api::Provider::OpenAi,
+            temperature: None,
+            max_tokens: None,
+            model: None,
+        }
+    }
+
+    pub fn temperature(mut self, temperature: impl Into<Option<f32>>) -> Self {
+        self.temperature = temperature.into();
+        self
+    }
+
+    #[allow(unused)]
+    pub fn max_tokens(mut self, max_tokens: impl Into<Option<u32>>) -> Self {
+        self.max_tokens = max_tokens.into();
+        self
+    }
+
+    pub fn bearer(mut self, bearer: impl Into<Option<String>>) -> Self {
+        self.bearer_token = bearer.into();
+        self
+    }
+
+    pub async fn chat(
+        &self,
+        messages: &[api::Message],
+    ) -> anyhow::Result<impl Stream<Item = anyhow::Result<String>>> {
+        let mut event_source = Box::pin(
+            EventSource::new({
+                let mut builder = self.http.post(format!("{}/v1/q", self.base_url));
+
+                if let Some(bearer) = &self.bearer_token {
+                    builder = builder.bearer_auth(bearer);
+                }
+
+                builder.json(&api::Request {
+                    messages: api::Messages {
+                        messages: messages.to_owned(),
+                    },
+                    max_tokens: self.max_tokens,
+                    temperature: self.temperature,
+                    provider: self.provider,
+                    model: self.model.clone(),
+                    extra_stop_sequences: vec![],
+                })
+            })
+            // We don't have a `Stream` body so this can't fail.
+            .expect("couldn't clone requestbuilder")
+            // `reqwest_eventsource` returns an error to signify a stream end, instead of simply ending
+            // the stream. So we catch the error here and close the stream.
+            .take_while(|result| {
+                let is_end = matches!(result, Err(reqwest_eventsource::Error::StreamEnded));
+                async move { !is_end }
+            }),
+        );
+
+        match event_source.next().await {
+            Some(Ok(reqwest_eventsource::Event::Open)) => {}
+            Some(Err(e)) => bail!("event source error: {:?}", e),
+            _ => bail!("event source failed to open"),
+        }
+
+        Ok(event_source
+            .filter_map(|result| async move {
+                match result {
+                    Ok(reqwest_eventsource::Event::Message(msg)) => Some(Ok(msg.data)),
+                    Ok(reqwest_eventsource::Event::Open) => None,
+                    Err(reqwest_eventsource::Error::StreamEnded) => None,
+                    Err(e) => Some(Err(e)),
+                }
+            })
+            .map(|result| match result {
+                Ok(s) => Ok(serde_json::from_str::<api::Result>(&s)??),
+                Err(e) => bail!("event source error {e:?}"),
+            }))
+    }
+}

--- a/server/bleep/src/webserver/answer/partial_parse.rs
+++ b/server/bleep/src/webserver/answer/partial_parse.rs
@@ -1,0 +1,352 @@
+use std::borrow::Cow;
+
+/// Rectify a JSON value, closing delimiters as necessary.
+///
+/// Returns a tuple of `(value, rest)`.
+pub fn rectify_json(input: &str) -> (Cow<str>, &str) {
+    if input.is_empty() {
+        return ("null".into(), "");
+    }
+
+    for constant in ["true", "false", "null"] {
+        if let Some(s) = input.strip_prefix(constant) {
+            return (constant.into(), s);
+        }
+    }
+
+    match input.chars().next().unwrap() {
+        '"' => rectify_str(input),
+        '[' => rectify_array(input),
+        '{' => rectify_object(input),
+        d if input.trim().starts_with(|c: char| c.is_ascii_digit()) => rectify_number(input),
+        c => panic!("malformed JSON value: `{c}`"),
+    }
+}
+
+fn rectify_str(input: &str) -> (Cow<str>, &str) {
+    let mut rest = &input[1..];
+    let mut escape = false;
+
+    // we have just `"` close it off with `"`
+    if rest.is_empty() {
+        return ("\"\"".into(), "");
+    }
+
+    for (len, c) in rest.chars().enumerate() {
+        rest = &rest[1..];
+
+        match c {
+            '\\' => escape = !escape,
+            '"' => {
+                if !escape {
+                    return (input[..len + 2].into(), rest);
+                } else {
+                    escape = false;
+                }
+            }
+            _ => {
+                if escape {
+                    escape = false
+                }
+            }
+        }
+    }
+
+    if escape {
+        let s = format!("{}\"", &input[..input.len() - 1]);
+        (s.into(), "")
+    } else {
+        ((input.to_owned() + "\"").into(), "")
+    }
+}
+
+fn rectify_array(input: &str) -> (Cow<str>, &str) {
+    let mut buf = String::from("[");
+    let mut rest = &input[1..];
+
+    rest = consume_whitespace(rest);
+
+    // we have just `[` close it off with `]`
+    if rest.is_empty() {
+        buf += "]";
+    }
+
+    let mut continuing = false;
+    while !rest.is_empty() {
+        let (value, r) = rectify_json(rest);
+        if continuing {
+            buf.push(',');
+            continuing = false;
+        }
+        buf += &value;
+        rest = r;
+
+        rest = consume_whitespace(rest);
+
+        match rest.chars().next() {
+            // end of this object
+            Some(']') => {
+                rest = &rest[1..];
+                buf.push(']');
+                break;
+            }
+
+            // expecting more objects ... or not
+            Some(',') => {
+                // we need to look further ahead:
+                // - if we have more content, we may append a `,`
+                // - if we cannot produce another json object, do not append `,`
+                rest = &rest[1..];
+                rest = consume_whitespace(rest);
+                if !rest.is_empty() {
+                    continuing = true;
+                }
+            }
+            None => {}
+            c => panic!("malformed JSON array: `{c:?}`"),
+        }
+
+        rest = consume_whitespace(rest);
+
+        if rest.is_empty() {
+            buf += "]";
+            break;
+        }
+    }
+
+    (buf.into(), rest)
+}
+
+fn rectify_number(input: &str) -> (Cow<str>, &str) {
+    let mut last = None;
+    let mut rest = &input[..];
+
+    for i in 0..input.len() {
+        if input[..i + 1].parse::<f64>().is_ok() {
+            last = Some(&input[..i + 1]);
+            rest = &rest[1..];
+        } else {
+            break;
+        }
+    }
+
+    (last.unwrap_or("").into(), rest)
+}
+
+fn rectify_object(input: &str) -> (Cow<str>, &str) {
+    let mut buf = String::from("{");
+    let mut rest = &input[1..];
+
+    rest = consume_whitespace(&rest);
+
+    // we have just `{` close it off with `}`
+    if rest.is_empty() {
+        buf += "}";
+    }
+
+    let mut continuing = false;
+    while !rest.is_empty() {
+        let (value, r) = rectify_str(rest);
+        if continuing {
+            buf.push(',');
+            continuing = false;
+        }
+        buf += &value;
+        rest = r;
+
+        rest = consume_whitespace(&rest);
+
+        match rest.chars().next() {
+            Some(':') => {
+                rest = &rest[1..];
+                buf += ":";
+            }
+            None => {
+                buf += ":null}";
+                break;
+            }
+            // beyond repair here
+            c => panic!("malformed JSON object: `{c:?}`"),
+        }
+
+        rest = consume_whitespace(&rest);
+
+        let (value, r) = rectify_json(rest);
+        buf += &value;
+        rest = r;
+
+        rest = consume_whitespace(&rest);
+
+        match rest.chars().next() {
+            // expecting more objects ... or not
+            Some(',') => {
+                // we need to look further ahead:
+                // - if we have more content, we may append a `,`
+                // - if we cannot produce another json object, do not append `,`
+                rest = &rest[1..];
+                rest = consume_whitespace(rest);
+                if !rest.is_empty() {
+                    continuing = true;
+                }
+            }
+            // end of object
+            Some('}') => {
+                rest = &rest[1..];
+                buf += "}";
+                break;
+            }
+            // end of stream, not much to do here
+            None => {
+                buf += "}";
+                break;
+            }
+            _ => panic!("malformed JSON object"),
+        }
+    }
+
+    (buf.into(), rest)
+}
+
+fn consume<F: Fn(char) -> bool + Copy>(mut rest: &str, f: F) -> (String, &str) {
+    let mut buf = String::new();
+
+    while rest.starts_with(f) {
+        buf.push(rest.chars().next().unwrap());
+        rest = &rest[1..];
+    }
+
+    (buf, rest)
+}
+
+fn consume_whitespace(rest: &str) -> &str {
+    consume(rest, |c| c.is_whitespace()).1
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_rectify_string() {
+        let (value, rest) = rectify_json("\"\"");
+        assert_eq!(value, "\"\"");
+        assert_eq!(rest, "");
+
+        let (value, rest) = rectify_json("\"");
+        assert_eq!(value, "\"\"");
+        assert_eq!(rest, "");
+
+        let (value, rest) = rectify_json("\"abc");
+        assert_eq!(value, "\"abc\"");
+        assert_eq!(rest, "");
+
+        let (value, rest) = rectify_json("\"abc\\");
+        assert_eq!(value, "\"abc\"");
+        assert_eq!(rest, "");
+
+        let (value, rest) = rectify_json("\"abc\\\"");
+        assert_eq!(value, "\"abc\\\"\"");
+        assert_eq!(rest, "");
+
+        let (value, rest) = rectify_json("\"abc\"foo");
+        assert_eq!(value, "\"abc\"");
+        assert_eq!(rest, "foo");
+    }
+
+    #[test]
+    fn test_rectify_array() {
+        let (value, rest) = rectify_json(r#"["foo", "bar","baaz"   ,  "fred" ]foo"#);
+        assert_eq!(value, r#"["foo","bar","baaz","fred"]"#);
+        assert_eq!(rest, "foo");
+
+        let (value, rest) = rectify_json(r#"["foo", "bar","baaz"   ,  "fred""#);
+        assert_eq!(value, r#"["foo","bar","baaz","fred"]"#);
+        assert_eq!(rest, "");
+
+        let (value, rest) = rectify_json(r#"["cite",1"#);
+        assert_eq!(value, r#"["cite",1]"#);
+        assert_eq!(rest, "");
+
+        let (value, rest) = rectify_json("[[\"cite\",1],\n");
+        assert_eq!(value, "[[\"cite\",1]]");
+        assert_eq!(rest, "");
+
+        let (value, rest) = rectify_json("[[\"cite\",1],\n[");
+        assert_eq!(value, "[[\"cite\",1],[]]");
+        assert_eq!(rest, "");
+
+        let (value, rest) = rectify_json("[[\"cite\",1],\n[\"");
+        assert_eq!(value, "[[\"cite\",1],[\"\"]]");
+        assert_eq!(rest, "");
+
+        let (value, rest) = rectify_json("[[\"cite\",1],\n[\"cite\",");
+        assert_eq!(value, "[[\"cite\",1],[\"cite\"]]");
+        assert_eq!(rest, "");
+    }
+
+    #[test]
+    fn test_rectify_number() {
+        let (value, rest) = rectify_json("123");
+        assert_eq!(value, "123");
+        assert_eq!(rest, "");
+
+        let (value, rest) = rectify_json("123.4");
+        assert_eq!(value, "123.4");
+        assert_eq!(rest, "");
+
+        let (value, rest) = rectify_json("1, \"");
+        assert_eq!(value, "1");
+        assert_eq!(rest, ", \"");
+    }
+
+    #[test]
+    fn test_rectify_object() {
+        let (value, rest) = rectify_json(r#"{"foo":"bar"}"#);
+        assert_eq!(value, r#"{"foo":"bar"}"#);
+        assert_eq!(rest, "");
+
+        let (value, rest) = rectify_json(r#"{"foo":"bar""#);
+        assert_eq!(value, r#"{"foo":"bar"}"#);
+        assert_eq!(rest, "");
+
+        let (value, rest) = rectify_json(r#"{"foo":"bar"#);
+        assert_eq!(value, r#"{"foo":"bar"}"#);
+        assert_eq!(rest, "");
+
+        let (value, rest) = rectify_json(r#"{"foo":""#);
+        assert_eq!(value, r#"{"foo":""}"#);
+        assert_eq!(rest, "");
+
+        let (value, rest) = rectify_json(r#"{"foo":"#);
+        assert_eq!(value, r#"{"foo":null}"#);
+        assert_eq!(rest, "");
+
+        let (value, rest) = rectify_json(r#"{"foo""#);
+        assert_eq!(value, r#"{"foo":null}"#);
+        assert_eq!(rest, "");
+
+        let (value, rest) = rectify_json(r#"{"fo""#);
+        assert_eq!(value, r#"{"fo":null}"#);
+        assert_eq!(rest, "");
+
+        let (value, rest) = rectify_json(r#"{"#);
+        assert_eq!(value, r#"{}"#);
+        assert_eq!(rest, "");
+
+        let (value, rest) = rectify_json(r#"{"foo": {"bar": "baz"}"#);
+        assert_eq!(value, r#"{"foo":{"bar":"baz"}}"#);
+        assert_eq!(rest, "");
+
+        let (value, rest) = rectify_json(r#"{"foo": ["hello"#);
+        assert_eq!(value, r#"{"foo":["hello"]}"#);
+        assert_eq!(rest, "");
+
+        let (value, rest) = rectify_json(r#"{"foo": {"bar""#);
+        assert_eq!(value, r#"{"foo":{"bar":null}}"#);
+        assert_eq!(rest, "");
+
+        let (value, rest) = rectify_json("{\"oldFileName\": \"config.rs\",\n\"new\"");
+        assert_eq!(value, "{\"oldFileName\":\"config.rs\",\"new\":null}");
+        assert_eq!(rest, "");
+    }
+}

--- a/server/bleep/src/webserver/answer/prompts.rs
+++ b/server/bleep/src/webserver/answer/prompts.rs
@@ -1,0 +1,73 @@
+//! Various prompts passed to the LLM.
+
+pub const INITIAL_PROMPT: &str = r#"["ask","Hi there, what can I help you with?"]"#;
+
+pub const CONTINUE: &str = "Is there anything else I can help with?";
+
+pub const SYSTEM: &str = r#"You must adhere to the following rules at all times:
+1. Your job is to act as a decision maker answering user's questions about the codebase.
+2. Decide which ACTION should be taken next.
+3. Do not repeat an ACTION.
+4. Do not assume the structure of the codebase, or the existence of files or folders.
+5. Respond only in valid JSON format.
+6. If an ACTION does not provide new information to answer the question, try a different ACTION or change your search terms.
+7. Only reply to the user with the "answer" ACTION. Do not include any text before or after the ACTION.
+8. If your answer involves a list of files, complete the list using the "path" ACTION.
+9. Check all possible files for answers before answering.
+10. If the user asks for two things at once, tell them that the query is too complicated and to politely ask their questions separately.
+11. The user's question is related to the codebase.
+12. You can only perform one action at a time.
+13. If a path has an alias, use the alias instead of the full path when using the path with an action.
+
+Below is a list of available ACTIONS:
+
+1. Search code using semantic search
+["code",STRING: SEARCH TERMS]
+Returns a list of paths and relevant code.
+
+2. Search file paths using exact text match
+["path",STRING: SEARCH TERMS]
+To list all files within a repo, leave the search terms blank.
+To find all files from a particular programming language, write a single file extension.
+To search for all files within a folder, write just the name of the folder.
+
+3. Read a file's contents
+["file",INT: §ALIAS]
+OR
+["file",STRING: PATH]
+Retrieve the contents of a single file.
+
+4. Check files for answer
+["check",STRING: QUESTION,INT[]: §ALIAS FOR EACH FILE]
+Check more than one file. Do not use this action if you are only checking one file.
+Do not check the same file more than once.
+
+5. Answer a question
+["answer",STRING: ANSWER]
+Only answer after you have made a search. The answer text MUST be a string, and human readable."#;
+
+pub fn file_explanation(question: &str, path: &str, code: &str) -> String {
+    format!(
+        r#"Here's the contents of the code file {path} in <code> tags:
+
+<code>
+{code}
+</code>
+
+The code is one file of many that can help answer a user query.
+
+The user's query is: {question}
+
+Answer in the following JSON format, identifying any relevant line ranges:
+[{{
+"start":int,
+"end":int,
+"answer":[natural language description]
+}}]
+
+If the user's query cannot be answered by the file do not answer, instead reply with "0".
+
+Do not repeat the question in your answer.
+Do not make any assumptions, your answer should only refer to insights taken from the code."#
+    )
+}

--- a/server/bleep/src/webserver/answer/prompts.rs
+++ b/server/bleep/src/webserver/answer/prompts.rs
@@ -11,13 +11,15 @@ pub const SYSTEM: &str = r#"You must adhere to the following rules at all times:
 4. Do not assume the structure of the codebase, or the existence of files or folders.
 5. Respond only in valid JSON format.
 6. If an ACTION does not provide new information to answer the question, try a different ACTION or change your search terms.
-7. Only reply to the user with the "answer" ACTION. Do not include any text before or after the ACTION.
-8. If your answer involves a list of files, complete the list using the "path" ACTION.
-9. Check all possible files for answers before answering.
+7. Only reply to the user with the "answer" ACTION.
+8. Do not use the answer action without first making a search.
+9. Check all possible files for answers before answering. Gather all information necessary to write a comprehensive answer, before using the answer ACTION.
 10. If the user asks for two things at once, tell them that the query is too complicated and to politely ask their questions separately.
 11. The user's question is related to the codebase.
 12. You can only perform one action at a time.
 13. If a path has an alias, use the alias instead of the full path when using the path with an action.
+
+#####
 
 Below is a list of available ACTIONS:
 
@@ -42,9 +44,11 @@ Retrieve the contents of a single file.
 Check more than one file. Do not use this action if you are only checking one file.
 Do not check the same file more than once.
 
-5. Answer a question
-["answer",STRING: ANSWER]
-Only answer after you have made a search. The answer text MUST be a string, and human readable."#;
+5. State that you are ready to answer the question after absolutely all information has been gathered
+["answer",STRING: STANDALONE USER REQUEST]
+Signal that you are ready to answer the user's request. Do not write your response.
+Your STANDALONE USER REQUEST should be based on all of the previous conversation with the user.
+It should be possible to understand from this string alone what the user is asking for."#;
 
 pub fn file_explanation(question: &str, path: &str, code: &str) -> String {
     format!(
@@ -69,5 +73,54 @@ If the user's query cannot be answered by the file do not answer, instead reply 
 
 Do not repeat the question in your answer.
 Do not make any assumptions, your answer should only refer to insights taken from the code."#
+    )
+}
+
+pub fn final_explanation_prompt(context: &str, question: &str) -> String {
+    format!(
+        r#"{context}#####
+Above are several pieces of information that can help you answer a user query.
+
+The user's query is "{question}"
+
+Your answer should be in the following JSON format: a list of objects, where each object represents one instance of:
+
+1. citing a single file from the codebase (this object can appear multiple times, in the form of a JSON array)
+START LINE and END LINE should focus on the code mentioned in the COMMENT.
+
+[["cite",INT: §ALIAS, STRING: COMMENT, INT: START LINE, INT: END LINE],
+["cite",INT: §ALIAS, STRING: COMMENT, INT: START LINE, INT: END LINE]]
+
+2. write a new code file (this object can appear multiple times)
+Do not use this to demonstrate updating an existing file.
+
+["new",STRING: LANGUAGE,STRING: CODE]
+
+3. update the code in an existing file (this object can appear multiple times)
+This is the best way to demonstrate updating an existing file.
+Changes should be as small as possible.
+
+["mod",INT: §ALIAS,CHANGES]
+Where CHANGES is an array of changes in the format:
+{{
+  oldFileName: 'oldfile', newFileName: 'newfile',
+  oldHeader: 'header1', newHeader: 'header2',
+  hunks: [{{
+    oldStart: 1, oldLines: 3, newStart: 1, newLines: 3,
+    lines: [' line2', ' line3', '-line4', '+line5', '\\ No newline at end of file'],
+  }}]
+}}
+The 'lines' array should contain each line of code within the line range.
+If you are adding a line, put a '+' at the start of the line.
+If you are removing a line, put a '-' at the start of the line.
+
+4. conclusion (this object is mandatory and must appear once at the end)
+
+["con",STRING: COMMENT]
+
+Your response should be a JSON array of objects.
+Refer to directories by their full paths, surrounded by single backticks.
+
+#####"#
     )
 }

--- a/server/bleep/src/webserver/github.rs
+++ b/server/bleep/src/webserver/github.rs
@@ -76,7 +76,7 @@ pub(super) async fn login(Extension(app): Extension<Application>) -> impl IntoRe
     let codes = github
         .authenticate_as_device(&client_id, ["public_repo", "repo", "read:org"])
         .await
-        .map_err(|_| Error::internal("failed to authenticate as device"))?;
+        .map_err(|e| Error::internal(format!("failed to authenticate as device: {e:?}")))?;
 
     tokio::spawn(poll_for_oauth_token(
         github,

--- a/server/bleep/src/webserver/semantic.rs
+++ b/server/bleep/src/webserver/semantic.rs
@@ -63,7 +63,7 @@ pub(super) async fn raw_chunks(
     }
 }
 
-fn kind_to_value(kind: Option<Kind>) -> serde_json::Value {
+pub fn kind_to_value(kind: Option<Kind>) -> serde_json::Value {
     match kind {
         Some(Kind::NullValue(_)) => serde_json::Value::Null,
         Some(Kind::BoolValue(v)) => serde_json::Value::Bool(v),


### PR DESCRIPTION
**Note: This PR is set to merge into `answer-tooling`, not `main`.**

---

Here, we utilize the LLM to answer questions by giving it several actions to select from. Each action operates on our data in some way, for example the `path` action will search for files. The responses to these actions build up knowledge for the LLM such that it can answer questions better.

The `answer` module was entirely rewritten, and split up. A new `llm_gateway` module holds an interface to the "Answer API", and we also split prompts out into their own module.

### Remaining back-end work:

- [ ] Integration with fuzzy path search
- [ ] Truncation of message history
- [ ] Structured answer format