### PR TITLE
prepend repo queries with `github.com/` when necessary

### DIFF
--- a/server/bleep/src/semantic.rs
+++ b/server/bleep/src/semantic.rs
@@ -182,7 +182,7 @@ impl Semantic {
             let conditions = parsed_query
                 .repos()
                 .map(|r| {
-                    if r.contains('/') {
+                    if r.contains('/') && !r.starts_with("github.com/") {
                         format!("github.com/{r}")
                     } else {
                         r.to_string()


### PR DESCRIPTION
- remote repo names are prepended with `github.com/`
- this changeset also removes repo or lang filters if they are empty