### PR TITLE
Fix `CompiledTooBig` error panics for long paths

### DIFF
--- a/server/bleep/src/indexes/file.rs
+++ b/server/bleep/src/indexes/file.rs
@@ -385,7 +385,11 @@ impl Indexer<File> {
                     v.push(additions(query_str, i, j));
                     v
                 });
+
             regex::RegexSetBuilder::new(all_regexes)
+                // Increased from the default to account for long paths. At the time of writing,
+                // the default was `10 * (1 << 20)`.
+                .size_limit(10 * (1 << 25))
                 .case_insensitive(true)
                 .build()
                 .unwrap()


### PR DESCRIPTION
This increases the maximum regex set size in fuzzy path matching by a factor of 32x, from `10 * (1 << 20)`, to `10 * (1 << 25)`. The test query used to trigger this was:

```
Explain lines 761 - 772 in server/bleep/src/webserver/answer.rs
```