### PR TITLE
Add conversation API, introduce `Exchange` history

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,8 @@ server/schema
 server/target
 server/tmp_index
 
+server/bleep/bleep.db*
+
 playwright-report
 .tests.env
 

--- a/.taurignore
+++ b/.taurignore
@@ -1,0 +1,1 @@
+server/bleep/bleep.db*

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -266,6 +266,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atoi"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c57d12312ff59c811c0643f4d80830505833c9ffaebd193d819392b265be8e"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "attohttpc"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -509,6 +518,7 @@ dependencies = [
  "serde_json",
  "serde_yaml 0.9.21",
  "smallvec",
+ "sqlx",
  "tantivy",
  "tempdir",
  "thiserror",
@@ -1202,6 +1212,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86ec7a15cbe22e59248fc7eadb1907dab5ba09372595da4d73dd805ed4417dfe"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cace84e55f07e7301bae1c519df89cdad8cc3cd868413d3fdbdeca9ff3db484"
+
+[[package]]
 name = "crc32fast"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1632,6 +1657,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
 name = "downcast-rs"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1663,6 +1694,9 @@ name = "either"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "embed_plist"
@@ -1736,6 +1770,12 @@ checksum = "1f748b253ceca9fed5f42f8b5ceb3851e93102199bc25b64b65369f76e5c0a35"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "event-listener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
 name = "eventsource-stream"
@@ -2007,6 +2047,17 @@ dependencies = [
  "futures-core",
  "futures-task",
  "futures-util",
+]
+
+[[package]]
+name = "futures-intrusive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a604f7a68fbf8103337523b1fadc8ade7361ee3f112f7c680ad179651616aed5"
+dependencies = [
+ "futures-core",
+ "lock_api",
+ "parking_lot 0.11.2",
 ]
 
 [[package]]
@@ -2468,7 +2519,7 @@ dependencies = [
  "jwalk",
  "libc",
  "once_cell",
- "parking_lot",
+ "parking_lot 0.12.1",
  "prodash",
  "sha1_smol",
  "thiserror",
@@ -2514,7 +2565,7 @@ checksum = "afebb85691c6a085b114e01a27f4a61364519298c5826cb87a45c304802299bc"
 dependencies = [
  "gix-hash",
  "hashbrown 0.13.2",
- "parking_lot",
+ "parking_lot 0.12.1",
 ]
 
 [[package]]
@@ -2605,7 +2656,7 @@ dependencies = [
  "gix-pack",
  "gix-path",
  "gix-quote",
- "parking_lot",
+ "parking_lot 0.12.1",
  "tempfile",
  "thiserror",
 ]
@@ -2627,7 +2678,7 @@ dependencies = [
  "gix-tempfile",
  "gix-traverse",
  "memmap2",
- "parking_lot",
+ "parking_lot 0.12.1",
  "smallvec",
  "thiserror",
  "uluru",
@@ -2664,7 +2715,7 @@ checksum = "78c5086dbabb66cb29d1dec4636cc0357e76fc95da682c149ec96dd97222697f"
 dependencies = [
  "gix-command",
  "gix-config-value",
- "parking_lot",
+ "parking_lot 0.12.1",
  "rustix",
  "thiserror",
 ]
@@ -2765,7 +2816,7 @@ checksum = "c2ceb30a610e3f5f2d5f9a5114689fde507ba9417705a8cf3429604275b2153c"
 dependencies = [
  "libc",
  "once_cell",
- "parking_lot",
+ "parking_lot 0.12.1",
  "signal-hook",
  "signal-hook-registry",
  "tempfile",
@@ -3036,6 +3087,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 
 [[package]]
+name = "hashlink"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69fe1fcf8b4278d860ad0548329f892a3631fb63f82574df68275f34cdbe0ffa"
+dependencies = [
+ "hashbrown 0.12.3",
+]
+
+[[package]]
 name = "hdrhistogram"
 version = "7.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3087,6 +3147,9 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "hermit-abi"
@@ -3738,6 +3801,17 @@ name = "libc"
 version = "0.2.142"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a987beff54b60ffa6d51982e1aa1146bc42f19bd26be28b0586f252fccf5317"
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "898745e570c7d0453cc1fbc4a701eb6c662ed54e8fec8b7d14be137ebeeb9d14"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "line-wrap"
@@ -4571,12 +4645,37 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
+dependencies = [
+ "instant",
+ "lock_api",
+ "parking_lot_core 0.8.6",
+]
+
+[[package]]
+name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
  "lock_api",
- "parking_lot_core",
+ "parking_lot_core 0.9.7",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
+dependencies = [
+ "cfg-if",
+ "instant",
+ "libc",
+ "redox_syscall 0.2.16",
+ "smallvec",
+ "winapi",
 ]
 
 [[package]]
@@ -6189,6 +6288,105 @@ dependencies = [
 ]
 
 [[package]]
+name = "sqlformat"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c12bc9199d1db8234678b7051747c07f517cdcf019262d1847b94ec8b1aee3e"
+dependencies = [
+ "itertools 0.10.5",
+ "nom",
+ "unicode_categories",
+]
+
+[[package]]
+name = "sqlx"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8de3b03a925878ed54a954f621e64bf55a3c1bd29652d0d1a17830405350188"
+dependencies = [
+ "sqlx-core",
+ "sqlx-macros",
+]
+
+[[package]]
+name = "sqlx-core"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa8241483a83a3f33aa5fff7e7d9def398ff9990b2752b6c6112b83c6d246029"
+dependencies = [
+ "ahash 0.7.6",
+ "atoi",
+ "bitflags 1.3.2",
+ "byteorder",
+ "bytes",
+ "crc",
+ "crossbeam-queue",
+ "dotenvy",
+ "either",
+ "event-listener",
+ "flume",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-intrusive",
+ "futures-util",
+ "hashlink",
+ "hex",
+ "indexmap",
+ "itoa 1.0.6",
+ "libc",
+ "libsqlite3-sys",
+ "log",
+ "memchr",
+ "once_cell",
+ "paste",
+ "percent-encoding",
+ "serde",
+ "sha2",
+ "smallvec",
+ "sqlformat",
+ "sqlx-rt",
+ "stringprep",
+ "thiserror",
+ "tokio-stream",
+ "url",
+]
+
+[[package]]
+name = "sqlx-macros"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9966e64ae989e7e575b19d7265cb79d7fc3cbbdf179835cb0d716f294c2049c9"
+dependencies = [
+ "dotenvy",
+ "either",
+ "heck 0.4.1",
+ "hex",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "sha2",
+ "sqlx-core",
+ "sqlx-rt",
+ "syn 1.0.109",
+ "url",
+]
+
+[[package]]
+name = "sqlx-rt"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "804d3f245f894e61b1e6263c84b23ca675d96753b5abfd5cc8597d86806e8024"
+dependencies = [
+ "native-tls",
+ "once_cell",
+ "tokio",
+ "tokio-native-tls",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6217,7 +6415,7 @@ checksum = "f91138e76242f575eb1d3b38b4f1362f10d3a43f47d182a5b359af488a02293b"
 dependencies = [
  "new_debug_unreachable",
  "once_cell",
- "parking_lot",
+ "parking_lot 0.12.1",
  "phf_shared 0.10.0",
  "precomputed-hash",
  "serde",
@@ -6233,6 +6431,16 @@ dependencies = [
  "phf_shared 0.10.0",
  "proc-macro2",
  "quote",
+]
+
+[[package]]
+name = "stringprep"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee348cb74b87454fff4b551cbf727025810a004f88aeacae7f85b87f4e9a1c1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
 ]
 
 [[package]]
@@ -6442,7 +6650,7 @@ dependencies = [
  "ndk-sys",
  "objc",
  "once_cell",
- "parking_lot",
+ "parking_lot 0.12.1",
  "paste",
  "png",
  "raw-window-handle",

--- a/bleep.db
+++ b/bleep.db
@@ -1,0 +1,1 @@
+server/bleep/bleep.db

--- a/server/bleep/Cargo.toml
+++ b/server/bleep/Cargo.toml
@@ -37,6 +37,7 @@ clap = { version = "4.1.4", features = ["derive"] }
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.16", features = ["env-filter", "registry"] }
 color-eyre = "0.6.2"
+sqlx = { version = "0.6.3", features = ["sqlite", "migrate", "offline", "runtime-tokio-native-tls"] }
 
 # for debugging
 console-subscriber = { version = "0.1.8", optional = true }

--- a/server/bleep/build.rs
+++ b/server/bleep/build.rs
@@ -15,6 +15,7 @@ struct Language {
 fn main() {
     set_index_version();
     process_languages();
+    println!("cargo:rerun-if-changed=migrations");
 }
 
 fn set_index_version() {

--- a/server/bleep/migrations/20230424095042_conversations.sql
+++ b/server/bleep/migrations/20230424095042_conversations.sql
@@ -1,0 +1,17 @@
+CREATE TABLE conversations (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    created_at INTEGER NOT NULL,
+    user_id TEXT NOT NULL,
+    thread_id TEXT NOT NULL,
+    repo_ref TEXT NOT NULL,
+    -- JSON array of strings
+    path_aliases TEXT NOT NULL
+);
+
+CREATE TABLE messages (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    conversation_id INTEGER REFERENCES conversations (id) ON DELETE CASCADE,
+    ordinal INTEGER NOT NULL,
+    role TEXT NOT NULL,
+    content TEXT NOT NULL
+);

--- a/server/bleep/migrations/20230424095042_conversations.sql
+++ b/server/bleep/migrations/20230424095042_conversations.sql
@@ -4,14 +4,10 @@ CREATE TABLE conversations (
     user_id TEXT NOT NULL,
     thread_id TEXT NOT NULL,
     repo_ref TEXT NOT NULL,
-    -- JSON array of strings
-    path_aliases TEXT NOT NULL
-);
+    title TEXT NOT NULL,
 
-CREATE TABLE messages (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    conversation_id INTEGER REFERENCES conversations (id) ON DELETE CASCADE,
-    ordinal INTEGER NOT NULL,
-    role TEXT NOT NULL,
-    content TEXT NOT NULL
+    -- JSON serialized fields
+    exchanges TEXT NOT NULL,
+    llm_history TEXT NOT NULL,
+    path_aliases TEXT NOT NULL
 );

--- a/server/bleep/sqlx-data.json
+++ b/server/bleep/sqlx-data.json
@@ -10,26 +10,42 @@
     },
     "query": "DELETE FROM conversations WHERE user_id = ? AND thread_id = ?"
   },
-  "65070b3ccabcae2f50e3010ff2d66c42cec6a8cbd11b0abe7c29e8b7ce12c87b": {
+  "5daa70448b2ce5c453ccf1993a632620b55dd85a15e0ae6d55171205ca3a236f": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Right": 7
+      }
+    },
+    "query": "INSERT INTO conversations (user_id, thread_id, repo_ref, title, exchanges, llm_history, path_aliases, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, strftime('%s', 'now'))"
+  },
+  "8224649272e8c092f30dc9da4c5e2fea845dd1b6a01de4614a02f2f878cb99bc": {
     "describe": {
       "columns": [
         {
-          "name": "id",
+          "name": "repo_ref",
           "ordinal": 0,
-          "type_info": "Int64"
+          "type_info": "Text"
         },
         {
-          "name": "repo_ref",
+          "name": "llm_history",
           "ordinal": 1,
           "type_info": "Text"
         },
         {
-          "name": "path_aliases",
+          "name": "exchanges",
           "ordinal": 2,
+          "type_info": "Text"
+        },
+        {
+          "name": "path_aliases",
+          "ordinal": 3,
           "type_info": "Text"
         }
       ],
       "nullable": [
+        false,
         false,
         false,
         false
@@ -38,9 +54,9 @@
         "Right": 2
       }
     },
-    "query": "SELECT id, repo_ref, path_aliases FROM conversations WHERE user_id = ? AND thread_id = ?"
+    "query": "SELECT repo_ref, llm_history, exchanges, path_aliases FROM conversations WHERE user_id = ? AND thread_id = ?"
   },
-  "7cc11708840a8317f33110dcff41a74c820527c9b043268cc2b4fc0ba8d694e9": {
+  "d5ee5becde7005920d7094fca5b7974bbf19713b3625fbf6d1a3e198e7cf4de4": {
     "describe": {
       "columns": [
         {
@@ -54,7 +70,7 @@
           "type_info": "Int64"
         },
         {
-          "name": "preview",
+          "name": "title",
           "ordinal": 2,
           "type_info": "Text"
         }
@@ -68,58 +84,6 @@
         "Right": 1
       }
     },
-    "query": "SELECT c.thread_id, c.created_at, messages.content as preview FROM conversations c JOIN ( SELECT conversation_id, min(ordinal) ordinal FROM messages WHERE role = \"user\" GROUP BY conversation_id ) m ON m.conversation_id = c.id JOIN messages ON messages.conversation_id = c.id AND messages.ordinal = m.ordinal WHERE c.user_id = ?"
-  },
-  "80640f5084d8cc0238fa8856f93240e427f5f3f2737744beeb7c4e69b26d11ff": {
-    "describe": {
-      "columns": [],
-      "nullable": [],
-      "parameters": {
-        "Right": 4
-      }
-    },
-    "query": "INSERT INTO messages (conversation_id, ordinal, role, content) VALUES (?, ?, ?, ?)"
-  },
-  "a25e7837a4a1bb09cafb917b0214307e17bca829b1e94d441b442c4f9c050fdf": {
-    "describe": {
-      "columns": [
-        {
-          "name": "id",
-          "ordinal": 0,
-          "type_info": "Int64"
-        }
-      ],
-      "nullable": [
-        false
-      ],
-      "parameters": {
-        "Right": 4
-      }
-    },
-    "query": "INSERT INTO conversations (repo_ref, user_id, thread_id, path_aliases, created_at) VALUES (?, ?, ?, ?, strftime('%s', 'now')) RETURNING id"
-  },
-  "e9cf879bf7b6efb8c5fc587a649be52010f7fa8e09c353154d9dd83607e2a970": {
-    "describe": {
-      "columns": [
-        {
-          "name": "role",
-          "ordinal": 0,
-          "type_info": "Text"
-        },
-        {
-          "name": "content",
-          "ordinal": 1,
-          "type_info": "Text"
-        }
-      ],
-      "nullable": [
-        false,
-        false
-      ],
-      "parameters": {
-        "Right": 1
-      }
-    },
-    "query": "SELECT role, content FROM messages WHERE conversation_id = ? ORDER BY ordinal ASC"
+    "query": "SELECT thread_id, created_at, title FROM conversations WHERE user_id = ? ORDER BY created_at DESC"
   }
 }

--- a/server/bleep/sqlx-data.json
+++ b/server/bleep/sqlx-data.json
@@ -1,0 +1,125 @@
+{
+  "db": "SQLite",
+  "392b563bb3af6711817fe99335d053691750426762dcde7b0381dc9f69cd804e": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Right": 2
+      }
+    },
+    "query": "DELETE FROM conversations WHERE user_id = ? AND thread_id = ?"
+  },
+  "65070b3ccabcae2f50e3010ff2d66c42cec6a8cbd11b0abe7c29e8b7ce12c87b": {
+    "describe": {
+      "columns": [
+        {
+          "name": "id",
+          "ordinal": 0,
+          "type_info": "Int64"
+        },
+        {
+          "name": "repo_ref",
+          "ordinal": 1,
+          "type_info": "Text"
+        },
+        {
+          "name": "path_aliases",
+          "ordinal": 2,
+          "type_info": "Text"
+        }
+      ],
+      "nullable": [
+        false,
+        false,
+        false
+      ],
+      "parameters": {
+        "Right": 2
+      }
+    },
+    "query": "SELECT id, repo_ref, path_aliases FROM conversations WHERE user_id = ? AND thread_id = ?"
+  },
+  "7cc11708840a8317f33110dcff41a74c820527c9b043268cc2b4fc0ba8d694e9": {
+    "describe": {
+      "columns": [
+        {
+          "name": "thread_id",
+          "ordinal": 0,
+          "type_info": "Text"
+        },
+        {
+          "name": "created_at",
+          "ordinal": 1,
+          "type_info": "Int64"
+        },
+        {
+          "name": "preview",
+          "ordinal": 2,
+          "type_info": "Text"
+        }
+      ],
+      "nullable": [
+        false,
+        false,
+        false
+      ],
+      "parameters": {
+        "Right": 1
+      }
+    },
+    "query": "SELECT c.thread_id, c.created_at, messages.content as preview FROM conversations c JOIN ( SELECT conversation_id, min(ordinal) ordinal FROM messages WHERE role = \"user\" GROUP BY conversation_id ) m ON m.conversation_id = c.id JOIN messages ON messages.conversation_id = c.id AND messages.ordinal = m.ordinal WHERE c.user_id = ?"
+  },
+  "80640f5084d8cc0238fa8856f93240e427f5f3f2737744beeb7c4e69b26d11ff": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Right": 4
+      }
+    },
+    "query": "INSERT INTO messages (conversation_id, ordinal, role, content) VALUES (?, ?, ?, ?)"
+  },
+  "a25e7837a4a1bb09cafb917b0214307e17bca829b1e94d441b442c4f9c050fdf": {
+    "describe": {
+      "columns": [
+        {
+          "name": "id",
+          "ordinal": 0,
+          "type_info": "Int64"
+        }
+      ],
+      "nullable": [
+        false
+      ],
+      "parameters": {
+        "Right": 4
+      }
+    },
+    "query": "INSERT INTO conversations (repo_ref, user_id, thread_id, path_aliases, created_at) VALUES (?, ?, ?, ?, strftime('%s', 'now')) RETURNING id"
+  },
+  "e9cf879bf7b6efb8c5fc587a649be52010f7fa8e09c353154d9dd83607e2a970": {
+    "describe": {
+      "columns": [
+        {
+          "name": "role",
+          "ordinal": 0,
+          "type_info": "Text"
+        },
+        {
+          "name": "content",
+          "ordinal": 1,
+          "type_info": "Text"
+        }
+      ],
+      "nullable": [
+        false,
+        false
+      ],
+      "parameters": {
+        "Right": 1
+      }
+    },
+    "query": "SELECT role, content FROM messages WHERE conversation_id = ? ORDER BY ordinal ASC"
+  }
+}

