### PR TITLE
allow multiple repo and lang filters in NL queries

### DIFF
--- a/server/bleep/src/semantic.rs
+++ b/server/bleep/src/semantic.rs
@@ -178,18 +178,33 @@ impl Semantic {
             anyhow::bail!("no search target for query");
         };
 
-        let repo_filter = parsed_query
-            .repo()
-            .map(|r| make_kv_filter("repo_name", r).into());
+        let repo_filter: qdrant_client::qdrant::Condition = {
+            let conditions = parsed_query
+                .repos()
+                .map(|r| make_kv_filter("repo_name", r).into())
+                .collect();
+            // one of the above repos should match
+            Filter {
+                should: conditions,
+                ..Default::default()
+            }
+        }
+        .into();
 
-        let lang_filter = parsed_query
-            .lang()
-            .map(|l| make_kv_filter("lang", l).into());
+        let lang_filter: qdrant_client::qdrant::Condition = {
+            let conditions = parsed_query
+                .langs()
+                .map(|l| make_kv_filter("lang", l).into())
+                .collect();
+            // one of the above langs should match
+            Filter {
+                should: conditions,
+                ..Default::default()
+            }
+        }
+        .into();
 
-        let filters = [repo_filter, lang_filter]
-            .into_iter()
-            .flatten()
-            .collect::<Vec<_>>();
+        let filters = vec![repo_filter, lang_filter];
 
         let response = self
             .qdrant


### PR DESCRIPTION
- adding more than one repo/lang filter works as a combination operation
- if multiple repo and lang filters are present, one of the repo filters should match, in conjunction with one of the lang filters.