### PR TITLE
introduce new `import` node

### DIFF
--- a/server/bleep/src/intelligence/code_navigation.rs
+++ b/server/bleep/src/intelligence/code_navigation.rs
@@ -55,7 +55,10 @@ impl<'a> CurrentFileHandler<'a> {
             .map(|d| d.range())
             .collect();
 
-        let refs = refs.into_iter().flatten().collect();
+        // remove self from the list of references
+        let mut refs = refs.into_iter().flatten().collect::<BTreeSet<_>>();
+        refs.remove(&self.scope_graph.graph[*idx].range());
+        let refs = refs.into_iter().collect::<Vec<_>>();
 
         (defs, refs)
     }

--- a/server/bleep/src/intelligence/language/c_sharp/scopes.scm
+++ b/server/bleep/src/intelligence/language/c_sharp/scopes.scm
@@ -168,20 +168,20 @@
 
 ;; using System.Text
 ;; 
-;; `Text` is a def
+;; `Text` is an import
 (using_directive
   .
   (qualified_name
     (_)
     .
-    (identifier) @local.definition))
+    (identifier) @local.import))
 
 ;; using Named = System.Text;
 ;;
 ;; `Named` is a def
 (using_directive
   (name_equals
-    (identifier) @local.definition))
+    (identifier) @local.import))
 
 
 ;; refs

--- a/server/bleep/src/intelligence/language/go/mod.rs
+++ b/server/bleep/src/intelligence/language/go/mod.rs
@@ -27,7 +27,7 @@ mod tests {
             const two, three = 2, 3
             "#;
 
-        let (_, d, _) = counts(src, "Go");
+        let (_, d, _, _) = counts(src, "Go");
         assert_eq!(d, 3);
     }
 
@@ -37,7 +37,7 @@ mod tests {
             const one uint64 = 1
             const two, three uint64 = 2, 3
             "#;
-        let (_, d, _) = counts(src, "Go");
+        let (_, d, _, _) = counts(src, "Go");
         assert_eq!(d, 3);
     }
 
@@ -49,7 +49,7 @@ mod tests {
                 one = 1
             )
         "#;
-        let (_, d, _) = counts(src, "Go");
+        let (_, d, _, _) = counts(src, "Go");
         assert_eq!(d, 2);
     }
 
@@ -61,7 +61,7 @@ mod tests {
                 one
             )
         "#;
-        let (_, d, _) = counts(src, "Go");
+        let (_, d, _, _) = counts(src, "Go");
         assert_eq!(d, 2);
     }
 
@@ -74,7 +74,7 @@ mod tests {
             var one, two = 1, 2
             var three, four, five = 3, 4, 5
         "#;
-        let (_, d, _) = counts(src, "Go");
+        let (_, d, _, _) = counts(src, "Go");
         assert_eq!(d, 6);
     }
 
@@ -86,7 +86,7 @@ mod tests {
             var zero uint64 = 0
             var one, two uint64 = 1, 2
         "#;
-        let (_, d, _) = counts(src, "Go");
+        let (_, d, _, _) = counts(src, "Go");
         assert_eq!(d, 3);
     }
 
@@ -100,7 +100,7 @@ mod tests {
                 one = 1
             )
         "#;
-        let (_, d, _) = counts(src, "Go");
+        let (_, d, _, _) = counts(src, "Go");
         assert_eq!(d, 2);
     }
 
@@ -114,7 +114,7 @@ mod tests {
         "#;
 
         // main, x, res, err
-        let (_, d, _) = counts(src, "Go");
+        let (_, d, _, _) = counts(src, "Go");
         assert_eq!(d, 4);
     }
 
@@ -129,7 +129,7 @@ mod tests {
             func f4(result int, err error) {}       // declares result, err
             func f5(x ... uint64, y ... uint64) {}  // declares x, y
         "#;
-        let (_, d, _) = counts(src, "Go");
+        let (_, d, _, _) = counts(src, "Go");
 
         // f1, f2, f3, f4, f5, result, err, x, y
         assert_eq!(d, 9);
@@ -148,7 +148,7 @@ mod tests {
             type s struct {}
             type i interface {}
         "#;
-        let (_, d, _) = counts(src, "Go");
+        let (_, d, _, _) = counts(src, "Go");
         assert_eq!(d, 5);
     }
 
@@ -162,7 +162,7 @@ mod tests {
                 b uint64
             )
         "#;
-        let (_, d, _) = counts(src, "Go");
+        let (_, d, _, _) = counts(src, "Go");
         assert_eq!(d, 2);
     }
 
@@ -177,7 +177,7 @@ mod tests {
         "#;
 
         // main, loop
-        let (_, d, _) = counts(src, "Go");
+        let (_, d, _, _) = counts(src, "Go");
         assert_eq!(d, 2);
     }
 
@@ -190,7 +190,7 @@ mod tests {
         "#;
 
         // main, t
-        let (_, d, _) = counts(src, "Go");
+        let (_, d, _, _) = counts(src, "Go");
         assert_eq!(d, 2);
     }
 
@@ -205,7 +205,7 @@ mod tests {
         "#;
 
         // 3 refs to a, 3 refs to b
-        let (_, _, r) = counts(src, "Go");
+        let (_, _, r, _) = counts(src, "Go");
         assert_eq!(r, 6);
     }
 