--- a/server/bleep/src/config.rs
+++ b/server/bleep/src/config.rs
@@ -26,6 +26,11 @@ pub struct Configuration {
     /// Directory to store indexes
     pub index_dir: PathBuf,
 
+    /// Directory to store persistent data
+    #[clap(long, default_value_os_t = default_data_dir())]
+    #[serde(default = "default_data_dir")]
+    pub data_dir: PathBuf,
+
     #[clap(long, default_value_t = false)]
     #[serde(skip)]
     /// Quit after indexing the specified repos
@@ -190,8 +195,8 @@ impl Configuration {
     pub fn cli_overriding_config_file() -> Result<Self> {
         let cli = Self::from_cli()?;
         let Ok(file) = cli.config_file.as_ref().context("no config file specified").and_then(Self::read) else {
-	    return Ok(cli);
-	};
+            return Ok(cli);
+        };
 
         Ok(Self::merge(file, cli))
     }
@@ -210,6 +215,8 @@ impl Configuration {
             source: right_if_default!(b.source, a.source, Default::default()),
 
             index_dir: b.index_dir,
+
+            data_dir: b.data_dir,
 
             index_only: b.index_only | a.index_only,
 
@@ -303,6 +310,13 @@ where
 fn default_index_path() -> PathBuf {
     match directories::ProjectDirs::from("ai", "bloop", "bleep") {
         Some(dirs) => dirs.cache_dir().to_owned(),
+        None => "bloop_index".into(),
+    }
+}
+
+fn default_data_dir() -> PathBuf {
+    match directories::ProjectDirs::from("ai", "bloop", "bloop") {
+        Some(dirs) => dirs.data_dir().join("bleep"),
         None => "bloop_index".into(),
     }
 }

--- a/server/bleep/src/db.rs
+++ b/server/bleep/src/db.rs
@@ -1,0 +1,29 @@
+use std::fs;
+
+use anyhow::{Result, anyhow};
+use once_cell::sync::{Lazy, OnceCell};
+use sqlx::SqlitePool;
+use tracing::debug;
+
+use crate::Configuration;
+
+static POOL: OnceCell<SqlitePool> = OnceCell::new();
+
+pub async fn init(config: &Configuration) -> Result<()> {
+    fs::create_dir_all(&config.data_dir)?;
+    let data_dir = config.data_dir.to_string_lossy();
+
+    let url = format!("sqlite://{data_dir}/bleep.db?mode=rwc");
+    debug!("loading db from {url}");
+    let pool = SqlitePool::connect(&url).await?;
+
+    sqlx::migrate!().run(&pool).await?;
+
+    POOL.set(pool).map_err(|_| anyhow!("database was already initialized!"))?;
+
+    Ok(())
+}
+
+pub async fn get() -> Result<&'static SqlitePool> {
+    POOL.get().ok_or(anyhow!("database pool was not initialized"))
+}

--- a/server/bleep/src/db.rs
+++ b/server/bleep/src/db.rs
@@ -1,7 +1,7 @@
 use std::fs;
 
-use anyhow::{Result, anyhow};
-use once_cell::sync::{Lazy, OnceCell};
+use anyhow::{anyhow, Result};
+use once_cell::sync::OnceCell;
 use sqlx::SqlitePool;
 use tracing::debug;
 
@@ -19,11 +19,13 @@ pub async fn init(config: &Configuration) -> Result<()> {
 
     sqlx::migrate!().run(&pool).await?;
 
-    POOL.set(pool).map_err(|_| anyhow!("database was already initialized!"))?;
+    POOL.set(pool)
+        .map_err(|_| anyhow!("database was already initialized!"))?;
 
     Ok(())
 }
 
 pub async fn get() -> Result<&'static SqlitePool> {
-    POOL.get().ok_or(anyhow!("database pool was not initialized"))
+    POOL.get()
+        .ok_or(anyhow!("database pool was not initialized"))
 }

