### PR TITLE
Index hidden files for filesystem repos

### DIFF
--- a/server/bleep/src/repo/iterator.rs
+++ b/server/bleep/src/repo/iterator.rs
@@ -47,8 +47,17 @@ impl FileType {
     }
 }
 
+fn should_index_de(de: &ignore::DirEntry) -> bool {
+    should_index(&de.path())
+}
+
 fn should_index<P: AsRef<Path>>(p: &P) -> bool {
     let path = p.as_ref();
+
+    // TODO: Make this more robust
+    if path.components().any(|c| c.as_os_str() == ".git") {
+        return false;
+    }
 
     #[rustfmt::skip]
     const EXT_BLACKLIST: &[&str] = &[
@@ -149,6 +158,11 @@ mod test {
             // These are not typically vendored in Rust.
             ("dist/main.rs", true),
             ("vendor/foo.rs", true),
+            // Ignore .git directory.
+            (".git/HEAD", false),
+            (".git/config", false),
+            (".gitignore", true),
+            (".github/workflows/ci.yml", true),
         ];
 
         for (path, index) in tests {

--- a/server/bleep/src/repo/iterator.rs
+++ b/server/bleep/src/repo/iterator.rs
@@ -47,7 +47,7 @@ impl FileType {
     }
 }
 
-fn should_index_de(de: &ignore::DirEntry) -> bool {
+fn should_index_entry(de: &ignore::DirEntry) -> bool {
     should_index(&de.path())
 }
 

--- a/server/bleep/src/repo/iterator/fs.rs
+++ b/server/bleep/src/repo/iterator/fs.rs
@@ -14,7 +14,7 @@ impl FileWalker {
         let walker = ignore::WalkBuilder::new(&dir)
             .standard_filters(true)
             .hidden(false)
-            .filter_entry(should_index_de)
+            .filter_entry(should_index_entry)
             .build();
 
         let file_list = walker

--- a/server/bleep/src/repo/iterator/fs.rs
+++ b/server/bleep/src/repo/iterator/fs.rs
@@ -11,7 +11,13 @@ pub struct FileWalker {
 impl FileWalker {
     pub fn index_directory(dir: impl AsRef<Path>) -> impl FileSource {
         // note: this WILL observe .gitignore files for the respective repos.
-        let file_list = ignore::Walk::new(&dir)
+        let walker = ignore::WalkBuilder::new(&dir)
+            .standard_filters(true)
+            .hidden(false)
+            .filter_entry(should_index_de)
+            .build();
+
+        let file_list = walker
             .filter_map(|de| match de {
                 Ok(de) => Some(de),
                 Err(err) => {
@@ -22,12 +28,6 @@ impl FileWalker {
             // Preliminarily ignore files that are very large, without reading the contents.
             .filter(|de| matches!(de.metadata(), Ok(meta) if meta.len() < MAX_FILE_LEN))
             .filter_map(|de| crate::canonicalize(de.into_path()).ok())
-            .filter(|p| {
-                p.strip_prefix(&dir)
-                    .as_ref()
-                    .map(should_index)
-                    .unwrap_or_default()
-            })
             .collect();
 
         Self { file_list }


### PR DESCRIPTION
The filesystem walker was using the default `ignore::Walk` struct and therefore ignored hidden files, including the useful `.github`, `.eslint` etc.