### PR TITLE
Rename 'ans' to 'none', minor tweaks

### DIFF
--- a/server/bleep/src/webserver/answer.rs
+++ b/server/bleep/src/webserver/answer.rs
@@ -485,12 +485,12 @@ impl Conversation {
             Action::Query(query) => {
                 self.llm_history
                     .push_back(llm_gateway::api::Message::user(&format!(
-                        "{query}\nRespond with a function:"
+                        "{query}\nOnly respond with a function_call."
                     )))
             }
             _ => {
                 let function_name = match &action {
-                    Action::Answer { .. } => "ans",
+                    Action::Answer { .. } => "none",
                     Action::Path { .. } => "path",
                     Action::Code { .. } => "code",
                     Action::Proc { .. } => "proc",
@@ -499,7 +499,7 @@ impl Conversation {
                 self.llm_history
                     .push_back(llm_gateway::api::Message::function_return(
                         function_name,
-                        &format!("{action_result}\nRespond with a function:"),
+                        &format!("{action_result}\nOnly respond with a function_call."),
                     ));
             }
         };
@@ -1308,7 +1308,7 @@ enum Action {
     Path {
         query: String,
     },
-    #[serde(rename = "ans")]
+    #[serde(rename = "none")]
     Answer {
         paths: Vec<usize>,
     },

--- a/server/bleep/src/webserver/answer.rs
+++ b/server/bleep/src/webserver/answer.rs
@@ -485,7 +485,7 @@ impl Conversation {
             Action::Query(query) => {
                 self.llm_history
                     .push_back(llm_gateway::api::Message::user(&format!(
-                        "{query}\nOnly respond with a function_call."
+                        "{query}\nDo not answer."
                     )))
             }
             _ => {
@@ -499,7 +499,7 @@ impl Conversation {
                 self.llm_history
                     .push_back(llm_gateway::api::Message::function_return(
                         function_name,
-                        &format!("{action_result}\nOnly respond with a function_call."),
+                        &format!("{action_result}\nDo not answer."),
                     ));
             }
         };

--- a/server/bleep/src/webserver/answer/prompts.rs
+++ b/server/bleep/src/webserver/answer/prompts.rs
@@ -51,7 +51,7 @@ pub fn functions() -> serde_json::Value {
                 }
             },
             {
-                "name": "ans",
+                "name": "none",
                 "description": "You have enough information to answer the user's query. This is the final step, and signals that you have enough information to respond to the user's query. Use this if the user has intructed you to modify some code.",
                 "parameters": {
                     "type": "object",
@@ -83,20 +83,18 @@ pub fn system(paths: &Vec<String>) -> String {
     }
 
     s.push_str(
-        r#"
-Follow these rules at all times:
+        r#"Follow these rules at all times:
 
 - If the output of a function is empty, try the same function again with different arguments or try using a different function
-- In most cases you'll have to use the `code` or `path` functions before using `ans`
+- In most cases respond with functions.code or functions.path functions before responding with functions.none
 - Do not assume the structure of the codebase, or the existence of files or folders
-- Do NOT use a function that you've used before with the same arguments
-- When you are confident that you have enough information needed to answer the query use the `ans` function
-- If after making a path search the query can be answered by the existance of the paths, and there are more than 5 paths, use the `ans` function
+- Do NOT respond with a function that you've used before with the same arguments
+- When you have enough information to answer the  user's query respond with functions.none
+- If after making a path search the query can be answered by the existance of the paths, and there are more than 5 paths, use the functions.none function
 - Only refer to path aliases that are under the PATHS heading above
-- Use the functions to find information related to the query, until all relevant information has been found.
-- If after attempting to gather information you are still unsure how to answer the query, use the `ans` function
-- Always answer with a function call. Do NOT answer the question directly
-"#);
+- Respond with functions to find information related to the query, until all relevant information has been found.
+- If after attempting to gather information you are still unsure how to answer the query, respond with the functions.none function
+- Always respond with a function call. Do NOT answer the question directly"#);
     s
 }
 


### PR DESCRIPTION
- Rename 'ans' to 'none' - doubled usage of proc on the eval set, now more or less same as pre-function-calling
- Slightly stricter language in the system prompt - stronger tool utilisation
- Removed blank newline above and below system prompt - unknown if any impact, good practise
- Changed "Respond with a function:" to "Do not answer." - this solves a content response in rare cases