### PR TITLE
Use `e5-small-v2` embedder

### DIFF
--- a/apps/desktop/src-tauri/model/model.onnx
+++ b/apps/desktop/src-tauri/model/model.onnx
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:712cda19c5e4803e4d2f1d5ae972083537ffc2531759b67641622251c8ec3caf
-size 22998413
+oid sha256:8e4fba6f4661630b6146bdbdc3d2ee81fce77821e25371bb64cafb73252b48ef
+size 33693969

--- a/apps/desktop/src-tauri/model/model.onnx
+++ b/apps/desktop/src-tauri/model/model.onnx
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8e4fba6f4661630b6146bdbdc3d2ee81fce77821e25371bb64cafb73252b48ef
-size 33693969
+oid sha256:36a9c799a8fcafec96444bb83d1b56ddb4887f0ee50cc42257ee464f4aad493e
+size 33694089

--- a/apps/desktop/src-tauri/model/tokenizer_config.json
+++ b/apps/desktop/src-tauri/model/tokenizer_config.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5a0279327ed471a6e4cfb88b6f62f73d8e8ddf3fdc1e9cbb98f692b1b9ae0d91
-size 579
+oid sha256:e1790949631401af1bfb6c9c7aeec7fcf612e274d73579d99f704faea40c8ba7
+size 394

--- a/server/bleep/src/config.rs
+++ b/server/bleep/src/config.rs
@@ -351,5 +351,5 @@ fn default_answer_api_url() -> String {
 }
 
 fn default_max_chunk_tokens() -> usize {
-    256
+    512
 }

--- a/server/bleep/src/semantic/chunk.rs
+++ b/server/bleep/src/semantic/chunk.rs
@@ -346,7 +346,7 @@ mod tests {
     use super::*;
     use std::{env, path::PathBuf};
 
-    fn minilm() -> Tokenizer {
+    fn tokenizer() -> Tokenizer {
         let tok_json = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
             .parent()
             .unwrap()
@@ -361,7 +361,7 @@ mod tests {
 
     #[test]
     pub fn empty() {
-        let tokenizer = minilm();
+        let tokenizer = tokenizer();
         let token_bounds = 50..256;
         let max_lines = 15;
         let no_tokens = super::by_tokens(
@@ -378,7 +378,7 @@ mod tests {
 
     #[test]
     pub fn by_tokens() {
-        let tokenizer = minilm();
+        let tokenizer = tokenizer();
         let token_bounds = 50..256;
         let max_lines = 15;
         let cur_dir = env::current_dir().unwrap();
@@ -433,7 +433,7 @@ mod tests {
 
     #[test]
     pub fn chunks_within_token_limit() {
-        let tokenizer = minilm();
+        let tokenizer = tokenizer();
         let max_lines = 15;
 
         let chunks = super::by_tokens(
@@ -458,7 +458,7 @@ mod tests {
 
     #[test]
     pub fn chunks_over_long_lined_file() {
-        let tokenizer = minilm();
+        let tokenizer = tokenizer();
         let max_lines = 15;
 
         // squish SRC into one big single-lined string

--- a/server/bleep/src/semantic/chunk.rs
+++ b/server/bleep/src/semantic/chunk.rs
@@ -151,7 +151,7 @@ impl OverlapStrategy {
 
 impl Default for OverlapStrategy {
     fn default() -> Self {
-        Self::Partial(0.25)
+        Self::Partial(0.75)
     }
 }
 

--- a/server/bleep/src/semantic/chunk.rs
+++ b/server/bleep/src/semantic/chunk.rs
@@ -151,7 +151,7 @@ impl OverlapStrategy {
 
 impl Default for OverlapStrategy {
     fn default() -> Self {
-        Self::Partial(0.5)
+        Self::Partial(0.25)
     }
 }
 
@@ -174,7 +174,7 @@ fn add_token_range<'s>(
     }
 
     debug_assert!(
-        o.end - o.start < 256,
+        o.end - o.start < 512,
         "chunk too large: {} tokens in {:?} bytes {:?}",
         o.end - o.start,
         o,

--- a/server/bleep/src/webserver/answer.rs
+++ b/server/bleep/src/webserver/answer.rs
@@ -785,12 +785,12 @@ impl Agent {
         self.update(Update::Step(SearchStep::Code(query.clone())))
             .await?;
 
-        let mut results = self.semantic_search(query.into(), 10, 0, true).await?;
+        let mut results = self.semantic_search(query.into(), 5, 0, true).await?;
 
         let hyde_docs = self.hyde(query).await?;
         if !hyde_docs.is_empty() {
             let hyde_doc = hyde_docs.first().unwrap().into();
-            let hyde_results = self.semantic_search(hyde_doc, 10, 0, true).await?;
+            let hyde_results = self.semantic_search(hyde_doc, 5, 0, true).await?;
             results.extend(hyde_results);
         }
 


### PR DESCRIPTION
This PR replaces the `MiniLM` embedder with the newer `e5-small-v2`. This model outperforms `MiniLM` on [MTEB](https://huggingface.co/spaces/mteb/leaderboard) and on own our retrieval benchmarks. It was also trained on sequences of up to 512 tokens long, twice `MiniLM`'s recommended `max_tokens`. This means that we only need to store half as many embeddings in our index. This PR also sets the `OverlapStrategy` ratio to 0.75 which - confusingly - means that we're now indexing even fewer chunks as the overlap is only 25%. 

The quantised `e5` model is 10Mb larger than `MiniLM` so index times are on par with before, despite fewer chunks being embedded. This PR also halves the number of chunks returned by the search pipeline when doing semantic search.