### PR TITLE
Track LLM gateway errors

### DIFF
--- a/server/bleep/src/webserver/answer.rs
+++ b/server/bleep/src/webserver/answer.rs
@@ -482,12 +482,10 @@ impl Conversation {
             &(action_result + "\n\nAnswer only with a JSON action."),
         ));
 
-        let messages = self.trimmed_history()?;
         let raw_response = ctx
             .llm_gateway
-            .chat(&messages)
-            .await
-            .map_err(|e| ctx.handle_chat_err(e, &messages))?
+            .chat(&self.trimmed_history()?)
+            .await?
             .try_collect::<String>()
             .await?;
 
@@ -597,12 +595,10 @@ impl Conversation {
                 let contents = lines.join("\n");
                 let prompt = prompts::file_explanation(question, &path, &contents);
 
-                let messages = &[llm_gateway::api::Message::system(&prompt)];
                 let json = ctx
                     .llm_gateway
-                    .chat(messages)
-                    .await
-                    .map_err(|e| ctx.handle_chat_err(e, messages))?
+                    .chat(&[llm_gateway::api::Message::system(&prompt)])
+                    .await?
                     .try_collect::<String>()
                     .await?;
 
@@ -856,12 +852,7 @@ impl Conversation {
 
         let messages = [llm_gateway::api::Message::system(&prompt)];
 
-        let mut stream = ctx
-            .llm_gateway
-            .chat(&messages)
-            .await
-            .map_err(|e| ctx.handle_chat_err(e, &messages))?
-            .boxed();
+        let mut stream = ctx.llm_gateway.chat(&messages).await?.boxed();
         let mut buffer = String::new();
         while let Some(token) = stream.next().await {
             buffer += &token?;
@@ -1242,19 +1233,6 @@ impl AppContext {
             data,
         };
         self.app.track_query(&self.user, &event);
-    }
-
-    fn handle_chat_err(
-        &self,
-        e: anyhow::Error,
-        messages: &[llm_gateway::api::Message],
-    ) -> anyhow::Error {
-        self.track_query(
-            EventData::output_stage("llm_error")
-                .with_payload("conversation", serde_json::to_string(messages).unwrap())
-                .with_payload("message", e.to_string()),
-        );
-        e
     }
 }
 


### PR DESCRIPTION
Due to our integration of `sentry_tracing`, `error!` logs are captured as sentry errors. We propagate additional information like message history using breadcrumbs generated by `debug!`.