### PR TITLE
Deduplicate /answer semantic search results

### DIFF
--- a/server/bleep/src/semantic/execute.rs
+++ b/server/bleep/src/semantic/execute.rs
@@ -8,31 +8,25 @@ use crate::{
     snippet::Snippet,
 };
 
-use super::{deduplicate_snippets, Semantic};
+use super::Semantic;
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 
 pub async fn execute(
     semantic: Semantic,
     query: SemanticQuery<'_>,
     params: ApiQuery,
 ) -> Result<QueryResponse> {
-    let vector = semantic.embed(query.target().context("invalid query")?)?;
-    let query_result = semantic
-        .search_with(
+    let results = semantic
+        .search(
             &query,
-            vector.clone(),
-            params.page_size as u64,
-            ((params.page + 1) * params.page_size) as u64,
+            params.page_size as u32,
+            ((params.page + 1) * params.page_size) as u32,
+            false,
         )
-        .await
-        .map(|raw| {
-            raw.into_iter()
-                .map(super::Payload::from_qdrant)
-                .collect::<Vec<_>>()
-        })?;
+        .await?;
 
-    let data = deduplicate_snippets(query_result, vector, params.page_size)
+    let data = results
         .into_iter()
         .fold(HashMap::new(), |mut acc, payload| {
             acc.entry((

--- a/server/bleep/src/semantic/execute.rs
+++ b/server/bleep/src/semantic/execute.rs
@@ -20,8 +20,8 @@ pub async fn execute(
     let results = semantic
         .search(
             &query,
-            params.page_size as u32,
-            ((params.page + 1) * params.page_size) as u32,
+            params.page_size as u64,
+            ((params.page + 1) * params.page_size) as u64,
             false,
         )
         .await?;

--- a/server/bleep/src/webserver/answer.rs
+++ b/server/bleep/src/webserver/answer.rs
@@ -389,16 +389,10 @@ impl Conversation {
                         .semantic
                         .as_ref()
                         .context("semantic search is not enabled")?
-                        .search(&nl_query, 30, 0)
+                        .search(&nl_query, 30, 0, true)
                         .await?
                         .into_iter()
-                        .map(|v| {
-                            v.payload
-                                .into_iter()
-                                .map(|(k, v)| (k, super::semantic::kind_to_value(v.kind)))
-                                .collect::<HashMap<_, _>>()
-                        })
-                        .map(|chunk| chunk["relative_path"].as_str().unwrap().to_owned())
+                        .map(|chunk| chunk.relative_path.into_owned())
                         .collect::<HashSet<_>>()
                         .into_iter()
                         .collect();
@@ -444,34 +438,18 @@ impl Conversation {
                     .semantic
                     .as_ref()
                     .context("semantic search is not enabled")?
-                    .search(&nl_query, 10, 0)
+                    .search(&nl_query, 10, 0, true)
                     .await?
                     .into_iter()
-                    .map(|v| {
-                        v.payload
-                            .into_iter()
-                            .map(|(k, v)| (k, super::semantic::kind_to_value(v.kind)))
-                            .collect::<HashMap<_, _>>()
-                    })
                     .map(|chunk| {
-                        let relative_path = chunk["relative_path"].as_str().unwrap();
+                        let relative_path = chunk.relative_path;
 
                         CodeChunk {
-                            path: relative_path.to_owned(),
-                            alias: self.path_alias(relative_path) as u32,
-                            snippet: chunk["snippet"].as_str().unwrap().to_owned(),
-                            start_line: chunk["start_line"]
-                                .as_str()
-                                .unwrap()
-                                .parse::<u32>()
-                                .unwrap()
-                                .saturating_add(1),
-                            end_line: chunk["end_line"]
-                                .as_str()
-                                .unwrap()
-                                .parse::<u32>()
-                                .unwrap()
-                                .saturating_add(1),
+                            path: relative_path.clone().into_owned(),
+                            alias: self.path_alias(&relative_path) as u32,
+                            snippet: chunk.text.into_owned(),
+                            start_line: (chunk.start_line as u32).saturating_add(1),
+                            end_line: (chunk.end_line as u32).saturating_add(1),
                         }
                     })
                     .collect::<Vec<_>>();

--- a/server/bleep/src/webserver/semantic.rs
+++ b/server/bleep/src/webserver/semantic.rs
@@ -6,7 +6,6 @@ use crate::{
     },
     semantic::{self, Semantic},
 };
-use qdrant_client::qdrant::value::Kind;
 use tracing::error;
 
 pub(super) async fn complex_search(
@@ -35,25 +34,5 @@ pub(super) async fn complex_search(
             error!(?err, "qdrant query failed");
             Err(Error::new(ErrorKind::UpstreamService, "error"))
         }
-    }
-}
-
-pub fn kind_to_value(kind: Option<Kind>) -> serde_json::Value {
-    match kind {
-        Some(Kind::NullValue(_)) => serde_json::Value::Null,
-        Some(Kind::BoolValue(v)) => serde_json::Value::Bool(v),
-        Some(Kind::DoubleValue(v)) => {
-            serde_json::Value::Number(serde_json::Number::from_f64(v).unwrap())
-        }
-        Some(Kind::IntegerValue(v)) => serde_json::Value::Number(v.into()),
-        Some(Kind::StringValue(v)) => serde_json::Value::String(v),
-        Some(Kind::ListValue(v)) => serde_json::Value::Array(
-            v.values
-                .into_iter()
-                .map(|v| kind_to_value(v.kind))
-                .collect(),
-        ),
-        Some(Kind::StructValue(_v)) => todo!(),
-        None => serde_json::Value::Null,
     }
 }


### PR DESCRIPTION
The implementation here is unsatisfactory. There is still a discrepancy in behaviour between the semantic search used in `/answer` and `/search`. In `/answer` `limit` is the post-deduplication number of search results, whereas in `/search` it is the pre-deduplication number (so as to be compatible with Qdrant paging).

Open to ideas for how to resolve this neatly.