### PR TITLE
ignore non-blob objects in git file sources

### DIFF
--- a/server/bleep/src/repo/iterator/git.rs
+++ b/server/bleep/src/repo/iterator/git.rs
@@ -143,6 +143,10 @@ impl FileSource for GitWalker {
                     return None;
                 }
 
+                if object.kind != gix::object::Kind::Blob {
+                    return None;
+                }
+
                 let buffer = String::from_utf8_lossy(&object.data).to_string();
 
                 Some(RepoFile {


### PR DESCRIPTION
sometimes tree-like objects would enter this function, and result in their object data being read into a buffer (they are not utf8 strings); producing funny looking buffer data:

    40000 ISSUE_TEMPLATEoDW$yhQ��M��\fX��V�40000 workflows�\nk��$�*^c���0N*7

inspecting the object in git shows that it is a tree and not a blob:

    λ git cat-file -t 3f8a07d9041eeeec38bbde7306023065257fb521
    tree

    λ git cat-file -p 3f8a07d9041eeeec38bbde7306023065257fb521
    040000 tree 6f445724796851c614b74d7fba9e0c58aaee5686    ISSUE_TEMPLATE
    040000 tree ee0a6b10e9e924f92a5e63bb95d730054e2a375c    workflows