### PR TITLE
Apply Qdrant quantisation and use on-disk storage

### DIFF
--- a/apps/desktop/src-tauri/src/QDRANT_CONFIG_TEMPLATE.yml
+++ b/apps/desktop/src-tauri/src/QDRANT_CONFIG_TEMPLATE.yml
@@ -10,7 +10,7 @@ storage:
   # It will be read from the disk every time it is requested.
   # This setting saves RAM by (slightly) increasing the response time.
   # Note: those payload values that are involved in filtering and are indexed - remain in RAM.
-  on_disk_payload: false
+  on_disk_payload: true
 
   # Write-ahead-log related configuration
   wal:

--- a/server/bleep/src/semantic.rs
+++ b/server/bleep/src/semantic.rs
@@ -10,10 +10,11 @@ use ort::{
 use qdrant_client::{
     prelude::{QdrantClient, QdrantClientConfig},
     qdrant::{
-        r#match::MatchValue, vectors::VectorsOptions, vectors_config, with_payload_selector,
-        with_vectors_selector, CollectionOperationResponse, CreateCollection, Distance,
-        FieldCondition, Filter, Match, PointId, PointStruct, ScoredPoint, SearchPoints, Value,
-        VectorParams, Vectors, VectorsConfig, WithPayloadSelector, WithVectorsSelector,
+        quantization_config::Quantization, r#match::MatchValue, vectors::VectorsOptions,
+        vectors_config, with_payload_selector, with_vectors_selector, CollectionOperationResponse,
+        CreateCollection, Distance, FieldCondition, Filter, Match, PointId, PointStruct,
+        QuantizationConfig, ScalarQuantization, ScoredPoint, SearchPoints, Value, VectorParams,
+        Vectors, VectorsConfig, WithPayloadSelector, WithVectorsSelector,
     },
 };
 
@@ -149,6 +150,13 @@ fn collection_config() -> CreateCollection {
             config: Some(vectors_config::Config::Params(VectorParams {
                 size: 384,
                 distance: Distance::Cosine.into(),
+                ..Default::default()
+            })),
+        }),
+        quantization_config: Some(QuantizationConfig {
+            quantization: Some(Quantization::Scalar(ScalarQuantization {
+                r#type: 1, // Int8
+                quantile: Some(0.99),
                 ..Default::default()
             })),
         }),


### PR DESCRIPTION
Applies two optimisations to Qdrant:

1) Int8 quantisation. This reduces the size of a Qdrant index with `bloop` indexed from 70Mb to 58Mb with no noticeable drop in search performance. See: https://qdrant.tech/documentation/guides/quantization/#setting-up-scalar-quantization

2) `on_disk` storage of payloads. Decreases RAM by slightly increasing response times: https://github.com/qdrant/qdrant/blob/8cb1a4e159c5de37662e55c29c870834e751f1c6/config/config.yaml#L15