### PR TITLE
Fix `case:ignore` in path searches

### DIFF
--- a/server/bleep/src/webserver/query.rs
+++ b/server/bleep/src/webserver/query.rs
@@ -19,7 +19,7 @@ use async_trait::async_trait;
 use axum::{extract::Query, response::IntoResponse as IntoAxumResponse, Extension};
 use regex::{
     bytes::{Regex as ByteRegex, RegexBuilder as ByteRegexBuilder},
-    Regex,
+    Regex, RegexBuilder,
 };
 use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
@@ -440,8 +440,15 @@ impl ExecuteQuery for FileReader {
             .filter(|q| self.query_matches(q))
             .filter_map(|q| {
                 let regex_str = q.path.as_ref()?.regex_str();
-                let regex = Regex::new(&regex_str).ok()?;
-                let byte_regex = ByteRegex::new(&regex_str).ok()?;
+                let case_insensitive = !q.case_sensitive.unwrap_or(true);
+                let regex = RegexBuilder::new(&regex_str)
+                    .case_insensitive(case_insensitive)
+                    .build()
+                    .ok()?;
+                let byte_regex = ByteRegexBuilder::new(&regex_str)
+                    .case_insensitive(case_insensitive)
+                    .build()
+                    .ok()?;
                 Some((regex, byte_regex))
             })
             .unzip();


### PR DESCRIPTION
Now we make sure to set the `case_insensitive` option on the generated regex.