### PR TITLE
Add path aliases argument to `resp`

### DIFF
--- a/server/bleep/src/webserver/answer/prompts.rs
+++ b/server/bleep/src/webserver/answer/prompts.rs
@@ -65,7 +65,16 @@ pub fn system() -> String {
         "description": "Answer the user's query. This is the final step in the process. You should use the information gathered from the other tools to answer the query.",
         "schema": {
           "name": "resp",
-          "args": [],
+          "args": [
+              {
+                "name": "RELEVANT PATH ALIASES",
+                "type": "INT[]",
+                "examples": [
+                  [1], [2, 5], [3]
+                ],
+                "description": "The path alias of the files you want to cite.",
+              }
+          ],
         },
       }
     ]);


### PR DESCRIPTION
This also detects explanation requests where there is only a single path alias returned, and opts to return the entire file instead, pruned to a maximum of 4000 tokens.