### PR TITLE
Use native message history when generating LLM request

### DIFF
--- a/server/bleep/src/webserver/answer.rs
+++ b/server/bleep/src/webserver/answer.rs
@@ -923,7 +923,7 @@ impl Conversation {
         let system_message = prompts::final_explanation_prompt(&context, query);
         let messages = Some(llm_gateway::api::Message::system(&system_message))
             .into_iter()
-            .chain(query_history)
+            .chain(query_history.iter().cloned())
             .collect::<Vec<_>>();
 
         let mut stream = ctx.llm_gateway.chat(&messages, None).await?.boxed();

--- a/server/bleep/src/webserver/answer.rs
+++ b/server/bleep/src/webserver/answer.rs
@@ -294,7 +294,7 @@ impl Conversation {
         }
     }
 
-    fn query_history(&self) -> Vec<llm_gateway::api::Message> {
+    fn query_history(&self) -> impl Iterator<Item = llm_gateway::api::Message> {
         self.exchanges
             .iter()
             .flat_map(|e| match (e.query(), e.conclusion()) {
@@ -303,7 +303,6 @@ impl Conversation {
                 _ => vec![],
             })
             .map(|(author, message)| format!("{author}: {message}"))
-            .collect()
     }
 
     // Generate a summary of the last exchange

--- a/server/bleep/src/webserver/answer.rs
+++ b/server/bleep/src/webserver/answer.rs
@@ -294,7 +294,7 @@ impl Conversation {
         }
     }
 
-    fn query_history(&self) -> Vec<String> {
+    fn query_history(&self) -> Vec<llm_gateway::api::Message> {
         self.exchanges
             .iter()
             .flat_map(|e| match (e.query(), e.conclusion()) {
@@ -915,13 +915,13 @@ impl Conversation {
             s
         };
 
-        let query_history = self.query_history().join("\n");
+        let query_history = self.query_history();
         let query = self
             .last_exchange()
             .query()
             .context("exchange did not have a user query")?;
 
-        let prompt = prompts::final_explanation_prompt(&context, query, &query_history);
+        let prompt = prompts::final_explanation_prompt(&context, query);
 
         let messages = [llm_gateway::api::Message::system(&prompt)];
 

--- a/server/bleep/src/webserver/answer.rs
+++ b/server/bleep/src/webserver/answer.rs
@@ -920,9 +920,8 @@ impl Conversation {
             .query()
             .context("exchange did not have a user query")?;
 
-        let prompt = prompts::final_explanation_prompt(&context, query);
-
-        let messages = Some(llm_gateway::api::Message::system(&prompt)).into_iter().chain(query_history).collect();
+        let system_message = prompts::final_explanation_prompt(&context, query);
+        let messages = Some(llm_gateway::api::Message::system(&system_message)).into_iter().chain(query_history).collect();
 
         let mut stream = ctx.llm_gateway.chat(&messages, None).await?.boxed();
         let mut buffer = String::new();

--- a/server/bleep/src/webserver/answer.rs
+++ b/server/bleep/src/webserver/answer.rs
@@ -921,7 +921,10 @@ impl Conversation {
             .context("exchange did not have a user query")?;
 
         let system_message = prompts::final_explanation_prompt(&context, query);
-        let messages = Some(llm_gateway::api::Message::system(&system_message)).into_iter().chain(query_history).collect();
+        let messages = Some(llm_gateway::api::Message::system(&system_message))
+            .into_iter()
+            .chain(query_history)
+            .collect::<Vec<_>>();
 
         let mut stream = ctx.llm_gateway.chat(&messages, None).await?.boxed();
         let mut buffer = String::new();

--- a/server/bleep/src/webserver/answer.rs
+++ b/server/bleep/src/webserver/answer.rs
@@ -294,7 +294,7 @@ impl Conversation {
         }
     }
 
-    fn query_history(&self) -> impl Iterator<Item = llm_gateway::api::Message> {
+    fn query_history(&self) -> impl Iterator<Item = llm_gateway::api::Message> + '_ {
         self.exchanges
             .iter()
             .flat_map(|e| {

--- a/server/bleep/src/webserver/answer.rs
+++ b/server/bleep/src/webserver/answer.rs
@@ -295,24 +295,24 @@ impl Conversation {
     }
 
     fn query_history(&self) -> impl Iterator<Item = llm_gateway::api::Message> + '_ {
-        self.exchanges
-            .iter()
-            .flat_map(|e| {
-                let query = e.query().map(|q| llm_gateway::api::Message::PlainText {
-                    role: "user".to_owned(),
-                    content: q.to_owned(),
-                });
+        self.exchanges.iter().flat_map(|e| {
+            let query = e.query().map(|q| llm_gateway::api::Message::PlainText {
+                role: "user".to_owned(),
+                content: q.to_owned(),
+            });
 
-                let conclusion = e.conclusion().map(|c| llm_gateway::api::Message::PlainText {
+            let conclusion = e
+                .conclusion()
+                .map(|c| llm_gateway::api::Message::PlainText {
                     role: "assistant".to_owned(),
                     content: c.to_owned(),
                 });
 
-                query
-                    .into_iter()
-                    .chain(conclusion.into_iter())
-                    .collect::<Vec<_>>()
-            })
+            query
+                .into_iter()
+                .chain(conclusion.into_iter())
+                .collect::<Vec<_>>()
+        })
     }
 
     // Generate a summary of the last exchange

--- a/server/bleep/src/webserver/answer.rs
+++ b/server/bleep/src/webserver/answer.rs
@@ -923,7 +923,7 @@ impl Conversation {
 
         let prompt = prompts::final_explanation_prompt(&context, query);
 
-        let messages = [llm_gateway::api::Message::system(&prompt)];
+        let messages = Some(llm_gateway::api::Message::system(&prompt)).into_iter().chain(query_history).collect();
 
         let mut stream = ctx.llm_gateway.chat(&messages, None).await?.boxed();
         let mut buffer = String::new();

--- a/server/bleep/src/webserver/answer.rs
+++ b/server/bleep/src/webserver/answer.rs
@@ -914,7 +914,7 @@ impl Conversation {
             s
         };
 
-        let query_history = self.query_history();
+        let query_history = self.query_history().collect::<Vec<_>>();
         let query = self
             .last_exchange()
             .query()
@@ -975,7 +975,7 @@ impl Conversation {
                 .with_payload("query", self.last_exchange().query())
                 .with_payload("query_history", &query_history)
                 .with_payload("response", &buffer)
-                .with_payload("raw_prompt", &prompt),
+                .with_payload("system_message", &system_message),
         );
 
         Ok(())

--- a/server/bleep/src/webserver/answer.rs
+++ b/server/bleep/src/webserver/answer.rs
@@ -915,12 +915,7 @@ impl Conversation {
         };
 
         let query_history = self.query_history().collect::<Vec<_>>();
-        let query = self
-            .last_exchange()
-            .query()
-            .context("exchange did not have a user query")?;
-
-        let system_message = prompts::final_explanation_prompt(&context, query);
+        let system_message = prompts::final_explanation_prompt(&context);
         let messages = Some(llm_gateway::api::Message::system(&system_message))
             .into_iter()
             .chain(query_history.iter().cloned())

--- a/server/bleep/src/webserver/answer.rs
+++ b/server/bleep/src/webserver/answer.rs
@@ -8,7 +8,7 @@ use std::{
     time::Duration,
 };
 
-use anyhow::{anyhow, Context, Result, bail};
+use anyhow::{anyhow, bail, Context, Result};
 use axum::{
     extract::Query,
     response::{
@@ -927,7 +927,9 @@ impl Conversation {
         let mut query_history = self.query_history().collect::<Vec<_>>();
 
         {
-            let (role, content) = query_history.last_mut().context("query history was empty")?
+            let (role, content) = query_history
+                .last_mut()
+                .context("query history was empty")?
                 .as_plaintext_mut()
                 .context("last message was not plaintext")?;
 

--- a/server/bleep/src/webserver/answer/llm_gateway.rs
+++ b/server/bleep/src/webserver/answer/llm_gateway.rs
@@ -152,7 +152,7 @@ impl api::Message {
     pub fn as_plaintext_mut(&mut self) -> Option<(&mut String, &mut String)> {
         match self {
             Self::PlainText { role, content } => Some((role, content)),
-            _ => None
+            _ => None,
         }
     }
 }

--- a/server/bleep/src/webserver/answer/llm_gateway.rs
+++ b/server/bleep/src/webserver/answer/llm_gateway.rs
@@ -148,6 +148,13 @@ impl api::Message {
             content: content.to_string(),
         }
     }
+
+    pub fn as_plaintext_mut(&mut self) -> Option<(&mut String, &mut String)> {
+        match self {
+            Self::PlainText { role, content } => Some((role, content)),
+            _ => None
+        }
+    }
 }
 
 enum ChatError {

--- a/server/bleep/src/webserver/answer/prompts.rs
+++ b/server/bleep/src/webserver/answer/prompts.rs
@@ -135,7 +135,7 @@ A: "#
     )
 }
 
-pub fn final_explanation_prompt(context: &str, query: &str, query_history: &str) -> String {
+pub fn final_explanation_prompt(context: &str, query: &str) -> String {
     struct Rule<'a> {
         title: &'a str,
         description: &'a str,
@@ -248,10 +248,7 @@ What's the value of MAX_FILE_LEN?
 
 #####
 
-{query_history}
-
-Above is the query and answer history. The user can see the previous queries and answers on their screen, but not anything else.
-Based on this history, answer the question: {query}
+Answer the question: {query}
 
 #####
 

--- a/server/bleep/src/webserver/answer/prompts.rs
+++ b/server/bleep/src/webserver/answer/prompts.rs
@@ -135,7 +135,7 @@ A: "#
     )
 }
 
-pub fn final_explanation_prompt(context: &str, query: &str) -> String {
+pub fn final_explanation_prompt(context: &str) -> String {
     struct Rule<'a> {
         title: &'a str,
         description: &'a str,
@@ -246,9 +246,6 @@ What's the value of MAX_FILE_LEN?
   ["con": "None of files in the context contain the value of MAX_FILE_LEN"]
 ]
 
-#####
-
-Answer the question: {query}
 
 #####
 


### PR DESCRIPTION
Rather than embedding the query history as a string, we can create native `Message`s, with user and assistant roles respectively. This means that the prompt only changes depending on context and not on the message chain.