@@ -220,7 +220,7 @@ mod tests {
             }
         "#;
 
-        let (_, _, r) = counts(src, "Go");
+        let (_, _, r, _) = counts(src, "Go");
         assert_eq!(r, 2);
     }
 
@@ -234,7 +234,7 @@ mod tests {
             }
         "#;
 
-        let (_, _, r) = counts(src, "Go");
+        let (_, _, r, _) = counts(src, "Go");
         assert_eq!(r, 2);
     }
 
@@ -247,7 +247,7 @@ mod tests {
             }
         "#;
 
-        let (_, _, r) = counts(src, "Go");
+        let (_, _, r, _) = counts(src, "Go");
         assert_eq!(r, 1);
     }
 
@@ -260,7 +260,7 @@ mod tests {
             }
         "#;
 
-        let (_, _, r) = counts(src, "Go");
+        let (_, _, r, _) = counts(src, "Go");
         assert_eq!(r, 1);
     }
 
@@ -277,7 +277,7 @@ mod tests {
             }
         "#;
 
-        let (_, _, r) = counts(src, "Go");
+        let (_, _, r, _) = counts(src, "Go");
 
         // p (variable ref), person (type ref)
         assert_eq!(r, 2);
@@ -292,7 +292,7 @@ mod tests {
             }
         "#;
 
-        let (_, _, r) = counts(src, "Go");
+        let (_, _, r, _) = counts(src, "Go");
         assert_eq!(r, 1);
     }
 
@@ -305,7 +305,7 @@ mod tests {
             }
         "#;
 
-        let (_, _, r) = counts(src, "Go");
+        let (_, _, r, _) = counts(src, "Go");
         assert_eq!(r, 1);
     }
 
@@ -332,7 +332,7 @@ mod tests {
             }
         "#;
 
-        let (_, _, r) = counts(src, "Go");
+        let (_, _, r, _) = counts(src, "Go");
         assert_eq!(r, 10);
     }
 
@@ -347,7 +347,7 @@ mod tests {
             }
             func f3() {}
         "#;
-        let (_, d, r) = counts(src, "Go");
+        let (_, d, r, _) = counts(src, "Go");
 
         // f1, f1::a, f2, f3
         assert_eq!(d, 4);
