### PR TITLE
Disable liveness check

### DIFF
--- a/helm/bloop/values.yaml
+++ b/helm/bloop/values.yaml
@@ -131,7 +131,7 @@ qdrant:
         checksEnabled: false
 
   livenessProbe:
-    enabled: true
+    enabled: false
     initialDelaySeconds: 60
     periodSeconds: 10
     timeoutSeconds: 1


### PR DESCRIPTION
This will give qdrant enough time to load documents.
As we still keep rediness check enabled, bloop app with restart until qdrant is ready