### PR TITLE
Add repo_ref filter to /answer/conversations

### DIFF
--- a/client/src/components/Chat/AllCoversations/index.tsx
+++ b/client/src/components/Chat/AllCoversations/index.tsx
@@ -24,6 +24,7 @@ type Props = {
   setActive: (b: boolean) => void;
   setConversation: (b: ChatMessage[]) => void;
   setThreadId: (b: string) => void;
+  repoRef: string;
 };
 
 const AllConversations = ({
@@ -32,6 +33,7 @@ const AllConversations = ({
   setActive,
   setThreadId,
   setConversation,
+  repoRef,
 }: Props) => {
   const [openItem, setOpenItem] = useState<ChatMessage[] | null>(null);
   const [conversations, setConversations] = useState<AllConversationsResponse>(
@@ -41,12 +43,14 @@ const AllConversations = ({
   const [title, setTitle] = useState('');
 
   const fetchConversations = useCallback(() => {
-    getAllConversations().then(setConversations);
-  }, []);
+    getAllConversations(repoRef).then(setConversations);
+  }, [repoRef]);
 
   useEffect(() => {
-    fetchConversations();
-  }, [isHistoryOpen]);
+    if (isHistoryOpen) {
+      fetchConversations();
+    }
+  }, [isHistoryOpen, fetchConversations]);
 
   const onDelete = useCallback((threadId: string) => {
     deleteConversation(threadId).then(fetchConversations);

--- a/client/src/components/Chat/index.tsx
+++ b/client/src/components/Chat/index.tsx
@@ -360,6 +360,7 @@ const Chat = () => {
         setActive={setChatOpen}
         setConversation={setConversation}
         setThreadId={setThreadId}
+        repoRef={tab.key}
       />
     </>
   );

--- a/client/src/services/api.ts
+++ b/client/src/services/api.ts
@@ -173,8 +173,12 @@ export const githubWebLogin = () =>
 
 export const getConfig = () => http.get('/config').then((r) => r.data);
 
-export const getAllConversations = (): Promise<AllConversationsResponse> =>
-  http.get('/answer/conversations').then((r) => r.data);
+export const getAllConversations = (
+  repo_ref: string,
+): Promise<AllConversationsResponse> =>
+  http
+    .get('/answer/conversations', { params: { repo_ref } })
+    .then((r) => r.data);
 
 export const getConversation = (
   thread_id: string,

--- a/server/bleep/sqlx-data.json
+++ b/server/bleep/sqlx-data.json
@@ -52,6 +52,36 @@
     },
     "query": "SELECT repo_ref, llm_history, exchanges, path_aliases, code_chunks FROM conversations WHERE user_id = ? AND thread_id = ?"
   },
+  "bc60b0f34fd20feba2da3f16458770424534eacaba75e6f45b8218f32767671b": {
+    "describe": {
+      "columns": [
+        {
+          "name": "thread_id",
+          "ordinal": 0,
+          "type_info": "Text"
+        },
+        {
+          "name": "created_at",
+          "ordinal": 1,
+          "type_info": "Int64"
+        },
+        {
+          "name": "title",
+          "ordinal": 2,
+          "type_info": "Text"
+        }
+      ],
+      "nullable": [
+        false,
+        false,
+        false
+      ],
+      "parameters": {
+        "Right": 2
+      }
+    },
+    "query": "SELECT thread_id, created_at, title FROM conversations WHERE user_id = ? AND repo_ref = ? ORDER BY created_at DESC"
+  },
   "cc1b6ba03d478b999fd7e6f2a3b64c710af167c84eadf715108e61b2564e22c1": {
     "describe": {
       "columns": [],


### PR DESCRIPTION
This adds an optional query parameter `repo_ref`, to enable requests like `/answer/conversations?repo_ref=...`