### PR TITLE
Remove redundant `gpt2` tokenizer

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,12 +3,6 @@ apps/desktop/src-tauri/model/model.onnx filter=lfs diff=lfs merge=lfs -text
 apps/desktop/src-tauri/model/special_tokens_map.json filter=lfs diff=lfs merge=lfs -text
 apps/desktop/src-tauri/model/tokenizer.json filter=lfs diff=lfs merge=lfs -text
 apps/desktop/src-tauri/model/tokenizer_config.json filter=lfs diff=lfs merge=lfs -text
-apps/desktop/src-tauri/model/gpt-2/merges.txt filter=lfs diff=lfs merge=lfs -text
-apps/desktop/src-tauri/model/gpt-2/special_tokens_map.json filter=lfs diff=lfs merge=lfs -text
-apps/desktop/src-tauri/model/gpt-2/tokenizer_config.json filter=lfs diff=lfs merge=lfs -text
-apps/desktop/src-tauri/model/gpt-2/vocab.json filter=lfs diff=lfs merge=lfs -text
-apps/desktop/src-tauri/model/gpt-2/ filter=lfs diff=lfs merge=lfs -text
-apps/desktop/src-tauri/model/gpt-2/tokenizer.json filter=lfs diff=lfs merge=lfs -text
 apps/desktop/src-tauri/bin/qdrant-x86_64-apple-darwin filter=lfs diff=lfs merge=lfs -text
 apps/desktop/src-tauri/bin/qdrant-aarch64-apple-darwin filter=lfs diff=lfs merge=lfs -text
 apps/desktop/src-tauri/bin/qdrant-x86_64-unknown-linux-gnu filter=lfs diff=lfs merge=lfs -text

--- a/apps/desktop/src-tauri/model/gpt-2/merges.txt
+++ b/apps/desktop/src-tauri/model/gpt-2/merges.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fe36cab26d4f4421ed725e10a2e9ddb7f799449c603a96e7f29b5a3c82a95862
-size 456356

--- a/apps/desktop/src-tauri/model/gpt-2/special_tokens_map.json
+++ b/apps/desktop/src-tauri/model/gpt-2/special_tokens_map.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c0b3c279b6ecdb71996a86ffb4d4ab94dfdb5df95f00bac9515688faef2ff5dd
-size 90

--- a/apps/desktop/src-tauri/model/gpt-2/tokenizer.json
+++ b/apps/desktop/src-tauri/model/gpt-2/tokenizer.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:86f12f9648802a0c45c4b87ef2ab235e9bfdf1a43cc40571291507c81e35c4c3
-size 2107625

--- a/apps/desktop/src-tauri/model/gpt-2/tokenizer_config.json
+++ b/apps/desktop/src-tauri/model/gpt-2/tokenizer_config.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1e664fe1a5bc404dcb204a76c76bc4100c91bd12c66098d8a8090b11b6ee6f0d
-size 236

--- a/apps/desktop/src-tauri/model/gpt-2/vocab.json
+++ b/apps/desktop/src-tauri/model/gpt-2/vocab.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3ba3c3109ff33976c4bd966589c11ee14fcaa1f4c9e5e154c2ed7f99d80709e7
-size 798156

--- a/server/bleep/src/semantic.rs
+++ b/server/bleep/src/semantic.rs
@@ -55,7 +55,6 @@ pub enum SemanticError {
 pub struct Semantic {
     qdrant: Arc<QdrantClient>,
     tokenizer: Arc<tokenizers::Tokenizer>,
-    gpt2_tokenizer: Arc<tokenizers::Tokenizer>,
     session: Arc<ort::Session>,
     config: Arc<Configuration>,
 }
@@ -211,9 +210,6 @@ impl Semantic {
             qdrant: qdrant.into(),
             tokenizer: tokenizers::Tokenizer::from_file(model_dir.join("tokenizer.json"))
                 .unwrap()
-                .into(),
-            gpt2_tokenizer: tokenizers::Tokenizer::from_file(model_dir.join("gpt-2").join("tokenizer.json"))
-                .expect("unable to open gpt2-tokenizer, try `git lfs pull` and pass `--model-dir bloop/model` at the CLI")
                 .into(),
             session: SessionBuilder::new(&environment)?
                 .with_optimization_level(GraphOptimizationLevel::Level3)?
@@ -504,13 +500,6 @@ impl Semantic {
             .qdrant
             .delete_points(COLLECTION_NAME, &selector, None)
             .await;
-    }
-
-    pub fn gpt2_token_count(&self, input: &str) -> usize {
-        self.gpt2_tokenizer
-            .encode(input, false)
-            .map(|code| code.len())
-            .unwrap_or(0)
     }
 
     pub fn overlap_strategy(&self) -> chunk::OverlapStrategy {


### PR DESCRIPTION
We used to use the `gpt2-tokenizer` before switching to `tiktoken`. This removes traces of it from the codebase.