### PR TITLE
fix git tree objects being detected as files

### DIFF
--- a/server/bleep/src/repo/iterator/git.rs
+++ b/server/bleep/src/repo/iterator/git.rs
@@ -143,9 +143,11 @@ impl FileSource for GitWalker {
                     return None;
                 }
 
-                let buffer = (object.kind == gix::object::Kind::Blob)
-                    .then(|| String::from_utf8_lossy(&object.data).to_string())
-                    .unwrap_or_default();
+                let buffer = match kind {
+                    FileType::File => String::from_utf8_lossy(&object.data).to_string(),
+                    FileType::Dir => String::default(),
+                    FileType::Other => return None,
+                };
 
                 Some(RepoFile {
                     path: file,

--- a/server/bleep/src/repo/iterator/git.rs
+++ b/server/bleep/src/repo/iterator/git.rs
@@ -43,7 +43,7 @@ impl GitWalker {
     pub fn open_repository(
         dir: impl AsRef<Path>,
         filter: impl Into<Option<BranchFilter>>,
-    ) -> Result<impl FileSource> {
+    ) -> Result<Self> {
         let root_dir = dir.as_ref();
         let branches = filter.into().unwrap_or_default();
         let git = gix::open::Options::isolated()
@@ -143,11 +143,9 @@ impl FileSource for GitWalker {
                     return None;
                 }
 
-                if matches!(kind, FileType::Other) {
-                    return None;
-                }
-
-                let buffer = String::from_utf8_lossy(&object.data).to_string();
+                let buffer = (object.kind == gix::object::Kind::Blob)
+                    .then(|| String::from_utf8_lossy(&object.data).to_string())
+                    .unwrap_or_default();
 
                 Some(RepoFile {
                     path: file,


### PR DESCRIPTION
the fix is very similar to the original PR. the original PR omitted non-blob objects in the FileSource trait, which resulted in directory items being omitted from the index altogether.

this changeset initializes non-blob objects in FileSource, albeit with an empty buffer.