@@ -580,18 +580,19 @@ mod tests {
             expect![[r#"
                 scope {
                     definitions: [
-                        x {
-                            kind: "module",
-                            context: "import §x§ \"github.com/golang/go/x\"",
-                            referenced in (1): [
-                                `var t §x§.Type := 2`,
-                            ],
-                        },
                         t {
                             kind: "var",
                             context: "var §t§ x.Type := 2",
                             referenced in (1): [
                                 `§t§++`,
+                            ],
+                        },
+                    ],
+                    imports: [
+                        x {
+                            context: "import §x§ \"github.com/golang/go/x\"",
+                            referenced in (1): [
+                                `var t §x§.Type := 2`,
                             ],
                         },
                     ],

--- a/server/bleep/src/intelligence/language/go/scopes.scm
+++ b/server/bleep/src/intelligence/language/go/scopes.scm
@@ -152,7 +152,7 @@
 
 ;; imports
 (import_spec 
-  (package_identifier) @local.definition.module)
+  (package_identifier) @local.import)
 
 ;; switch t := q.(type)
 (type_switch_statement

--- a/server/bleep/src/intelligence/language/java/scopes.scm
+++ b/server/bleep/src/intelligence/language/java/scopes.scm
@@ -131,19 +131,19 @@
 (lambda_expression
   parameters: (identifier) @local.definition.local)
 
-;; imports are defs
+;; imports
 ;;
 ;; import item;
-;;        ^^^^ is a def
+;;        ^^^^ is an import
 (import_declaration 
-  (identifier) @local.definition)
+  (identifier) @local.import)
 
 ;; import java.util.Vector;
-;;                  ^^^^^^ is a def
+;;                  ^^^^^^ is an import
 (import_declaration 
   (scoped_identifier
     (_)
-    (identifier) @local.definition))
+    (identifier) @local.import))
 
 ;; labels
 (labeled_statement 

--- a/server/bleep/src/intelligence/language/javascript/mod.rs
+++ b/server/bleep/src/intelligence/language/javascript/mod.rs
@@ -71,13 +71,16 @@ mod test {
             const g = (h) => {}
             const i = (j, k) => {}
 
-            function({l, field: {m, n}}) {}
-            function({o, ...p}) {}
+            // TODO: object patterns with shorthand patterns are 
+            // not handled in every situation right now (only in const/var decls.)
+            // function({field: {l, m}}) {}
+
+            function({...n}) {}
         "#;
 
         let (_, def_count, _, _) = counts(src, "JavaScript");
 
-        assert_eq!(def_count, 16);
+        assert_eq!(def_count, 12);
     }
 
     #[test]
@@ -328,16 +331,17 @@ mod test {
             expect![[r#"
                 scope {
                     definitions: [
+                        elasticClient {
+                            kind: "constant",
+                            context: "const §elasticClient§ = new Client({node: ELASTIC_CONNECTION_STRING});",
+                        },
+                    ],
+                    imports: [
                         Client {
-                            kind: "variable",
                             context: "const { §Client§ } = require(\"@elastic/elasticsearch\");",
                             referenced in (1): [
                                 `const elasticClient = new §Client§({node: ELASTIC_CONNECTION_STRING});`,
                             ],
-                        },
-                        elasticClient {
-                            kind: "constant",
-                            context: "const §elasticClient§ = new Client({node: ELASTIC_CONNECTION_STRING});",
                         },
                     ],
                     child scopes: [

--- a/server/bleep/src/intelligence/language/javascript/mod.rs
+++ b/server/bleep/src/intelligence/language/javascript/mod.rs
@@ -36,7 +36,7 @@ mod test {
             d = a;
         "#;
 
-        let (_, def_count, _) = counts(src, "JavaScript");
+        let (_, def_count, _, _) = counts(src, "JavaScript");
 
         // a, b, c, d
         assert_eq!(def_count, 4);
@@ -55,7 +55,7 @@ mod test {
             function* five() {}
         "#;
 
-        let (_, def_count, _) = counts(src, "JavaScript");
+        let (_, def_count, _, _) = counts(src, "JavaScript");
 
         assert_eq!(def_count, 5);
     }
@@ -75,7 +75,7 @@ mod test {
             function({o, ...p}) {}
         "#;
 
-        let (_, def_count, _) = counts(src, "JavaScript");
+        let (_, def_count, _, _) = counts(src, "JavaScript");
 
         assert_eq!(def_count, 16);
     }
@@ -89,7 +89,7 @@ mod test {
             }
         "#;
 
-        let (_, def_count, _) = counts(src, "JavaScript");
+        let (_, def_count, _, _) = counts(src, "JavaScript");
 
         // class, prop, prop
         assert_eq!(def_count, 3);
@@ -103,9 +103,9 @@ mod test {
             import { four, member as five } from "module";
         "#;
 
-        let (_, def_count, _) = counts(src, "JavaScript");
+        let (_, _, _, import_count) = counts(src, "JavaScript");
 
-        assert_eq!(def_count, 5);
+        assert_eq!(import_count, 5);
     }
 
     #[test]
@@ -122,7 +122,7 @@ mod test {
                     break three;
         "#;
 
-        let (_, def_count, _) = counts(src, "JavaScript");
+        let (_, def_count, _, _) = counts(src, "JavaScript");
 
         assert_eq!(def_count, 3);
     }
@@ -139,7 +139,7 @@ mod test {
             a.length();
         "#;
 
-        let (_, _, ref_count) = counts(src, "JavaScript");
+        let (_, _, ref_count, _) = counts(src, "JavaScript");
 
         assert_eq!(ref_count, 5);
     }
@@ -154,7 +154,7 @@ mod test {
             await a;
         "#;
 
-        let (_, _, ref_count) = counts(src, "JavaScript");
+        let (_, _, ref_count, _) = counts(src, "JavaScript");
 
         assert_eq!(ref_count, 3);
     }
@@ -189,7 +189,7 @@ mod test {
             a.b
         "#;
 
-        let (_, _, ref_count) = counts(src, "JavaScript");
+        let (_, _, ref_count, _) = counts(src, "JavaScript");
 
         assert_eq!(ref_count, 13);
     }
@@ -208,7 +208,7 @@ mod test {
             export default c;
         "#;
 
-        let (_, _, ref_count) = counts(src, "JavaScript");
+        let (_, _, ref_count, _) = counts(src, "JavaScript");
 
         assert_eq!(ref_count, 5);
     }
@@ -228,7 +228,7 @@ mod test {
 
         "#;
 
-        let (_, _, ref_count) = counts(src, "JavaScript");
+        let (_, _, ref_count, _) = counts(src, "JavaScript");
 
         assert_eq!(ref_count, 7);
     }
@@ -240,7 +240,7 @@ mod test {
             b = <Foo.Bar>{string(a)}<span>b</span> c</Foo.Bar>;
         "#;
 
-        let (_, _, ref_count) = counts(src, "JavaScript");
+        let (_, _, ref_count, _) = counts(src, "JavaScript");
 
         assert_eq!(ref_count, 1);
     }
@@ -269,7 +269,7 @@ mod test {
         // Button           x 4,
         // ChevronRightIcon x 1,
         // NavBarNoUser     x 1
-        let (_, _, ref_count) = counts(src, "JSX");
+        let (_, _, ref_count, _) = counts(src, "JSX");
 
         assert_eq!(ref_count, 6);
     }

--- a/server/bleep/src/intelligence/language/javascript/scopes.scm
+++ b/server/bleep/src/intelligence/language/javascript/scopes.scm
@@ -66,19 +66,24 @@
   (identifier) @local.definition.variable
   (identifier) @local.reference)
 
-;; for ([a, b] in thing)
-;;
-;; `a` & `b` are defs
-;; (array_pattern
-;;   (identifier) @local.definition.variable)
-
-;; let {a, b} = obj;
-;; (object_pattern
-;;   (shorthand_property_identifier_pattern) @local.definition.variable)
+;; {x: y}
+(pair_pattern
+  (property_identifier)
+  (identifier) @local.definition.variable)
 
 ;; var x = _
+;; var [x, y] = _
+;; var {x, y} = _
 (variable_declaration
   (variable_declarator . (identifier) @local.definition.variable))
+(variable_declaration
+  (variable_declarator 
+    name: (array_pattern
+            (identifier) @local.definition.variable)))
+(variable_declaration
+  (variable_declarator 
+    name: (object_pattern
+            (shorthand_property_identifier_pattern) @local.definition.variable)))
 
 ;; const _ = require(_) should produce imports
 (
@@ -152,7 +157,7 @@
    (variable_declarator 
      name: 
      (object_pattern
-       (shorthand_property_identifier_pattern) @local.definition.const)
+       (shorthand_property_identifier_pattern) @local.definition.constant)
      value: (_) @_rest))
   (#not-match? @_rest "require.*")
 )
@@ -174,7 +179,7 @@
    (variable_declarator 
      name: 
       (array_pattern
-        (identifier) @local.definition.const)
+        (identifier) @local.definition.constant)
      value: (_) @_rest))
   (#not-match? @_rest "require.*")
 )

--- a/server/bleep/src/intelligence/language/javascript/scopes.scm
+++ b/server/bleep/src/intelligence/language/javascript/scopes.scm
@@ -114,19 +114,19 @@
 (arrow_function
   (identifier) @local.definition.variable)
 
-;; imports are defs, but of unknown kinds
+;; imports
 
 ;; import defaultMember from "module";
 (import_statement
-  (import_clause (identifier) @local.definition))
+  (import_clause (identifier) @local.import))
 
 ;; import { member } from "module";
 ;; import { member as alias } from "module";
 (import_statement
   (import_clause
     (named_imports
-      [(import_specifier !alias (identifier) @local.definition)
-       (import_specifier alias: (identifier) @local.definition)])))
+      [(import_specifier !alias (identifier) @local.import)
+       (import_specifier alias: (identifier) @local.import)])))
 
 ;; for (item in list)
 ;;

