### PR TITLE
Trim old code chunks in the answer prompt

### DIFF
--- a/server/bleep/src/webserver/answer.rs
+++ b/server/bleep/src/webserver/answer.rs
@@ -827,7 +827,7 @@ impl Conversation {
                 let formatted_snippet =
                     format!("### path alias: {} ###\n{snippet}\n\n", chunk.alias);
 
-                let snippet_tokens = bpe.split_by_token_ordinary_iter(&formatted_snippet).count();
+                let snippet_tokens = bpe.encode_ordinary(&formatted_snippet).len();
 
                 if snippet_tokens >= remaining_prompt_tokens - PROMPT_HEADROOM {
                     debug!("Breaking at {} tokens...", remaining_prompt_tokens);

--- a/server/bleep/src/webserver/answer.rs
+++ b/server/bleep/src/webserver/answer.rs
@@ -22,7 +22,7 @@ use reqwest::StatusCode;
 use secrecy::ExposeSecret;
 use tiktoken_rs::CoreBPE;
 use tokio::sync::mpsc::Sender;
-use tracing::{info, trace, warn};
+use tracing::{debug, info, trace, warn};
 
 use super::middleware::User;
 use crate::{
@@ -811,6 +811,10 @@ impl Conversation {
                     .collect()
             };
 
+            const PROMPT_HEADROOM: usize = 1500;
+            let bpe = tiktoken_rs::get_bpe_from_model("gpt-4")?;
+            let mut remaining_prompt_tokens = tiktoken_rs::get_completion_max_tokens("gpt-4", &s)?;
+
             // Order chunks by most recent.
             for chunk in code_chunks.iter().rev() {
                 let snippet = chunk
@@ -820,9 +824,19 @@ impl Conversation {
                     .map(|(i, line)| format!("{} {line}\n", i + chunk.start_line as usize))
                     .collect::<String>();
 
-                s += &format!("### path alias: {} ###\n{snippet}\n\n", chunk.alias);
-            }
+                let formatted_snippet =
+                    format!("### path alias: {} ###\n{snippet}\n\n", chunk.alias);
 
+                let snippet_tokens = bpe.split_by_token_ordinary_iter(&formatted_snippet).count();
+
+                if snippet_tokens >= remaining_prompt_tokens - PROMPT_HEADROOM {
+                    debug!("Breaking at {} tokens...", remaining_prompt_tokens);
+                    break;
+                }
+
+                remaining_prompt_tokens -= snippet_tokens;
+                debug!("{}", remaining_prompt_tokens);
+            }
             s
         };
 


### PR DESCRIPTION
Previously we inserted every discovered code chunk into the explanation prompt. This iteratively adds recent chunks until the token count exceeds `max_tokens - headroom`, where `headroom` is set to 1500 to make room for the prompt text itself.