### PR TITLE
load previous exchange's summary into next query

### DIFF
--- a/server/bleep/src/webserver/answer/response.rs
+++ b/server/bleep/src/webserver/answer/response.rs
@@ -7,7 +7,7 @@ pub struct Exchange {
     finished: bool,
     conclusion: Option<String>,
     search_steps: Vec<SearchStep>,
-    results: Vec<SearchResult>,
+    pub results: Vec<SearchResult>,
 }
 
 impl Exchange {
@@ -119,6 +119,14 @@ impl SearchResult {
             s => s,
         }
     }
+
+    pub fn summarize(&self) -> String {
+        match self {
+            Self::Cite(cite) => cite.summarize(),
+            Self::Conclude(conclude) => conclude.summarize(),
+            _ => String::default(),
+        }
+    }
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Default, Debug, Clone)]
@@ -191,6 +199,16 @@ impl CiteResult {
             .and_then(|alias| path_aliases.get(*alias as usize))
             .map(ToOwned::to_owned);
         self
+    }
+
+    fn summarize(&self) -> String {
+        fn _summarize(s: &CiteResult) -> Option<String> {
+            let comment = s.comment.as_ref()?;
+            let path = s.path.as_ref()?;
+            Some(format!("'{comment}' in `{path}`",))
+        }
+
+        _summarize(&self).unwrap_or_default()
     }
 }
 
@@ -320,5 +338,9 @@ impl ConcludeResult {
             .and_then(serde_json::Value::as_str)
             .map(ToOwned::to_owned);
         Some(Self { comment })
+    }
+
+    fn summarize(&self) -> String {
+        self.comment.clone().unwrap_or_default()
     }
 }


### PR DESCRIPTION
this patchset loads up a summarized version of the previous exchange in this conversation as an 'assistant' prompt. if the previous exchange is organized as:

    ["cite", 0, "This is the model/ directory"]
    ["cite", 1, "This is the gpt-2/ directory"]
    ["con", "The model files are present in the model/ directory"]

then the generated summary is produced by resolving path aliases and stripping json content:

    "This is the model/ directory" in "model/"
    "This is the gpt-2/ directory" in "model/gpt-2/"
    "The model files are present in the model/ directory"

the goal of this patchset is to allow answering queries that refer to previous citations or conclusions, in this example, the query "what is the parent directory of this directory?" is understood by the llm to be refering to the `model/` directory.