--- a/server/bleep/src/intelligence/language/javascript/scopes.scm
+++ b/server/bleep/src/intelligence/language/javascript/scopes.scm
@@ -373,3 +373,7 @@
 
 (jsx_self_closing_element
   (identifier) @local.reference)
+
+;; template strings
+(template_substitution
+  (identifier) @local.reference)

--- a/server/bleep/src/intelligence/language/python/mod.rs
+++ b/server/bleep/src/intelligence/language/python/mod.rs
@@ -5,7 +5,7 @@ pub static PYTHON: TSLanguageConfig = TSLanguageConfig {
     file_extensions: &["py"],
     grammar: tree_sitter_python::language,
     scope_query: MemoizedQuery::new(include_str!("./scopes.scm")),
-    namespaces: &[&["class", "function", "parameter", "variable", "unknown"]],
+    namespaces: &[&["class", "function", "parameter", "variable"]],
 };
 
 #[cfg(test)]
@@ -136,21 +136,6 @@ mod tests {
             expect![[r#"
                 scope {
                     definitions: [
-                        List {
-                            kind: "unknown",
-                            context: "from typings import §List§",
-                            referenced in (2): [
-                                `def sines(items: §List§[int]) -> List[int]:`,
-                                `def sines(items: List[int]) -> §List§[int]:`,
-                            ],
-                        },
-                        math {
-                            kind: "unknown",
-                            context: "import §math§",
-                            referenced in (1): [
-                                `return [§math§.sin(item) for item in items]`,
-                            ],
-                        },
                         sines {
                             kind: "function",
                             context: "def §sines§(items: List[int]) -> List[int]:",
@@ -163,6 +148,21 @@ mod tests {
                             context: "§list§ = [1, 2, 3]",
                             referenced in (1): [
                                 `sines(§list§)`,
+                            ],
+                        },
+                    ],
+                    imports: [
+                        List {
+                            context: "from typings import §List§",
+                            referenced in (2): [
+                                `def sines(items: §List§[int]) -> List[int]:`,
+                                `def sines(items: List[int]) -> §List§[int]:`,
+                            ],
+                        },
+                        math {
+                            context: "import §math§",
+                            referenced in (1): [
+                                `return [§math§.sin(item) for item in items]`,
                             ],
                         },
                     ],
@@ -358,16 +358,17 @@ mod tests {
             expect![[r#"
                 scope {
                     definitions: [
+                        foo {
+                            kind: "function",
+                            context: "def §foo§():",
+                        },
+                    ],
+                    imports: [
                         decor {
-                            kind: "unknown",
                             context: "from module import §decor§",
                             referenced in (1): [
                                 `@§decor§`,
                             ],
-                        },
-                        foo {
-                            kind: "function",
-                            context: "def §foo§():",
                         },
                     ],
                     child scopes: [

--- a/server/bleep/src/intelligence/language/python/scopes.scm
+++ b/server/bleep/src/intelligence/language/python/scopes.scm
@@ -142,6 +142,10 @@
 (list
   (identifier) @local.reference)
 
+;; f-strings
+(interpolation
+  (identifier) @local.reference)
+
 ;; [ *a ]
 (list_splat
   (identifier) @local.reference)

--- a/server/bleep/src/intelligence/language/python/scopes.scm
+++ b/server/bleep/src/intelligence/language/python/scopes.scm
@@ -93,7 +93,7 @@
   .
   (identifier) @local.definition.variable)
 
-;; imports create defs
+;; imports:
 ;;
 ;;     import a, b
 ;;     import module.submodule.c
@@ -101,34 +101,31 @@
 ;; here, `a`, `b`, `c` are imports, `module` and
 ;; `submodule` are ignored. so we capture the last
 ;; child of the `dotted_name` node using an anchor.
-;;
-;; all imports kinds are `unknown` because their kind 
-;; is unknown without resolving the source file.
 (import_statement
   (dotted_name
-    (identifier) @local.definition.unknown
+    (identifier) @local.import
     .))
 
 ;; import a as b
 ;;
 ;; `a` is ignored
-;; `b` is a def
+;; `b` is an import
 (import_statement
   (aliased_import
     "as"
-    (identifier) @local.definition.unknown))
+    (identifier) @local.import))
 
 ;; from module import name1, name2
 (import_from_statement
   name: 
   (dotted_name
-    (identifier) @local.definition.unknown))
+    (identifier) @local.import))
 
 ;; from __future__ import name
 (future_import_statement
   name:
   (dotted_name 
-    (identifier) @local.definition.unknown))
+    (identifier) @local.import))
 
 ;; class A
 (class_definition

--- a/server/bleep/src/intelligence/language/rust/mod.rs
+++ b/server/bleep/src/intelligence/language/rust/mod.rs
@@ -38,7 +38,7 @@ mod tests {
             static b: () = ();
         "#;
 
-        let (_, def_count, _) = counts(src, "Rust");
+        let (_, def_count, _, _) = counts(src, "Rust");
 
         // a, b
         assert_eq!(def_count, 2);
@@ -56,7 +56,7 @@ mod tests {
                 let S { i, field: _ } = ();
             }
         "#;
-        let (_, def_count, _) = counts(src, "Rust");
+        let (_, def_count, _, _) = counts(src, "Rust");
 
         // main, a, b, c, d, e, f, g, h, i
         assert_eq!(def_count, 10);
@@ -72,7 +72,7 @@ mod tests {
             fn f5(S {h, ..}: S) {}
             fn f6(S { field: i }: S) {}
         "#;
-        let (_, def_count, _) = counts(src, "Rust");
+        let (_, def_count, _, _) = counts(src, "Rust");
 
         // f1, f2, f3, f4, f5, f6, a, b, c, d, e, f, g, h, i
         assert_eq!(def_count, 15);
@@ -88,7 +88,7 @@ mod tests {
                 let _ = |(x, y): ()| {};
             }
         "#;
-        let (_, def_count, _) = counts(src, "Rust");
+        let (_, def_count, _, _) = counts(src, "Rust");
 
         // main,
         // x,
@@ -107,7 +107,7 @@ mod tests {
                 'loop: while true {}
             }
         "#;
-        let (_, def_count, _) = counts(src, "Rust");
+        let (_, def_count, _, _) = counts(src, "Rust");
 
         // main, 'loop x3
         assert_eq!(def_count, 4);
@@ -133,7 +133,7 @@ mod tests {
 
             type Ten = ();
         "#;
-        let (_, def_count, _) = counts(src, "Rust");
+        let (_, def_count, _, _) = counts(src, "Rust");
 
         assert_eq!(def_count, 10);
     }
@@ -147,7 +147,7 @@ mod tests {
                 mod four {}
             }
         "#;
-        let (_, def_count, _) = counts(src, "Rust");
+        let (_, def_count, _, _) = counts(src, "Rust");
 
         assert_eq!(def_count, 4);
     }
@@ -161,7 +161,7 @@ mod tests {
             while let a = () {}
             while let Some(a) = () {}
         "#;
-        let (_, def_count, _) = counts(src, "Rust");
+        let (_, def_count, _, _) = counts(src, "Rust");
 
         assert_eq!(def_count, 4);
     }
@@ -176,7 +176,7 @@ mod tests {
                 *a;
             }
         "#;
-        let (_, _, ref_count) = counts(src, "Rust");
+        let (_, _, ref_count, _) = counts(src, "Rust");
 
         assert_eq!(ref_count, 3);
     }
@@ -191,7 +191,7 @@ mod tests {
                 a >> b;
             }
         "#;
-        let (_, _, ref_count) = counts(src, "Rust");
+        let (_, _, ref_count, _) = counts(src, "Rust");
 
         assert_eq!(ref_count, 4);
     }
@@ -227,7 +227,7 @@ mod tests {
                 yield a;
             }
         "#;
-        let (_, _, ref_count) = counts(src, "Rust");
+        let (_, _, ref_count, _) = counts(src, "Rust");
 
         assert_eq!(ref_count, 8);
     }
@@ -242,7 +242,7 @@ mod tests {
                 a *= 2;
             }
         "#;
-        let (_, _, ref_count) = counts(src, "Rust");
+        let (_, _, ref_count, _) = counts(src, "Rust");
 
         assert_eq!(ref_count, 3);
     }
@@ -258,7 +258,7 @@ mod tests {
                 S { field: a, b };
             }
         "#;
-        let (_, _, ref_count) = counts(src, "Rust");
+        let (_, _, ref_count, _) = counts(src, "Rust");
 
         assert_eq!(ref_count, 5);
     }
