### PR TITLE
Fix code chunk canonicalization

### DIFF
--- a/server/bleep/src/webserver/answer.rs
+++ b/server/bleep/src/webserver/answer.rs
@@ -1078,6 +1078,8 @@ impl Conversation {
                                     a.push(next);
                                 }
                             }
+                        } else {
+                            a.push(next);
                         }
 
                         a


### PR DESCRIPTION
Previously, code chunks would be folded without inserting the initial element. Now, we make sure to push the first chunk when the accumulator is empty.