### PR TITLE
fix bugs in hoverables queries

### DIFF
--- a/server/bleep/src/intelligence/language/rust/mod.rs
+++ b/server/bleep/src/intelligence/language/rust/mod.rs
@@ -8,8 +8,6 @@ pub static RUST: TSLanguageConfig = TSLanguageConfig {
     hoverable_query: MemoizedQuery::new(
         r#"
         [(identifier)
-         (scoped_identifier)
-         (scoped_type_identifier)
          (shorthand_field_identifier)
          (field_identifier)
          (type_identifier)] @hoverable

--- a/server/bleep/src/intelligence/language/typescript/scopes.scm
+++ b/server/bleep/src/intelligence/language/typescript/scopes.scm
@@ -17,6 +17,7 @@
   (for_statement)
   (for_in_statement)
   (switch_case)
+  (catch_clause)
   ;; assignments are permitted inside sequence exprs:
   ;;
   ;;     const a = 2;
@@ -202,6 +203,10 @@
 ;; interface T
 (interface_declaration
   (type_identifier) @local.definition.interface)
+
+;; catch clauses
+(catch_clause
+  (identifier) @local.definition.variable)
 
 
 ;; refs


### PR DESCRIPTION
- scoped identifiers in rust result in `module::type` being hoverable, whereas we require `module` and `type` to be individually hoverable.
- catch clause variables in typescript were hoverable but did not produce results