### PR TITLE
fix crashes on NL parser

### DIFF
--- a/server/bleep/src/query/grammar.pest
+++ b/server/bleep/src/query/grammar.pest
@@ -53,4 +53,5 @@ group = !{ group_start ~ intersection ~ group_end }
 WHITESPACE = _{ " " }
 
 // natural language queries
-nl_query = _{ SOI ~ (label | mode | literal)* ~ EOI }
+raw_text = @{ (!WHITESPACE ~ ANY)+ }
+nl_query = _{ SOI ~ (label | mode | raw_text)* ~ EOI }


### PR DESCRIPTION
NL parser would only accept literals that were valid in the context of regex search. This patch permits arbitrary text in the target field of NLQuery.