### PR TITLE
Unify user-specific github client handling

### DIFF
--- a/server/bleep/src/analytics.rs
+++ b/server/bleep/src/analytics.rs
@@ -118,11 +118,11 @@ impl RudderHub {
     }
 
     pub fn tracking_id(&self, user: &crate::webserver::middleware::User) -> String {
-        match user.0 {
-            Some(ref username) => {
+        match user.login() {
+            Some(username) => {
                 let id = self
                     .user_store
-                    .entry(username.clone())
+                    .entry(username.to_string())
                     .or_default()
                     .get()
                     .tracking_id();

--- a/server/bleep/src/webserver/answer.rs
+++ b/server/bleep/src/webserver/answer.rs
@@ -96,8 +96,7 @@ pub(super) async fn _handle(
 > {
     let conversation_id = ConversationId {
         user_id: user
-            .0
-            .as_ref()
+            .login()
             .ok_or_else(|| super::Error::user("didn't have user ID"))?
             .to_string(),
         thread_id: params.thread_id,

--- a/server/bleep/src/webserver/config.rs
+++ b/server/bleep/src/webserver/config.rs
@@ -42,10 +42,8 @@ pub(super) async fn handle(
     });
 
     let github_user = 'user: {
-        let Some(gh) = app.credentials.github() else {
-            break 'user None;
-        };
-        let Ok(crab) = gh.client() else {
+        let Some(crab) = user.github()
+	else {
             break 'user None;
         };
         crab.current().user().await.ok()
@@ -55,7 +53,7 @@ pub(super) async fn handle(
         analytics_data_plane: app.config.analytics_data_plane.clone(),
         analytics_key_fe: app.config.analytics_key_fe.clone(),
         sentry_dsn_fe: app.config.sentry_dsn_fe.clone(),
-        user_login: user.0,
+        user_login: user.login().map(str::to_owned),
         schema_version: crate::state::SCHEMA_VERSION.into(),
         bloop_version: env!("CARGO_PKG_VERSION").into(),
         bloop_commit: git_version::git_version!(fallback = "unknown").into(),


### PR DESCRIPTION
This should fix cloud issues where the GitHub object is empty in the config endpoint response.