### PR TITLE
Generate article summary responses inline 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -480,6 +480,7 @@ dependencies = [
  "clap 4.3.10",
  "color-eyre",
  "compact_str",
+ "comrak",
  "console-subscriber",
  "criterion",
  "directories",
@@ -986,6 +987,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "comrak"
+version = "0.18.0"
+source = "git+https://github.com/kivikakk/comrak#91e5240e4a2d878ab699d84bf123075ced74bf23"
+dependencies = [
+ "derive_builder",
+ "entities",
+ "memchr",
+ "once_cell",
+ "regex",
+ "slug",
+ "typed-arena",
+ "unicode_categories",
+]
+
+[[package]]
 name = "console"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1461,6 +1477,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "deunicode"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "850878694b7933ca4c9569d30a34b55031b9b139ee1fc7b94a527c4ef960d690"
+
+[[package]]
 name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1612,6 +1634,12 @@ checksum = "071a31f4ee85403370b58aca746f01041ede6f0da2730960ad001edc2b71b394"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "entities"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5320ae4c3782150d900b79807611a59a99fc9a1d61d686faafc24b93fc8d7ca"
 
 [[package]]
 name = "enum-as-inner"
@@ -6270,6 +6298,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "slug"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3bc762e6a4b6c6fcaade73e77f9ebc6991b676f88bb2358bddb56560f073373"
+dependencies = [
+ "deunicode",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7696,6 +7733,12 @@ name = "try-lock"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
+
+[[package]]
+name = "typed-arena"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
 
 [[package]]
 name = "typenum"

--- a/server/bleep/Cargo.toml
+++ b/server/bleep/Cargo.toml
@@ -123,6 +123,9 @@ sentry-tracing = "0.31.5"
 git-version = "0.3.5"
 gix = { version="0.47.0", features = ["blocking-http-transport-reqwest-rust-tls", "pack-cache-lru-static"] }
 thread-priority = "0.13.1"
+# We use the git version here, so that we can pull in recent changes that make footnotes work. The
+# latest crates.io version at the time of writing does not include necessary patches.
+comrak = { default-features = false, git = "https://github.com/kivikakk/comrak" }
 
 [target.'cfg(windows)'.dependencies]
 dunce = "1.0.4"

--- a/server/bleep/src/webserver/answer.rs
+++ b/server/bleep/src/webserver/answer.rs
@@ -1,4 +1,3 @@
-use rand::{seq::SliceRandom, SeedableRng};
 use secrecy::ExposeSecret;
 use std::{
     collections::{HashMap, HashSet, VecDeque},
@@ -1251,22 +1250,20 @@ impl Agent {
         while let Some(fragment) = stream.next().await {
             let fragment = fragment?;
             response += &fragment;
-            self.update(Update::Article(fragment)).await?;
+
+            if let Some((article, summary)) = split_article_summary(&response) {
+                self.update(Update::Article(article)).await?;
+                self.update(Update::Conclude(summary)).await?;
+            } else {
+                self.update(Update::Article(response.clone())).await?;
+            }
         }
 
-        let article_conclusion_messages = vec![
-            "I hope that was useful, can I help with anything else?",
-            "Is there anything else I can help you with?",
-            "Can I help you with anything else?",
-        ];
+        let summary = split_article_summary(&response)
+            .context("article did not have a summary")?
+            .1;
 
-        self.update(Update::Conclude(
-            article_conclusion_messages
-                .choose(&mut rand::rngs::StdRng::from_entropy())
-                .unwrap()
-                .to_string(),
-        ))
-        .await?;
+        self.update(Update::Conclude(summary)).await?;
 
         self.track_query(
             EventData::output_stage("answer_article")
@@ -1564,6 +1561,55 @@ fn merge_nearby(a: &mut CodeChunk, b: CodeChunk, contents: &str) -> Option<CodeC
     a.snippet += "\n";
     a.snippet += &b.snippet;
     a.end_line = b.end_line;
+
+    None
+}
+
+fn split_article_summary(response: &str) -> Option<(String, String)> {
+    // The `comrak` crate has a very unusual API which makes this logic difficult to follow. It
+    // favours arena allocation instead of a tree-based AST, and requires `Write`rs to regenerate
+    // markdown output.
+    //
+    // There are quirks to the parsing logic, comments have been added for clarity.
+
+    let arena = comrak::Arena::new();
+    let mut options = comrak::ComrakOptions::default();
+    options.extension.footnotes = true;
+
+    // We don't have an easy built-in way to generate a string with `comrak`, so we encapsulate
+    // that logic here.
+    let comrak_to_string = |node| {
+        let mut out = Vec::<u8>::new();
+        comrak::format_commonmark(node, &options, &mut out).unwrap();
+        String::from_utf8_lossy(&out).trim().to_owned()
+    };
+
+    // `comrak` will not recognize footnote definitions unless they have been referenced at least
+    // once. To ensure our potential summary appears in the parse tree, we prepend the entire
+    // response with a sentinel reference to the footnote. After parsing, we look for that
+    // footnote and immediately remove (detach) it from the root node. This ensures that our
+    // artifical reference does not appear in the output.
+
+    let document = format!("[^summary]\n\n{response}");
+    let root = comrak::parse_document(&arena, &document, &options);
+    let mut children = root.children();
+    // Detach the sentinel footnote reference.
+    children.next().unwrap().detach();
+
+    for child in children {
+        match &child.data.borrow().value {
+            comrak::nodes::NodeValue::FootnoteDefinition(def) if def.name == "summary" => (),
+            _ => continue,
+        };
+
+        let first_child = child.children().next()?;
+        if let comrak::nodes::NodeValue::Paragraph = &first_child.data.borrow().value {
+            // We detach the summary from the main text, so that it does not end up in the final
+            // article output.
+            child.detach();
+            return Some((comrak_to_string(root), comrak_to_string(first_child)));
+        }
+    }
 
     None
 }
@@ -2178,5 +2224,35 @@ mod tests {
                 .join("\n")
             );
         }
+    }
+
+    #[test]
+    fn test_split_article_summary() {
+        let (body, summary) = split_article_summary(
+            r#"Hello world
+
+[^summary]: This is an example summary, with **bold text**."#,
+        )
+        .unwrap();
+
+        assert_eq!(body, "Hello world");
+        assert_eq!(summary, "This is an example summary, with **bold text**.");
+
+        let (body, summary) = split_article_summary(
+            r#"Hello world.
+
+Goodbye world.
+
+Hello again, world.
+
+[^summary]: This is an example summary, with **bold text**."#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            body,
+            "Hello world.\n\nGoodbye world.\n\nHello again, world."
+        );
+        assert_eq!(summary, "This is an example summary, with **bold text**.");
     }
 }

--- a/server/bleep/src/webserver/answer.rs
+++ b/server/bleep/src/webserver/answer.rs
@@ -1,3 +1,4 @@
+use rand::{rngs::OsRng, seq::SliceRandom};
 use secrecy::ExposeSecret;
 use std::{
     collections::{HashMap, HashSet, VecDeque},
@@ -1260,8 +1261,18 @@ impl Agent {
         }
 
         let summary = split_article_summary(&response)
-            .context("article did not have a summary")?
-            .1;
+            .map(|(_article, summary)| summary)
+            .unwrap_or_else(|| {
+                [
+                    "I hope that was useful, can I help with anything else?",
+                    "Is there anything else I can help you with?",
+                    "Can I help you with anything else?",
+                ]
+                .choose(&mut OsRng)
+                .copied()
+                .unwrap()
+                .to_owned()
+            });
 
         self.update(Update::Conclude(summary)).await?;
 

--- a/server/bleep/src/webserver/answer/exchange.rs
+++ b/server/bleep/src/webserver/answer/exchange.rs
@@ -22,8 +22,7 @@ impl Exchange {
 
     /// Advance this exchange.
     ///
-    /// This should always be additive. An update should not result in fewer search results or fewer
-    /// search steps.
+    /// An update should not result in fewer search results or fewer search steps.
     pub fn apply_update(&mut self, update: Update) {
         match update {
             Update::Step(search_step) => self.search_steps.push(search_step),
@@ -34,7 +33,7 @@ impl Exchange {
                 let outcome = self
                     .outcome
                     .get_or_insert_with(|| Outcome::Article(String::new()));
-                *outcome.as_article_mut().unwrap() += &text;
+                *outcome.as_article_mut().unwrap() = text;
             }
             Update::Conclude(conclusion) => {
                 self.conclusion = Some(conclusion);

--- a/server/bleep/src/webserver/answer/prompts.rs
+++ b/server/bleep/src/webserver/answer/prompts.rs
@@ -289,7 +289,8 @@ Respect these rules at all times:
   - For example, to quote lines 10 to 15 in `src/main.c`, use `c,path:src/main.c,lines:L10-L15`
   - For example, to quote lines 154 to 190 in `index.js`, use `javascript,path:index.js,lines:L154-L190`
 - Always begin your answer with an appropriate title
-- If your are unable to answer the query using the information above, do NOT make up an answer. Explain that you need more information to answer the question and why"#
+- Always finish your answer with a summary in a [^summary] footnote
+  - If you do not have enough information needed to answer the query, do not make up an answer. Instead respond only with a [^summary] footnote that asks the user for more information, e.g. `assistant: [^summary]: I'm sorry, I couldn't find what you were looking for, could you provide more information?`"#
     )
 }
 


### PR DESCRIPTION
We replace the previous fixed summaries with summaries generated inline
with the article prompt.

Some of the logic which makes use of the `comrak` crate is difficult to
follow. Comments have been added for clarity.