### PR TITLE
Split large files in proc if they exceed a token limit

### DIFF
--- a/server/bleep/src/webserver/answer.rs
+++ b/server/bleep/src/webserver/answer.rs
@@ -502,7 +502,7 @@ impl Conversation {
             // Buffer file loading to load multiple paths at once
             .buffered(10)
             .and_then(|(lines, path): (Vec<String>, String)| async move {
-                const MAX_TOKENS: usize = 3600;
+                const MAX_TOKENS: usize = 3400;
                 const OVERLAP: usize = 50;
 
                 let bpe = tiktoken_rs::get_bpe_from_model("gpt-3.5-turbo")?;


### PR DESCRIPTION
When reading files in `proc`, large files are now split into multiple sub-files if they exceed a token limit of 3600. This results in multiple proc prompts, for each section of a large file. A token overlap of 50 is included.
 
---

This may work better if we modify the logic so that the chunk barrier is between lines rather than between arbitrary tokens. Though this may affect the quality of results so it needs to be tested further.