### PR TITLE
Ensure that path aliases are in the explanation prompt

### DIFF
--- a/server/bleep/src/webserver/answer.rs
+++ b/server/bleep/src/webserver/answer.rs
@@ -660,11 +660,11 @@ impl Conversation {
             path_aliases.sort();
             path_aliases.dedup();
 
-            if !path_aliases.is_empty() {
+            if !self.path_aliases.is_empty() {
                 s += "##### PATHS #####\npath alias, path\n";
 
-                for alias in &path_aliases {
-                    s += &format!("{alias}, {}\n", &self.path_aliases[*alias]);
+                for (alias, path) in self.path_aliases.iter().enumerate() {
+                    s += &format!("{alias}, {}\n", &path);
                 }
             }
 


### PR DESCRIPTION
After #490, the only `paths` in the explanation prompt were those that were generated as arguments by the `none` action and which overlapped with `code_chunks` in the context. As a result, `paths` found as a result of a path search were not included in the context and queries that relied on a path search failed.

This PR adds _all_ discovered paths to the final explanation context. I'm not sure what's best behaviour here: including all paths or only those paths which are returned as arguments by the `none` action.