### PR TITLE
prevent line numbers from going out of domain

### DIFF
--- a/server/bleep/src/webserver/answer.rs
+++ b/server/bleep/src/webserver/answer.rs
@@ -406,8 +406,14 @@ impl Conversation {
                                 .as_str()
                                 .unwrap()
                                 .parse::<u32>()
-                                .unwrap(),
-                            end_line: chunk["end_line"].as_str().unwrap().parse::<u32>().unwrap(),
+                                .unwrap()
+                                .saturating_add(1),
+                            end_line: chunk["end_line"]
+                                .as_str()
+                                .unwrap()
+                                .parse::<u32>()
+                                .unwrap()
+                                .saturating_add(1),
                         }
                     })
                     .collect::<Vec<_>>();


### PR DESCRIPTION
line numbers stored in qdrant start from zero. when the llm sees zero-indexed line ranges, it begins to produce such ranges too. this also causes off-by-1 errors with the `/file` endpoint.