### PR TITLE
Use Git walker if Git is available

### DIFF
--- a/server/bleep/src/indexes/file.rs
+++ b/server/bleep/src/indexes/file.rs
@@ -200,7 +200,7 @@ impl Indexable for File {
         };
 
         let start = std::time::Instant::now();
-        if reporef.is_remote() && matches!(repo.remote, RepoRemote::Git { .. }) {
+        if matches!(repo.remote, RepoRemote::Git { .. }) {
             let walker = GitWalker::open_repository(&repo.disk_path, None)?;
             let count = walker.len();
             walker.for_each(file_worker(count));


### PR DESCRIPTION
This will effectively disable the filesystem backend as the UX currently doesn't allow adding non-repo directories to be indexed.

I'm leaving in the code paths that support this for future prosperity and testing.