### PR TITLE
Expand code chunks to try and maximize context

### DIFF
--- a/server/bleep/src/webserver/answer.rs
+++ b/server/bleep/src/webserver/answer.rs
@@ -1099,7 +1099,7 @@ impl Agent {
         /// The ratio of code tokens to context size.
         ///
         /// Making this closure to 1 means that more of the context is taken up by source code.
-        const CONTEXT_CODE_RATIO: f32 = 0.6;
+        const CONTEXT_CODE_RATIO: f32 = 0.5;
 
         let bpe = tiktoken_rs::get_bpe_from_model(gpt_model).unwrap();
         let context_size = tiktoken_rs::model::get_context_size(gpt_model);

--- a/server/bleep/src/webserver/answer.rs
+++ b/server/bleep/src/webserver/answer.rs
@@ -889,7 +889,7 @@ impl Agent {
         // Sometimes, there are just too many code chunks in the context, and deduplication still
         // doesn't trim enough chunks. So, we enforce a hard limit here that stops adding tokens
         // early if we reach a heuristic limit.
-        const PROMPT_HEADROOM: usize = 1500;
+        const PROMPT_HEADROOM: usize = 2500;
         let bpe = tiktoken_rs::get_bpe_from_model(gpt_model)?;
         let mut remaining_prompt_tokens = tiktoken_rs::get_completion_max_tokens(gpt_model, &s)?;
 

--- a/server/bleep/src/webserver/answer.rs
+++ b/server/bleep/src/webserver/answer.rs
@@ -972,17 +972,13 @@ impl Agent {
     }
 
     async fn answer(&mut self, aliases: &[usize]) -> Result<()> {
-        let gpt_model = if cfg!(feature = "ee") || self.app.env.is_cloud_instance() {
-            "gpt-4-32k-0613"
-        } else {
-            "gpt-4-0613"
-        };
+        const ANSWER_ARTICLE_MODEL: &str = "gpt-4-0613";
 
         let context = self
             .answer_context(
                 aliases,
                 PathScope::Full {
-                    gpt_model: gpt_model.to_owned(),
+                    gpt_model: ANSWER_ARTICLE_MODEL.to_owned(),
                 },
             )
             .await?;
@@ -997,7 +993,7 @@ impl Agent {
         let mut stream = pin!(
             self.llm_gateway
                 .clone()
-                .model(gpt_model)
+                .model(ANSWER_ARTICLE_MODEL)
                 .chat(&messages, None)
                 .await?
         );

--- a/server/bleep/src/webserver/answer.rs
+++ b/server/bleep/src/webserver/answer.rs
@@ -908,7 +908,7 @@ impl Agent {
         } else {
             code_chunks
                 .iter()
-                .filter(|c| path_aliases.contains(&(c.alias as usize)))
+                .filter(|c| path_aliases.contains(&c.alias))
                 .cloned()
                 .collect()
         };
@@ -924,7 +924,7 @@ impl Agent {
                 .snippet
                 .lines()
                 .enumerate()
-                .map(|(i, line)| format!("{} {line}\n", i + chunk.start_line as usize))
+                .map(|(i, line)| format!("{} {line}\n", i + chunk.start_line))
                 .collect::<String>();
 
             let formatted_snippet = format!("### path alias: {} ###\n{snippet}\n\n", chunk.alias);
@@ -1170,7 +1170,7 @@ impl Agent {
                 spans.sort_by_key(|c| c.start);
 
                 let lines = self_
-                    .get_file_content(&path)
+                    .get_file_content(path)
                     .await
                     .unwrap()
                     .unwrap_or_else(|| panic!("path did not exist in the index: {path}"))

--- a/server/bleep/src/webserver/answer.rs
+++ b/server/bleep/src/webserver/answer.rs
@@ -1139,7 +1139,7 @@ impl Agent {
         // Total number of lines to try and expand by, per loop iteration.
         const TOTAL_LINE_INC: usize = 100;
 
-        while spans_by_path
+        while !spans_by_path.is_empty() && spans_by_path
             .iter()
             .flat_map(|(path, spans)| spans.iter().map(move |s| (path, s)))
             .map(|(path, span)| {
@@ -1155,7 +1155,8 @@ impl Agent {
                 / spans_by_path
                     .values()
                     .map(|spans| spans.len())
-                    .sum::<usize>();
+                    .sum::<usize>()
+                    .max(1);
 
             let range_step = range_step.max(1);
 

--- a/server/bleep/src/webserver/answer.rs
+++ b/server/bleep/src/webserver/answer.rs
@@ -865,11 +865,22 @@ impl Agent {
 
         debug!(?paths, ?aliases, "created filtered path alias list");
 
+        // NB: If we have more than one selected alias passed to the agent `none` tool, we
+        // intentionally ignore the alias list. This is part of a bigger issue that is to be
+        // discussed and investigated separately, that points to odd behaviour with the agent
+        // implementation.
+        let aliases = if aliases.len() == 1 {
+            aliases
+        } else {
+            (0..paths.len()).collect()
+        };
+
         if !aliases.is_empty() {
             s += "##### PATHS #####\npath alias, path\n";
 
-            for alias in aliases.iter() {
-                s += &format!("{alias}, {}\n", paths[*alias]);
+            for alias in &aliases {
+                let path = &paths[*alias];
+                s += &format!("{alias}, {path}\n");
             }
         }
 

--- a/server/bleep/src/webserver/answer.rs
+++ b/server/bleep/src/webserver/answer.rs
@@ -973,7 +973,7 @@ impl Agent {
     }
 
     async fn answer(&mut self, aliases: &[usize]) -> Result<()> {
-        let gpt_model = if self.app.env.is_cloud_instance() {
+        let gpt_model = if cfg!(feature = "ee") || self.app.env.is_cloud_instance() {
             "gpt-4-32k-0613"
         } else {
             "gpt-4-0613"


### PR DESCRIPTION
Depends on #780.

We now try to expand code chunks to fill 70% of the context, using a greedy iterative algorithm:

1. Calculate per-chunk expansion: we target a small line increment (100 lines as currently implemented), and divide this number to obtain per-chunk line increments.
2. We expand each chunk both up and down, according to this increment
3. We merge overlapping chunks
4. Repeat until we reach our 70% threshold

This iterative approach avoids problems with overlapping spans, and is fairly simple to follow.