### PR TITLE
introduce minified tools prompt

### DIFF
--- a/server/bleep/src/webserver/answer/prompts.rs
+++ b/server/bleep/src/webserver/answer/prompts.rs
@@ -4,49 +4,83 @@ pub const INITIAL_PROMPT: &str = r#"["ask","Hi there, what can I help you with?"
 
 pub const CONTINUE: &str = "Is there anything else I can help with?";
 
-pub const SYSTEM: &str = r#"You must adhere to the following rules at all times:
-1. Your job is to act as a decision maker answering user's questions about the codebase.
-2. Decide which ACTION should be taken next.
-3. Do not repeat an ACTION.
-4. Do not assume the structure of the codebase, or the existence of files or folders.
-5. Respond only in valid JSON format.
-6. If an ACTION does not provide new information to answer the question, try a different ACTION or change your search terms.
-7. Only reply to the user with the "answer" ACTION.
-8. Do not use the answer action without first making a search.
-9. Check all possible files for answers before answering. Gather all information necessary to write a comprehensive answer, before using the answer ACTION.
-10. If the user asks for two things at once, tell them that the query is too complicated and to politely ask their questions separately.
-11. The user's question is related to the codebase.
-12. You can only perform one action at a time.
-13. If a path has an alias, use the alias instead of the full path when using the path with an action.
+pub fn system() -> String {
+    let today = chrono::offset::Local::now();
+    let tools = serde_json::json!([
+      {
+        "title": "Semantic code search",
+        "schema": {
+          "name": "code",
+          "args": [
+            {
+              "name": "SEARCH TERMS",
+              "type": "STRING"
+            }
+          ]
+        },
+        "note": "This does not return an exhaustive list of result, just the top matches. For exhaustive results, use path search first."
+      },
+      {
+        "title": "Fuzzy path search",
+        "schema": {
+          "name": "path",
+          "args": [
+            {
+              "name": "SEARCH TERMS",
+              "type": "STRING",
+              "examples": [
+                "src",
+                "tests",
+                ".css",
+                ".tsx"
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "title": "Process files for information or answers",
+        "schema": {
+          "name": "proc",
+          "args": [
+            {
+              "name": "FIND INFORMATION",
+              "type": "STRING",
+              "example": "the user wants to find all the functional react components"
+            },
+            {
+              "name": "PATH ALIAS FOR EACH FILE",
+              "type": "INT[]"
+            }
+          ]
+        }
+      },
+      {
+        "title": "No tool left to take",
+        "schema": {
+          "name": "none",
+          "args": [],
+        }
+      }
+    ]);
 
-#####
+    format!(
+        r#"The following tools are available: {tools}.
 
-Below is a list of available ACTIONS:
-
-1. Search code using semantic search
-["code",STRING: SEARCH TERMS]
-Returns a list of paths and relevant code.
-
-2. Search file paths using exact text match
-["path",STRING: SEARCH TERMS]
-To list all files within a repo, leave the search terms blank.
-To find all files from a particular programming language, write a single file extension.
-To search for all files within a folder, write just the name of the folder.
-
-3. Process files to find answer
-["proc",STRING: PROCESS,INT[]: PATH ALIAS FOR EACH FILE]
-Process the files with the given aliases to find the answer to the question.
-Do not check the same file more than once.
-This will return a list of paths, relevant line ranges and relevant dependencies. You may wish to check the relevant dependencies.
-PROCESS should be a question, or detailed instruction of information to extract like:
-- find references to API
-- find react components
-
-4. State that you are ready to answer the question after absolutely all information has been gathered
-["answer",STRING: STANDALONE USER REQUEST]
-Signal that you are ready to answer the user's request. Do not write your response.
-Your STANDALONE USER REQUEST should be based on all of the previous conversation with the user.
-It should be possible to understand from this string alone what the user is asking for."#;
+You must adhere to the following rules at all times:
+- Your job is to use the tools to find information related to the query, until all information has been found.
+- Output a JSON list to use a tool. For example to use the semantic code search tool, output: ["code","search terms here"]
+- Respect action arg types, only types with brackets [] can be used as lists.
+- You will need to use multiple tools before using the none tool.
+- Do not repeat any action.
+- If you are following a path search with a proc, and there are more than 10 path aliases to proc, instead return none and see if the user asks a follow up question.
+- Do not assume the structure of the codebase, or the existence of files or folders.
+- If a query is too complicated to answer, ask the user to ask a simpler question.
+- To perform multiple actions, perform just one, wait for the response, then perform the next.
+- Todays date is {today}.
+        "#
+    )
+}
 
 pub fn file_explanation(question: &str, path: &str, code: &str) -> String {
     format!(
@@ -74,14 +108,12 @@ A: "#
     )
 }
 
-pub fn final_explanation_prompt(context: &str, question: &str) -> String {
+pub fn final_explanation_prompt(context: &str, query_history: &str) -> String {
     format!(
         r#"{context}#####
 Above are several pieces of information that can help you answer a user query.
 
-The user's query is "{question}"
-
-Your answer should be in the following JSON format: a list of objects, where each object represents one instance of:
+Your job is to answer the user's query. Your answer should be in the following JSON format: a list of objects, where each object represents one instance of:
 
 1. citing a single file from the codebase (this object can appear multiple times, in the form of a JSON array)
 START LINE and END LINE should focus on the code mentioned in the COMMENT.
@@ -112,6 +144,17 @@ For example:
 Your response should be a JSON array of objects.
 Refer to directories by their full paths, surrounded by single backticks.
 
-#####"#
+#####
+
+{query_history}
+
+Above is the query and answer history. The user can see the previous queries and answers on their screen, but not anything else.
+Based on this history, answer the user's last question.
+
+#####
+
+Output only JSON.
+
+"#
     )
 }

--- a/server/bleep/src/webserver/answer/response.rs
+++ b/server/bleep/src/webserver/answer/response.rs
@@ -30,6 +30,11 @@ impl Exchange {
         })
     }
 
+    /// Get the conslusion associated with this exchange, if it has been made.
+    pub fn conclusion(&self) -> Option<&str> {
+        self.conclusion.as_ref().map(String::as_str)
+    }
+
     /// Set the current search result list.
     fn set_results(&mut self, mut results: Vec<SearchResult>) {
         // fish out the conclusion from the result list, if any


### PR DESCRIPTION
- rework the `answer` tool into `none`
- add query history to the the `none` tool, the generated history is formatted as user-assistant pairs:

    user: where are the model files
    assistant: The model files for GPT-2 are located in the ...
    user: how are they loaded?
    assistant: The model files are loaded in ...

- use safe bounds check in `proc`