### PR TITLE
add comment field to directory citations

### DIFF
--- a/server/bleep/src/webserver/answer/prompts.rs
+++ b/server/bleep/src/webserver/answer/prompts.rs
@@ -150,8 +150,8 @@ pub fn final_explanation_prompt(context: &str, query: &str, query_history: &str)
         },
         Rule {
             title: "Cite a single directory from the codebase",
-            description: "When you wish to cite every file in a directory, use this to directly cite the directory instead.",
-            schema: "[\"dir\",PATH:STRING]",
+            description: "When you wish to cite every file in a directory, use this to directly cite the directory instead. The COMMENT should answer the query with respect to the given directory.",
+            schema: "[\"dir\",PATH:STRING,COMMENT:STRING]",
             note: "This object can occur multiple times",
             example: Some(r#"The path is a relative path, with no leading slash. You must generate a trailing slash, for example: server/bleep/src/webserver/. On Windows, generate backslash separated components, for example: server\bleep\src\webserver\"#),
         },
@@ -232,7 +232,7 @@ Show all the analytics events
 
 Where is the webserver code located
 
-[["dir","server/bleep/src/webserver/"],["con","The webserver code is located under the server directory"]]
+[["dir","server/bleep/src/webserver/","This directory contains the webserver module"],["con","The webserver code is located under the server directory"]]
 
 #####
 

--- a/server/bleep/src/webserver/answer/response.rs
+++ b/server/bleep/src/webserver/answer/response.rs
@@ -144,6 +144,7 @@ pub struct CiteResult {
 #[derive(serde::Serialize, serde::Deserialize, Default, Debug, Clone)]
 pub struct DirectoryResult {
     path: Option<String>,
+    comment: Option<String>,
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Default, Debug, Clone)]
@@ -225,8 +226,13 @@ impl DirectoryResult {
             .get(0)
             .and_then(serde_json::Value::as_str)
             .map(ToOwned::to_owned);
+        let comment = v
+            .get(1)
+            .and_then(serde_json::Value::as_str)
+            .map(ToOwned::to_owned);
         Some(Self {
             path,
+            comment,
             ..Default::default()
         })
     }


### PR DESCRIPTION
cc @anastasiya1155, the response format from the `Directory` tool now includes a streamed comment, just like code citations.