### PR TITLE
fix answer summary

### DIFF
--- a/server/bleep/src/webserver/answer/prompts.rs
+++ b/server/bleep/src/webserver/answer/prompts.rs
@@ -191,8 +191,8 @@ For example:
 
     let output_rules_str = rules
         .into_iter()
-        .enumerate()
-        .map(|(i, r)| {
+        .zip(1..)
+        .map(|(r, i)| {
             let Rule {
                 title,
                 description,


### PR DESCRIPTION
- the previous exchange is the second to last exchange, and not the last exchange
- when we continue a thread, we also add a CONTINUE prompt to the llm history
- change indices of tools to start from 1 instead of 0