--- a/server/bleep/src/lib.rs
+++ b/server/bleep/src/lib.rs
@@ -42,6 +42,7 @@ use tracing_subscriber::EnvFilter;
 mod background;
 mod collector;
 mod config;
+mod db;
 mod env;
 mod remotes;
 mod repo;
@@ -116,6 +117,8 @@ impl Application {
 
         let config = Arc::new(config);
         debug!(?config, "effective configuration");
+
+        db::init(&config).await?;
 
         // Initialise Semantic index if `qdrant_url` set in config
         let semantic = match config.qdrant_url {

--- a/server/bleep/src/webserver.rs
+++ b/server/bleep/src/webserver.rs
@@ -65,7 +65,14 @@ pub async fn start(app: Application) -> anyhow::Result<()> {
         .route("/search", get(semantic::complex_search))
         .route("/answer", get(answer::handle))
         .route("/answer/conversations", get(answer::conversations::list))
-        .route("/answer/conversations", delete(answer::conversations::delete));
+        .route(
+            "/answer/conversations/:thread_id",
+            get(answer::conversations::thread),
+        )
+        .route(
+            "/answer/conversations",
+            delete(answer::conversations::delete),
+        );
 
     if app.env.allow(Feature::AnyPathScan) {
         api = api.route("/repos/scan", get(repos::scan_local));

--- a/server/bleep/src/webserver.rs
+++ b/server/bleep/src/webserver.rs
@@ -62,8 +62,8 @@ pub async fn start(app: Application) -> anyhow::Result<()> {
         .route("/token-info", get(intelligence::handle))
         // misc
         .route("/search", get(semantic::complex_search))
-        .route("/file", get(file::handle))
-        .route("/answer", answer::endpoint());
+        .route("/answer", get(answer::handle))
+        .route("/answer/conversations", get(answer::conversations::list));
 
     if app.env.allow(Feature::AnyPathScan) {
         api = api.route("/repos/scan", get(repos::scan_local));

--- a/server/bleep/src/webserver.rs
+++ b/server/bleep/src/webserver.rs
@@ -1,5 +1,6 @@
 use crate::{env::Feature, Application};
 
+use axum::routing::delete;
 use axum::{http::StatusCode, response::IntoResponse, routing::get, Extension, Json};
 use std::{borrow::Cow, net::SocketAddr};
 use tower::Service;
@@ -63,7 +64,8 @@ pub async fn start(app: Application) -> anyhow::Result<()> {
         // misc
         .route("/search", get(semantic::complex_search))
         .route("/answer", get(answer::handle))
-        .route("/answer/conversations", get(answer::conversations::list));
+        .route("/answer/conversations", get(answer::conversations::list))
+        .route("/answer/conversations", delete(answer::conversations::delete));
 
     if app.env.allow(Feature::AnyPathScan) {
         api = api.route("/repos/scan", get(repos::scan_local));

--- a/server/bleep/src/webserver.rs
+++ b/server/bleep/src/webserver.rs
@@ -1,6 +1,5 @@
 use crate::{env::Feature, Application};
 
-use axum::routing::delete;
 use axum::{http::StatusCode, response::IntoResponse, routing::get, Extension, Json};
 use std::{borrow::Cow, net::SocketAddr};
 use tower::Service;
@@ -63,15 +62,15 @@ pub async fn start(app: Application) -> anyhow::Result<()> {
         .route("/token-info", get(intelligence::handle))
         // misc
         .route("/search", get(semantic::complex_search))
+        .route("/file", get(file::handle))
         .route("/answer", get(answer::handle))
-        .route("/answer/conversations", get(answer::conversations::list))
+        .route(
+            "/answer/conversations",
+            get(answer::conversations::list).delete(answer::conversations::delete),
+        )
         .route(
             "/answer/conversations/:thread_id",
             get(answer::conversations::thread),
-        )
-        .route(
-            "/answer/conversations",
-            delete(answer::conversations::delete),
         );
 
     if app.env.allow(Feature::AnyPathScan) {

--- a/server/bleep/src/webserver/answer.rs
+++ b/server/bleep/src/webserver/answer.rs
@@ -517,7 +517,7 @@ impl Conversation {
             .exchanges
             .first()
             .and_then(|list| list.query())
-            .and_then(|q| q.split("\n").next())
+            .and_then(|q| q.split('\n').next())
             .context("couldn't find conversation title")?;
 
         let exchanges = serde_json::to_string(&self.exchanges)?;

--- a/server/bleep/src/webserver/answer/conversations.rs
+++ b/server/bleep/src/webserver/answer/conversations.rs
@@ -1,0 +1,56 @@
+use axum::{extract::Query, response::IntoResponse, Extension, Json};
+
+use crate::{
+    db,
+    webserver::{self, middleware::User, Error},
+};
+
+use super::Conversation;
+
+#[derive(serde::Serialize)]
+pub struct ConversationPreview {
+    pub thread_id: String,
+    pub created_at: i64,
+    pub preview: String,
+}
+
+pub(in crate::webserver) async fn list(
+    Extension(user): Extension<User>,
+) -> webserver::Result<impl IntoResponse> {
+    let db = db::get().await?;
+
+    let user_id = user.0.ok_or_else(|| Error::user("missing user ID"))?;
+
+    // We create a nested query to fetch all lowest-ordinal "user" messages, grouped by
+    // conversation.
+
+    let mut conversations = sqlx::query_as! {
+        ConversationPreview,
+        "SELECT c.thread_id, c.created_at, messages.content as preview \
+         FROM conversations c \
+         JOIN ( \
+             SELECT conversation_id, min(ordinal) ordinal FROM messages \
+             WHERE role = \"user\" \
+             GROUP BY conversation_id \
+         ) m ON m.conversation_id = c.id \
+         JOIN messages ON messages.conversation_id = c.id AND messages.ordinal = m.ordinal \
+         WHERE c.user_id = ?",
+        user_id,
+    }
+    .fetch_all(db)
+    .await
+    .map_err(Error::internal)?;
+
+    // Trim the preview, and only read up to the first newline.
+    for conversation in &mut conversations {
+        conversation.preview = conversation
+            .preview
+            .trim()
+            .split("\n")
+            .next()
+            .unwrap_or("")
+            .to_owned();
+    }
+
+    Ok(Json(conversations))
+}


### PR DESCRIPTION
In this PR, we add an sqlite database for storing conversation history. We also add a few endpoints for managing this history, namely listing, deleting, and retrieving conversations.

The `ResponseState` struct has been simplified and refactored into the idea of an `Exchange`. Exchanges are stored directly in the corresponding `Conversation` for retrieval at a later date.

## Using `sqlx` with the database

To create new queries or modify existing ones, we can use `sqlx`. You'll need to `cargo install sqlx-cli` first, then these commands can be run from within `server/bleep`:

- `sqlx database reset --database-url=sqlite://bleep.db`: This will set up the database from scratch, deleting an old database if it exists
- `cargo sqlx prepare --database-url=sqlite://bleep.db`: This will update the `sqlx-data.json` file, which is nominally used to build the app without requiring a database instance.