### PR TITLE
Fix ruby compile error

### DIFF
--- a/server/bleep/src/intelligence/language/ruby/mod.rs
+++ b/server/bleep/src/intelligence/language/ruby/mod.rs
@@ -5,6 +5,11 @@ pub static RUBY: TSLanguageConfig = TSLanguageConfig {
     file_extensions: &["rb"],
     grammar: tree_sitter_ruby::language,
     scope_query: MemoizedQuery::new(include_str!("./scopes.scm")),
+    hoverable_query: MemoizedQuery::new(
+        r#"
+        (identifier) @hoverable
+        "#,
+    ),
     namespaces: &[
         // everything is an object
         &["variable", "constant", "class", "method", "module"],


### PR DESCRIPTION
Add `hoverable_query` to the Ruby `TSLanguageConfig`. This likely does not cover all Ruby hoverables but is a quick fix. cc. @nerdypepper 