### PR TITLE
Revert Rudderstack field names

### DIFF
--- a/server/bleep/src/analytics.rs
+++ b/server/bleep/src/analytics.rs
@@ -176,7 +176,7 @@ impl RudderHub {
         self.send(Message::Track(Track {
             user_id: Some(self.tracking_id(username)),
             event: "track_synced_repos".into(),
-            properties: Some(serde_json::json!({ "count": count, "organization": org_name })),
+            properties: Some(serde_json::json!({ "count": count, "org_name": org_name })),
             ..Default::default()
         }));
     }

--- a/server/bleep/src/webserver/aaa.rs
+++ b/server/bleep/src/webserver/aaa.rs
@@ -190,9 +190,9 @@ pub(super) async fn authorized(
         analytics.send(Message::Identify(Identify {
             user_id: Some(analytics.tracking_id(Some(&user_name))),
             traits: Some(serde_json::json!({
-                "organization": app.org_name(),
+                "org_name": app.org_name(),
                 "device_id": analytics.device_id(),
-                "is_cloud_instance": app.env.is_cloud_instance(),
+                "is_self_serve": app.env.is_cloud_instance(),
                 "github_username": user_name,
             })),
             ..Default::default()

--- a/server/bleep/src/webserver/github.rs
+++ b/server/bleep/src/webserver/github.rs
@@ -51,9 +51,9 @@ pub(super) async fn status(Extension(app): Extension<Application>) -> impl IntoR
             analytics.send(Message::Identify(Identify {
                 user_id: Some(analytics.tracking_id(Some(&username))),
                 traits: Some(serde_json::json!({
-                    "organization": app.org_name(),
+                    "org_name": app.org_name(),
                     "device_id": analytics.device_id(),
-                    "is_cloud_instance": app.env.is_cloud_instance(),
+                    "is_self_serve": app.env.is_cloud_instance(),
                     "github_username": username,
                 })),
                 ..Default::default()


### PR DESCRIPTION
Revert name changes to the `org_name` and `is_self_serve` Rudderstack fields. The new names introduce new, duplicate columns in the DB.