### PR TITLE
Change endpoints to take query param instead of path

### DIFF
--- a/client/src/services/api.ts
+++ b/client/src/services/api.ts
@@ -137,13 +137,15 @@ export const scanLocalRepos = (path: string) => {
 };
 
 export const deleteRepo = (repoRef: string) =>
-  http.delete(`/repos/indexed/${repoRef}`).then((r) => r.data);
+  http
+    .delete(`/repos/indexed`, { params: { repo: repoRef } })
+    .then((r) => r.data);
 
 export const cancelSync = (repoRef: string) =>
-  http.delete(`/repos/sync/${repoRef}`).then((r) => r.data);
+  http.delete(`/repos/sync`, { params: { repo: repoRef } }).then((r) => r.data);
 
 export const syncRepo = (repoRef: string) =>
-  http.get(`/repos/sync/${repoRef}`).then((r) => r.data);
+  http.get(`/repos/sync`, { params: { repo: repoRef } }).then((r) => r.data);
 
 export const saveUserData = (userData: {
   email: string;

--- a/server/bleep/src/webserver.rs
+++ b/server/bleep/src/webserver.rs
@@ -50,16 +50,11 @@ pub async fn start(app: Application) -> anyhow::Result<()> {
         .route("/repos/status", get(repos::index_status))
         .route(
             "/repos/indexed",
-            get(repos::indexed).put(repos::set_indexed),
+            get(repos::indexed)
+                .put(repos::set_indexed)
+                .delete(repos::delete_by_id),
         )
-        .route(
-            "/repos/indexed/*path",
-            get(repos::get_by_id).delete(repos::delete_by_id),
-        )
-        .route(
-            "/repos/sync/*path",
-            get(repos::sync).delete(repos::delete_sync),
-        )
+        .route("/repos/sync", get(repos::sync).delete(repos::delete_sync))
         // intelligence
         .route("/hoverable", get(hoverable::handle))
         .route("/token-info", get(intelligence::handle))


### PR DESCRIPTION
The following endpoints have changed:

```
GET or DELETE /repos/indexed/*path -> /repos/indexed?repo=reporef
GET or DELETE /repos/sync/*path -> /repos/sync?repo=reporef
```

This hopefully resolves ambiguities in path parsing across OSs