### PR TITLE
Remove `new` response type

### DIFF
--- a/server/bleep/src/webserver/answer/prompts.rs
+++ b/server/bleep/src/webserver/answer/prompts.rs
@@ -59,7 +59,7 @@ pub fn functions() -> serde_json::Value {
                         "mode": {
                             "type": "string",
                             "enum": ["article", "filesystem"],
-                            "description": "The type of answer to provide. If the user's query is best answered with the location of one or multiple files and folders with no explanation choose filesystem. If the user's query is best answered with any explanation, choose article. If the user's query is neither, choose filesystem."
+                            "description": "The type of answer to provide. If the user's query is best answered with the location of one or multiple files and folders with no explanation choose filesystem. If the user's query is best answered with any explanation, or they're instructing you to write new code choose article. If the user's query is neither, choose filesystem."
                         },
                         "paths": {
                             "type": "array",
@@ -165,9 +165,9 @@ pub fn answer_filesystem_prompt(context: &str) -> String {
             example: Some(r#"The path is a relative path, with no leading slash. You must generate a trailing slash, for example: server/bleep/src/webserver/. On Windows, generate backslash separated components, for example: server\bleep\src\webserver\"#),
         },
         Rule {
-            title: "Write a new code file",
-            description: "Write a new code file that satisfies the query. Do not use this to demonstrate updating an existing file.",
-            schema: "[\"new\",LANGUAGE:STRING,CODE:STRING]",
+            title: "Cite line ranges from the file",
+            description: "START LINE and END LINE should focus on the code mentioned in the COMMENT. COMMENT should be a detailed explanation.",
+            schema: "[\"cite\",PATH ALIAS:INT,COMMENT:STRING,START LINE:INT,END LINE:INT]",
             note: "This object can occur multiple times",
             example: None,
         },
@@ -181,13 +181,6 @@ For example:
 @@ -1 +1 @@
 -this is a git diff test example
 +this is a diff example"#),
-        },
-        Rule {
-            title: "Cite line ranges from the file",
-            description: "START LINE and END LINE should focus on the code mentioned in the COMMENT. COMMENT should be a detailed explanation.",
-            schema: "[\"cite\",PATH ALIAS:INT,COMMENT:STRING,START LINE:INT,END LINE:INT]",
-            note: "This object can occur multiple times",
-            example: None,
         },
         Rule {
             title: "Conclusion",

--- a/server/bleep/src/webserver/answer/response.rs
+++ b/server/bleep/src/webserver/answer/response.rs
@@ -192,7 +192,6 @@ pub enum Update {
 pub enum SearchResult {
     Cite(CiteResult),
     Directory(DirectoryResult),
-    New(NewResult),
     Modify(ModifyResult),
     Conclude(ConcludeResult),
 }
@@ -204,7 +203,6 @@ impl SearchResult {
         match tag.as_str()? {
             "cite" => CiteResult::from_json_array(&v[1..]).map(Self::Cite),
             "dir" => DirectoryResult::from_json_array(&v[1..]).map(Self::Directory),
-            "new" => NewResult::from_json_array(&v[1..]).map(Self::New),
             "mod" => ModifyResult::from_json_array(&v[1..]).map(Self::Modify),
             "con" => ConcludeResult::from_json_array(&v[1..]).map(Self::Conclude),
             _ => None,
@@ -245,12 +243,6 @@ pub struct CiteResult {
 pub struct DirectoryResult {
     path: Option<String>,
     comment: Option<String>,
-}
-
-#[derive(serde::Serialize, serde::Deserialize, Default, Debug, Clone)]
-pub struct NewResult {
-    language: Option<String>,
-    code: Option<String>,
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Default, Debug, Clone)]
@@ -331,20 +323,6 @@ impl DirectoryResult {
             .and_then(serde_json::Value::as_str)
             .map(ToOwned::to_owned);
         Some(Self { path, comment })
-    }
-}
-
-impl NewResult {
-    fn from_json_array(v: &[serde_json::Value]) -> Option<Self> {
-        let language = v
-            .get(0)
-            .and_then(serde_json::Value::as_str)
-            .map(ToOwned::to_owned);
-        let code = v
-            .get(1)
-            .and_then(serde_json::Value::as_str)
-            .map(ToOwned::to_owned);
-        Some(Self { language, code })
     }
 }
 


### PR DESCRIPTION
Remove the redundant `new` response type and prompt model to output an article when instructed to generate new code. This PR persists the `modify` response type.