### PR TITLE
attach thread-id to response

### DIFF
--- a/server/bleep/Cargo.toml
+++ b/server/bleep/Cargo.toml
@@ -105,7 +105,7 @@ tokenizers = "0.13.2"
 tokio-stream = "0.1.12"
 ort = { git = "https://github.com/bloopai/ort", branch = "merge-upstream" }
 ndarray = "0.15"
-uuid = { version = "1.2.2", features = ["v4", "fast-rng"] }
+uuid = { version = "1.2.2", features = ["v4", "fast-rng", "serde"] }
 jsonwebtoken = { version = "8.2.0", features = ["use_pem"] }
 
 # telemetry

--- a/server/bleep/src/webserver/answer/conversations.rs
+++ b/server/bleep/src/webserver/answer/conversations.rs
@@ -70,7 +70,7 @@ pub(in crate::webserver) async fn delete(
 }
 
 pub(in crate::webserver) async fn thread(
-    Path(thread_id): Path<String>,
+    Path(thread_id): Path<uuid::Uuid>,
     Extension(user): Extension<User>,
 ) -> webserver::Result<impl IntoResponse> {
     let user_id = user.0.ok_or_else(|| Error::user("missing user ID"))?;

--- a/server/bleep/src/webserver/answer/response.rs
+++ b/server/bleep/src/webserver/answer/response.rs
@@ -8,6 +8,7 @@ pub struct Exchange {
     conclusion: Option<String>,
     search_steps: Vec<SearchStep>,
     results: Vec<SearchResult>,
+    thread_id: uuid::Uuid,
 }
 
 impl Exchange {
@@ -55,6 +56,11 @@ impl Exchange {
         }
 
         self.conclusion = conclusion;
+    }
+
+    pub fn with_thread_id(mut self, thread_id: uuid::Uuid) -> Self {
+        self.thread_id = thread_id;
+        self
     }
 }
 


### PR DESCRIPTION
also converts `thread_id` into a uuid everywhere. uuid::Uuid is copy and easy to throw around.