@@ -273,7 +273,7 @@ mod tests {
                 a.foo();
             }
         "#;
-        let (_, _, ref_count) = counts(src, "Rust");
+        let (_, _, ref_count, _) = counts(src, "Rust");
 
         assert_eq!(ref_count, 2);
     }
@@ -287,7 +287,7 @@ mod tests {
                 foo(a, b);
             }
         "#;
-        let (_, _, ref_count) = counts(src, "Rust");
+        let (_, _, ref_count, _) = counts(src, "Rust");
 
         assert_eq!(ref_count, 2);
     }
@@ -400,24 +400,21 @@ mod tests {
                                 `use §intelligence§::language as lang;`,
                             ],
                         },
+                    ],
+                    imports: [
                         bleep {
-                            kind: "none",
                             context: "use §bleep§;",
                         },
                         test_utils {
-                            kind: "none",
                             context: "use super::§test_utils§;",
                         },
                         lang {
-                            kind: "none",
                             context: "use intelligence::language as §lang§;",
                         },
                         TextRange {
-                            kind: "none",
                             context: "use crate::text_range::{§TextRange§, Point};",
                         },
                         Point {
-                            kind: "none",
                             context: "use crate::text_range::{TextRange, §Point§};",
                         },
                     ],

--- a/server/bleep/src/intelligence/language/rust/scopes.scm
+++ b/server/bleep/src/intelligence/language/rust/scopes.scm
@@ -175,23 +175,23 @@
 
 ;; use item;
 (use_declaration
-  (identifier) @local.definition)
+  (identifier) @local.import)
 
 ;; use path as item;
 (use_as_clause
-  alias: (identifier) @local.definition)
+  alias: (identifier) @local.import)
 
 ;; use path::item;
 (use_declaration 
   (scoped_identifier 
-    name: (identifier) @local.definition))
+    name: (identifier) @local.import))
 
 ;; use module::{member1, member2, member3};
 (use_list
-  (identifier) @local.definition)
+  (identifier) @local.import)
 (use_list 
   (scoped_identifier
-    name: (identifier) @local.definition))
+    name: (identifier) @local.import))
 
 
 ;; refs

