### PR TITLE
Search with hypothetical documents

### DIFF
--- a/server/bleep/src/query/parser.rs
+++ b/server/bleep/src/query/parser.rs
@@ -68,6 +68,14 @@ impl<'a> SemanticQuery<'a> {
     pub fn branch(&self) -> impl Iterator<Item = &Cow<'_, str>> {
         self.branch.iter().filter_map(|t| t.as_plain())
     }
+
+    pub fn from_str(query: String, repo_ref: String) -> Self {
+        Self {
+            target: Some(Literal::Plain(Cow::Owned(query))),
+            repos: [Literal::Plain(Cow::Owned(repo_ref))].into(),
+            ..Default::default()
+        }
+    }
 }
 
 impl<'a> Query<'a> {

--- a/server/bleep/src/semantic.rs
+++ b/server/bleep/src/semantic.rs
@@ -482,10 +482,8 @@ impl Semantic {
             })
             .await?;
 
-        dbg!(&response.result);
         let scored_points: Vec<ScoredPoint> =
             response.result.into_iter().flat_map(|r| r.result).collect();
-        dbg!(&scored_points.len());
         Ok(scored_points)
     }
 

--- a/server/bleep/src/webserver/answer.rs
+++ b/server/bleep/src/webserver/answer.rs
@@ -509,8 +509,8 @@ impl Conversation {
                 let hyde_docs = self.hyde(ctx, query).await?;
                 if !hyde_docs.is_empty() {
                     let hyde_queries = hyde_docs
-                        .into_iter()
-                        .map(|q| SemanticQuery::from_str(q, self.repo_ref.display_name()))
+                        .iter()
+                        .map(|q| SemanticQuery::from_str(q.into(), self.repo_ref.display_name()))
                         .collect::<Vec<_>>();
 
                     let hyde_results = ctx
@@ -553,6 +553,7 @@ impl Conversation {
                 ctx.track_query(
                     EventData::input_stage("semantic code search")
                         .with_payload("query", query)
+                        .with_payload("hyde_queries", &hyde_docs)
                         .with_payload("chunks", &chunks)
                         .with_payload("raw_prompt", &prompt),
                 );
@@ -645,11 +646,10 @@ impl Conversation {
             .try_collect::<String>()
             .await?;
 
-        dbg!(&response);
         let documents = prompts::try_parse_hypothetical_documents(&response);
 
         for doc in documents.iter() {
-            println!("{}\n", doc);
+            info!("{}\n", doc);
         }
 
         Ok(documents)

--- a/server/bleep/src/webserver/answer.rs
+++ b/server/bleep/src/webserver/answer.rs
@@ -654,19 +654,9 @@ impl Conversation {
     }
 
     async fn hyde(&mut self, ctx: &AppContext, query: &str) -> Result<Vec<String>> {
-        let mut history = self.llm_history.clone();
-        let mut hyde_context = vec![llm_gateway::api::Message::system(
+        let hyde_context = vec![llm_gateway::api::Message::system(
             &prompts::hypothetical_document_prompt(query),
         )];
-
-        // let last_n_interactions = 5; // Maximum number of conversation interactions
-        // let trimmed_history = history
-        //     .iter()
-        //     .filter(|m| matches!(m, llm_gateway::api::Message::FunctionCall { .. }))
-        //     .rev()
-        //     .take(last_n_interactions)
-        //     .cloned()
-        //     .collect::<Vec<llm_gateway::api::Message>>();
 
         let ctx = &ctx.clone().model("gpt-3.5-turbo-0613");
         let response = ctx
@@ -680,7 +670,7 @@ impl Conversation {
         let hyde_docs = prompts::try_parse_hypothetical_document(&response);
         // Print each doc
         for doc in hyde_docs.iter() {
-            println!("{}", doc);
+            println!("{}\n", doc);
         }
         Ok(hyde_docs)
     }

--- a/server/bleep/src/webserver/answer/prompts.rs
+++ b/server/bleep/src/webserver/answer/prompts.rs
@@ -284,3 +284,14 @@ Respect these rules at all times:
 "#
     )
 }
+
+pub fn hypothetical_document_prompt(query: &str) -> String {
+    format!(
+        r#"Write a short code fragment that could hypothetically be returned by a code search engine as the answer to the query: {query}
+
+- The code should be written one of these languages: [Rust, Typescript, TSX, YAML]
+- Your code fragment should be between 5 and 10 lines long
+- Surround the code with triple backticks
+- Only generate a single code fragment"#
+    )
+}

--- a/server/bleep/src/webserver/answer/prompts.rs
+++ b/server/bleep/src/webserver/answer/prompts.rs
@@ -335,7 +335,7 @@ const res = await qdrant.search(collectionName, {{
     )
 }
 
-pub fn try_parse_hypothetical_document(document: &str) -> Vec<String> {
+pub fn try_parse_hypothetical_documents(document: &str) -> Vec<String> {
     let pattern = r"```([\s\S]*?)```";
     let re = regex::Regex::new(pattern).unwrap();
 
@@ -378,6 +378,6 @@ pub fn final_explanation_prompt(context: &str, query: &str, query_history: &str)
     serde_json::json!("#,
         ];
 
-        assert_eq!(try_parse_hypothetical_document(document), expected);
+        assert_eq!(try_parse_hypothetical_documents(document), expected);
     }
 }

--- a/server/bleep/src/webserver/answer/prompts.rs
+++ b/server/bleep/src/webserver/answer/prompts.rs
@@ -289,7 +289,7 @@ pub fn hypothetical_document_prompt(query: &str) -> String {
     format!(
         r#"Write three code snippets that could hypothetically be returned by a code search engine as the answer to the query: {query}
 
-- All three snippets should be written in any one of these languages: [Rust, Typescript, TSX, YAML]
+- Write these snippets in a variety of programming languages
 - The snippets should not be too similar to one another
 - Each snippet should be between 5 and 10 lines long
 - Surround the snippets in triple backticks


### PR DESCRIPTION
Our semantic search pipeline sometimes fails to return relevant information. The queries that the agent generates do not overlap at all with the correct documents. For example, for the user query `which ml library do we use?` bloop might make a semantic search for `ml library` or `machine learning library`, neither of which overlap with `ort` or `onnxruntime`.

This PR implements a popular approach to tackling this recall problem. As well as making a semantic search with the query, use an LLM to generate a set of hypothetical documents that _could_ answer the query and search w.r.t. those too. https://arxiv.org/abs/2212.10496

We take the user query and ask GPT-3.5 to generate three code snippets in a variety of languages that _could_ answer it. We then batch search Qdrant for all of those queries at once (very open to more elegant implementations of this).