### PR TITLE
Tweak prompt to encourage agent to respond with function call

### DIFF
--- a/server/bleep/src/webserver/answer.rs
+++ b/server/bleep/src/webserver/answer.rs
@@ -485,7 +485,7 @@ impl Conversation {
             Action::Query(query) => {
                 self.llm_history
                     .push_back(llm_gateway::api::Message::user(&format!(
-                        "{query}\nDo not answer."
+                        "{query}\nCall a function. Do not answer."
                     )))
             }
             _ => {
@@ -499,7 +499,7 @@ impl Conversation {
                 self.llm_history
                     .push_back(llm_gateway::api::Message::function_return(
                         function_name,
-                        &format!("{action_result}\nDo not answer."),
+                        &format!("{action_result}\nCall a function. Do not answer."),
                     ));
             }
         };

--- a/server/bleep/src/webserver/answer/prompts.rs
+++ b/server/bleep/src/webserver/answer/prompts.rs
@@ -52,7 +52,7 @@ pub fn functions() -> serde_json::Value {
             },
             {
                 "name": "none",
-                "description": "You have enough information to answer the user's query. This is the final step, and signals that you have enough information to respond to the user's query. Use this if the user has intructed you to modify some code.",
+                "description": "You have enough information to answer the user's query. This is the final step, and signals that you have enough information to respond to the user's query. Use this if the user has instructed you to modify some code.",
                 "parameters": {
                     "type": "object",
                     "properties": {
@@ -72,8 +72,7 @@ pub fn functions() -> serde_json::Value {
 }
 
 pub fn system(paths: &Vec<String>) -> String {
-    let mut s =
-        "Your job is to choose a function that will help you answer the query.\n".to_string();
+    let mut s = "".to_string();
 
     if !paths.is_empty() {
         s.push_str("## PATHS ##\nalias, path\n");
@@ -90,11 +89,13 @@ pub fn system(paths: &Vec<String>) -> String {
 - Do not assume the structure of the codebase, or the existence of files or folders
 - Do NOT respond with a function that you've used before with the same arguments
 - When you have enough information to answer the user's query respond with functions.none
-- If after making a path search the query can be answered by the existance of the paths, and there are more than 5 paths, use the functions.none function
+- If after making a path search the query can be answered by the existence of the paths, and there are more than 5 paths, use the functions.none function
 - Only refer to path aliases that are under the PATHS heading above
 - Respond with functions to find information related to the query, until all relevant information has been found
 - If you have already called functions.code or functions.path but they did not return any relevant information, try again with a substantively different query. The terms in your new query should not overlap with terms in previous queries
 - If after attempting to gather information you are still unsure how to answer the query, respond with the functions.none function
+- If the query is a greeting, or not a question or an instruction use functions.none
+- Always use a function, even if the query is not in English
 - Always respond with a function call. Do NOT answer the question directly"#);
     s
 }


### PR DESCRIPTION
Queries regularly fail because the action selection call does not respond with a function. This PR makes some tweaks to the prompt to address these cases. 