### PR TITLE
Introduce `Agent` struct, simplify `Exchange` data structure

### DIFF
--- a/client/src/components/Chat/index.tsx
+++ b/client/src/components/Chat/index.tsx
@@ -172,13 +172,13 @@ const Chat = () => {
           if (data.Ok) {
             const newMessage = data.Ok;
             if (
-              ((newMessage.results?.Filesystem?.length &&
+              ((newMessage.outcome?.Filesystem?.length &&
                 !newMessage.conclusion) ||
-                newMessage.results?.Article?.length) &&
+                newMessage.outcome?.Article?.length) &&
               !firstResultCame
             ) {
               setConversation((prev) => {
-                if (newMessage.mode === 'article') {
+                if (newMessage.outcome?.Article?.length) {
                   setChatOpen(false);
                   navigateArticleResponse(prev.length - 1, threadId);
                 } else {
@@ -197,11 +197,11 @@ const Chat = () => {
               const lastMessage = prev?.slice(-1)[0];
               const messageToAdd = {
                 author: ChatMessageAuthor.Server,
-                isLoading: !newMessage.finished,
+                isLoading: true,
                 type: ChatMessageType.Answer,
                 loadingSteps: mapLoadingSteps(newMessage.search_steps),
                 text: newMessage.conclusion,
-                results: newMessage.results,
+                results: newMessage.outcome,
               };
               const lastMessages: ChatMessage[] =
                 lastMessage?.author === ChatMessageAuthor.Server

--- a/server/bleep/src/webserver/answer.rs
+++ b/server/bleep/src/webserver/answer.rs
@@ -225,7 +225,7 @@ pub(super) async fn _handle(
                 match item {
                     Ok(Either::Left(exchange)) => yield exchange,
                     Ok(Either::Right(next_action)) => match next_action {
-                        Ok(n) => next = n,
+                        Ok(n) => break next = n,
                         Err(e) => break 'outer Err(AgentError::Processing(e)),
                     },
                     Err(_) => break 'outer Err(AgentError::Timeout(timeout)),

--- a/server/bleep/src/webserver/answer.rs
+++ b/server/bleep/src/webserver/answer.rs
@@ -1356,7 +1356,7 @@ impl Agent {
                 .iter()
                 .map(Vec::as_slice)
                 .filter_map(|v| {
-                    let item = exchange::FileAction::from_json_array(v);
+                    let item = exchange::FileResult::from_json_array(v);
                     if item.is_none() {
                         warn!("failed to build search result from: {v:?}");
                     }

--- a/server/bleep/src/webserver/answer/llm_gateway.rs
+++ b/server/bleep/src/webserver/answer/llm_gateway.rs
@@ -200,6 +200,27 @@ impl Client {
         }
     }
 
+    pub fn model(mut self, model: &str) -> Self {
+        if model.is_empty() {
+            self.model = None;
+        } else {
+            self.model = Some(model.to_owned());
+        }
+
+        self
+    }
+
+    pub fn frequency_penalty(mut self, frequency: impl Into<Option<f32>>) -> Self {
+        self.frequency_penalty = frequency.into();
+        self
+    }
+
+    #[allow(unused)]
+    pub fn presence_penalty(mut self, presence_penalty: impl Into<Option<f32>>) -> Self {
+        self.presence_penalty = presence_penalty.into();
+        self
+    }
+
     pub fn temperature(mut self, temperature: impl Into<Option<f32>>) -> Self {
         self.temperature = temperature.into();
         self


### PR DESCRIPTION
In this PR we simplify the `answer` module, and clean up the `Exchange`-related data types. Now, the `Agent` struct is used to drive conversations instead of `Conversation`, and it holds surrounding conversation context, such as thread IDs and LLM gateway clients.

Of note:

- `Exchange` has been reorganized and simplified
  - `Outcome` replaces the old `enum Results`
  - `finished` has been removed, and can now be inferred by the closing of a stream
  - `SearchResult` has been renamed to `FileAction`, and all associated `*Result` types were renamed to `*Action`
- `Conversation` methods related to agent tasks were split into a new `Agent` type
- Methods related to the LLM gateway were moved from `AppContext` to `llm_gateway::Client`
- The `AppContext` struct was merged into `Agent`
- The `CancellationTrack` struct was merged into `Agent`