### PR TITLE
Prioritize indexer threads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -538,6 +538,7 @@ dependencies = [
  "tantivy",
  "tempdir",
  "thiserror",
+ "thread-priority",
  "tiktoken-rs",
  "time 0.3.21",
  "tokenizers",
@@ -6925,6 +6926,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.16",
+]
+
+[[package]]
+name = "thread-priority"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c56ce92f1285eaaa11fc1a3201e25de97898c50e87caa4c2aee836fe05288de"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+ "log",
+ "rustversion",
+ "winapi",
 ]
 
 [[package]]

--- a/server/bleep/Cargo.toml
+++ b/server/bleep/Cargo.toml
@@ -119,6 +119,7 @@ scc = { version= "1.8.0", features = ["serde"] }
 sentry-tracing = "0.31.1"
 git-version = "0.3.5"
 gix = { version="0.44.1", features = ["blocking-http-transport-reqwest", "blocking-network-client", "pack-cache-lru-static"] }
+thread-priority = "0.13.1"
 
 [target.'cfg(windows)'.dependencies]
 dunce = "1.0.4"


### PR DESCRIPTION
This may help alleviate issues where CPU use drops when the window is unfocused.