### PR TITLE
Fix case insensitive regex searches

### DIFF
--- a/server/bleep/src/indexes/reader.rs
+++ b/server/bleep/src/indexes/reader.rs
@@ -28,6 +28,7 @@ pub struct ContentDocument {
     pub branches: Option<String>,
 }
 
+#[derive(Debug)]
 pub struct FileDocument {
     pub relative_path: String,
     pub repo_name: String,

--- a/server/bleep/src/query/compiler.rs
+++ b/server/bleep/src/query/compiler.rs
@@ -370,7 +370,12 @@ mod tests {
             let (occur, query) = clause;
             assert_eq!(*occur, Occur::Must);
 
-            let term = query.downcast_ref::<TermQuery>().unwrap();
+            let subquery = query.downcast_ref::<BooleanQuery>().unwrap();
+            assert_eq!(subquery.clauses().len(), 1);
+
+            let (occur, term) = &subquery.clauses()[0];
+            let term = term.downcast_ref::<TermQuery>().unwrap();
+            assert_eq!(*occur, Occur::Should);
             assert_eq!(term.term().as_str().unwrap(), expected);
         }
     }

--- a/server/bleep/src/query/execute.rs
+++ b/server/bleep/src/query/execute.rs
@@ -196,6 +196,7 @@ impl ApiQuery {
     pub async fn query(self: Arc<Self>, indexes: Arc<Indexes>) -> Result<QueryResponse> {
         let query = self.q.clone();
         let compiled = parser::parse(&query)?;
+        tracing::debug!("compiled query as {compiled:?}");
         self.query_with(indexes, compiled).await
     }
 
@@ -230,12 +231,16 @@ impl ApiQuery {
         // homogenous results will work as expected: `repo:foo or repo:bar`.
         for q in &queries {
             if ContentReader.query_matches(q) {
+                tracing::trace!("executing with ContentReader");
                 return ContentReader.execute(&indexes.file, &queries, &self).await;
             } else if RepoReader.query_matches(q) {
+                tracing::trace!("executing with RepoReader");
                 return RepoReader.execute(&indexes.repo, &queries, &self).await;
             } else if FileReader.query_matches(q) {
+                tracing::trace!("executing with FileReader");
                 return FileReader.execute(&indexes.file, &queries, &self).await;
             } else if OpenReader.query_matches(q) {
+                tracing::trace!("executing with OpenReader");
                 return OpenReader.execute(&indexes.file, &queries, &self).await;
             }
         }


### PR DESCRIPTION
This fixes queries like `path:/README.*/` or simply `/bloop/`.