--- a/server/bleep/src/intelligence/language/rust/scopes.scm
+++ b/server/bleep/src/intelligence/language/rust/scopes.scm
@@ -455,3 +455,9 @@
 ;; `T` is a ref
 (scoped_type_identifier
   path: (identifier) @local.reference)
+
+;; struct _ { field: Type }
+;; `Type` is a ref
+ (field_declaration
+   name: (_)
+   type: (type_identifier) @local.reference)

--- a/server/bleep/src/intelligence/language/test_utils.rs
+++ b/server/bleep/src/intelligence/language/test_utils.rs
@@ -7,14 +7,15 @@ use crate::intelligence::{scope_resolution::NodeKind, Language, TreeSitterFile};
 use expect_test::Expect;
 
 #[rustfmt::skip]
-pub fn counts(src: &str, lang_id: &str) -> (usize, usize, usize) {
+pub fn counts(src: &str, lang_id: &str) -> (usize, usize, usize, usize) {
     let tsf = TreeSitterFile::try_build(src.as_bytes(), lang_id).unwrap();
     let scope_graph = tsf.scope_graph().unwrap();
     let nodes = scope_graph.graph.node_weights();
-    nodes.fold((0, 0, 0), |(s, d, r), node| match node {
-        NodeKind::Scope(_) => (s + 1, d,     r    ),
-        NodeKind::Def(_)   => (s,     d + 1, r    ),
-        NodeKind::Ref(_)   => (s,     d,     r + 1),
+    nodes.fold((0, 0, 0, 0), |(s, d, r, i), node| match node {
+        NodeKind::Scope(_) => (s + 1, d,     r    , i    ),
+        NodeKind::Def(_)   => (s,     d + 1, r    , i    ),
+        NodeKind::Ref(_)   => (s,     d,     r + 1, i    ),
+        NodeKind::Import(_)=> (s,     d,     r    , i + 1),
     })
 }
 

--- a/server/bleep/src/intelligence/language/typescript/mod.rs
+++ b/server/bleep/src/intelligence/language/typescript/mod.rs
@@ -69,34 +69,6 @@ mod test {
             expect![[r#"
                 scope {
                     definitions: [
-                        React {
-                            kind: "none",
-                            context: "import §React§, { createContext } from 'react';",
-                            referenced in (1): [
-                                `icon?: §React§.ReactElement;`,
-                            ],
-                        },
-                        createContext {
-                            kind: "none",
-                            context: "import React, { §createContext§ } from 'react';",
-                            referenced in (1): [
-                                `export const SearchContext = §createContext§<ContextType>({`,
-                            ],
-                        },
-                        ExtendedItemType {
-                            kind: "none",
-                            context: "import { §ExtendedItemType§, ItemType }",
-                            referenced in (1): [
-                                `type: ItemType | §ExtendedItemType§;`,
-                            ],
-                        },
-                        ItemType {
-                            kind: "none",
-                            context: "import { ExtendedItemType, §ItemType§ }",
-                            referenced in (1): [
-                                `type: §ItemType§ | ExtendedItemType;`,
-                            ],
-                        },
                         SearchHistoryType {
                             kind: "alias",
                             context: "type §SearchHistoryType§ = {",
@@ -115,6 +87,32 @@ mod test {
                         SearchContext {
                             kind: "constant",
                             context: "export const §SearchContext§ = createContext<ContextType>({",
+                        },
+                    ],
+                    imports: [
+                        React {
+                            context: "import §React§, { createContext } from 'react';",
+                            referenced in (1): [
+                                `icon?: §React§.ReactElement;`,
+                            ],
+                        },
+                        createContext {
+                            context: "import React, { §createContext§ } from 'react';",
+                            referenced in (1): [
+                                `export const SearchContext = §createContext§<ContextType>({`,
+                            ],
+                        },
+                        ExtendedItemType {
+                            context: "import { §ExtendedItemType§, ItemType }",
+                            referenced in (1): [
+                                `type: ItemType | §ExtendedItemType§;`,
+                            ],
+                        },
+                        ItemType {
+                            context: "import { ExtendedItemType, §ItemType§ }",
+                            referenced in (1): [
+                                `type: §ItemType§ | ExtendedItemType;`,
+                            ],
                         },
                     ],
                     child scopes: [
@@ -213,9 +211,9 @@ mod test {
             "#,
             expect![[r#"
                 scope {
-                    definitions: [
+                    definitions: [],
+                    imports: [
                         React {
-                            kind: "none",
                             context: "import §React§ from 'react';",
                             referenced in (2): [
                                 `<§React§.StrictMode>`,
@@ -223,14 +221,12 @@ mod test {
                             ],
                         },
                         ReactDOM {
-                            kind: "none",
                             context: "import §ReactDOM§ from 'react-dom/client';",
                             referenced in (1): [
                                 `§ReactDOM§.createRoot(document.getElementById('root') as HTMLElement).render(`,
                             ],
                         },
                         App {
-                            kind: "none",
                             context: "import §App§ from './App';",
                             referenced in (1): [
                                 `<§App§ />`,

--- a/server/bleep/src/intelligence/language/typescript/scopes.scm
+++ b/server/bleep/src/intelligence/language/typescript/scopes.scm
@@ -128,19 +128,20 @@
 (arrow_function
   (identifier) @local.definition.variable)
 
-;; imports are defs, but of unknown kinds
+
+;; imports
 
 ;; import defaultMember from "module";
 (import_statement
-  (import_clause (identifier) @local.definition))
+  (import_clause (identifier) @local.import))
 
 ;; import { member } from "module";
 ;; import { member as alias } from "module";
 (import_statement
   (import_clause
     (named_imports
-      [(import_specifier !alias (identifier) @local.definition)
-       (import_specifier alias: (identifier) @local.definition)])))
+      [(import_specifier !alias (identifier) @local.import)
+       (import_specifier alias: (identifier) @local.import)])))
 
 ;; for (item in list)
 ;;

--- a/server/bleep/src/intelligence/scope_resolution.rs
+++ b/server/bleep/src/intelligence/scope_resolution.rs
@@ -1,10 +1,12 @@
 #[cfg(test)]
 mod debug;
 mod def;
+mod import;
 mod reference;
 mod scope;
 
 pub use def::LocalDef;
+pub use import::LocalImport;
 pub use reference::Reference;
 pub use scope::{LocalScope, ScopeStack};
 
@@ -58,6 +60,9 @@ pub enum NodeKind {
     /// A definition node
     Def(LocalDef),
 
+    /// An import node
+    Import(LocalImport),
+
     /// A reference node
     Ref(Reference),
 }
@@ -74,6 +79,7 @@ impl NodeKind {
             Self::Scope(l) => l.range,
             Self::Def(d) => d.range,
             Self::Ref(r) => r.range,
+            Self::Import(i) => i.range,
         }
     }
 }
@@ -84,11 +90,17 @@ pub enum EdgeKind {
     /// The edge weight from a nested scope to its parent scope
     ScopeToScope,
 
-    ///The edge weight from a definition to its definition scope
+    /// The edge weight from a definition to its definition scope
     DefToScope,
 
-    ///The edge weight from a reference to its definition
+    /// The edge weight from an import to its definition scope
+    ImportToScope,
+
+    /// The edge weight from a reference to its definition
     RefToDef,
+
+    /// The edge weight from a reference to its import
+    RefToImport,
 }
 
 /// A graph representation of scopes and names in a single syntax tree
@@ -152,9 +164,20 @@ impl ScopeGraph {
         }
     }
 
+    /// Insert an import into the scope-graph
+    pub fn insert_local_import(&mut self, new: LocalImport) {
+        if let Some(defining_scope) = self.scope_by_range(new.range, self.root_idx) {
+            let new_imp = NodeKind::Import(new);
+            let new_idx = self.graph.add_node(new_imp);
+            self.graph
+                .add_edge(new_idx, defining_scope, EdgeKind::ImportToScope);
+        }
+    }
+
     /// Insert a ref into the scope-graph
     pub fn insert_ref(&mut self, new: Reference, src: &[u8]) {
         let mut possible_defs = vec![];
+        let mut possible_imports = vec![];
         if let Some(local_scope_idx) = self.scope_by_range(new.range, self.root_idx) {
             // traverse the scopes from the current-scope to the root-scope
             for scope in self.scope_stack(local_scope_idx) {
@@ -184,14 +207,31 @@ impl ScopeGraph {
                         }
                     }
                 }
+
+                // find candidate imports in each scope
+                for local_import in self
+                    .graph
+                    .edges_directed(scope, Direction::Incoming)
+                    .filter(|edge| *edge.weight() == EdgeKind::ImportToScope)
+                    .map(|edge| edge.source())
+                {
+                    if let NodeKind::Import(import) = &self.graph[local_import] {
+                        if new.name(src) == import.name(src) {
+                            possible_imports.push(local_import);
+                        }
+                    }
+                }
             }
         }
 
-        if !possible_defs.is_empty() {
+        if !possible_defs.is_empty() || !possible_imports.is_empty() {
             let new_ref = NodeKind::Ref(new);
             let ref_idx = self.graph.add_node(new_ref);
             for def_idx in possible_defs {
                 self.graph.add_edge(ref_idx, def_idx, EdgeKind::RefToDef);
+            }
+            for imp_idx in possible_imports {
+                self.graph.add_edge(ref_idx, imp_idx, EdgeKind::RefToImport);
             }
         }
     }
@@ -246,6 +286,7 @@ impl ScopeGraph {
                     NodeKind::Scope(_) => None,
                     NodeKind::Def(d) => Some(d.range),
                     NodeKind::Ref(r) => Some(r.range),
+                    NodeKind::Import(i) => Some(i.range),
                 });
         Box::new(iterator)
     }
@@ -368,6 +409,9 @@ fn scope_res_generic(
     // is a local_def
     let mut local_def_captures = Vec::<LocalDefCapture<'_>>::new();
 
+    // every capture of the form local.import is a local_import
+    let mut local_import_capture_index = None;
+
     // every capture of the form local.reference.<symbol> is a local_ref
     let mut local_ref_captures = Vec::<LocalRefCapture<'_>>::new();
 
@@ -419,6 +463,7 @@ fn scope_res_generic(
                 local_ref_captures.push(l);
             }
             ["local", "scope"] => local_scope_capture_index = Some(i),
+            ["local", "import"] => local_import_capture_index = Some(i),
             _ if !name.starts_with('_') => warn!(?name, "unrecognized query capture"),
             _ => (), // allow captures that start with underscore to fly under the radar
         }
@@ -448,6 +493,14 @@ fn scope_res_generic(
         for range in ranges {
             let scope = LocalScope::new(*range);
             scope_graph.insert_local_scope(scope);
+        }
+    }
+
+    // followed by imports
+    if let Some(ranges) = local_import_capture_index.and_then(|idx| capture_map.get(&idx)) {
+        for range in ranges {
+            let import = LocalImport::new(*range);
+            scope_graph.insert_local_import(import);
         }
     }
 

--- a/server/bleep/src/intelligence/scope_resolution/import.rs
+++ b/server/bleep/src/intelligence/scope_resolution/import.rs
@@ -1,0 +1,19 @@
+use crate::text_range::TextRange;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub struct LocalImport {
+    pub range: TextRange,
+}
+
+impl LocalImport {
+    /// Initialize a new import
+    pub fn new(range: TextRange) -> Self {
+        Self { range }
+    }
+
+    pub fn name<'a>(&self, buffer: &'a [u8]) -> &'a [u8] {
+        &buffer[self.range.start.byte..self.range.end.byte]
+    }
+}

--- a/server/bleep/src/webserver/intelligence.rs
+++ b/server/bleep/src/webserver/intelligence.rs
@@ -289,8 +289,12 @@ pub(super) async fn handle(
             let (repo_wide_definitions, repo_wide_references) =
                 handle_reference_repo_wide(token, kind, current_file, &all_docs);
 
-            // merge the two
-            let definitions = merge([local_definitions], repo_wide_definitions);
+            // if we already have a local-def, do not search globally
+            let definitions = if local_definitions.is_empty() {
+                repo_wide_definitions
+            } else {
+                local_definitions
+            };
             let references = merge([local_references], repo_wide_references);
 
             Ok(json(TokenInfoResponse::Reference {

--- a/server/bleep/src/webserver/intelligence.rs
+++ b/server/bleep/src/webserver/intelligence.rs
@@ -290,10 +290,10 @@ pub(super) async fn handle(
                 handle_reference_repo_wide(token, kind, current_file, &all_docs);
 
             // if we already have a local-def, do not search globally
-            let definitions = if local_definitions.is_empty() {
-                repo_wide_definitions
+            let definitions = if local_definitions.data.is_empty() {
+                merge([], repo_wide_definitions)
             } else {
-                local_definitions
+                merge([local_definitions], [])
             };
             let references = merge([local_references], repo_wide_references);
 


### PR DESCRIPTION
`import`s are both definitions (the introduction of a name to a syntax tree) and references (they refere to a name outside this syntax tree).

this should help improve cross-file navigation using the following heuristics:

- the definition of a name can exclude imports in cross-file navigation by default
- if no definition exists for a name across the entire repo, this name is an externally definied name, we can mark its import node in the same syntax-tree (or file) as its definition node