### PR TITLE
Sync-related consistency improvements

### DIFF
--- a/.github/workflows/server-test.yml
+++ b/.github/workflows/server-test.yml
@@ -30,7 +30,7 @@ jobs:
         run: nix develop -c bash -c 'cargo --locked fmt -p bleep -- --check'
 
       - name: Clippy
-        run: nix develop -c bash -c 'cargo --locked clippy -p bleep'
+        run: nix develop -c bash -c 'cargo --locked clippy -p bleep --features=ee'
 
       - name: Tests
         run: nix develop -c bash -c 'cargo --locked test -p bleep --release'

--- a/server/bleep/src/background.rs
+++ b/server/bleep/src/background.rs
@@ -224,7 +224,8 @@ impl BoundSyncQueue {
             }
 
             info!(%reporef, "queueing for sync");
-            let handle = SyncHandle::new(self.0.clone(), reporef, self.1.progress.clone(), None);
+            let handle =
+                SyncHandle::new(self.0.clone(), reporef, self.1.progress.clone(), None).await;
             self.1.queue.push(handle).await;
             num_queued += 1;
         }
@@ -236,7 +237,7 @@ impl BoundSyncQueue {
     ///
     /// Returns the new status.
     pub(crate) async fn block_until_synced(self, reporef: RepoRef) -> anyhow::Result<SyncStatus> {
-        let handle = SyncHandle::new(self.0.clone(), reporef, self.1.progress.clone(), None);
+        let handle = SyncHandle::new(self.0.clone(), reporef, self.1.progress.clone(), None).await;
         let finished = handle.notify_done();
         self.1.queue.push(handle).await;
         Ok(finished.recv_async().await?)

--- a/server/bleep/src/background/control.rs
+++ b/server/bleep/src/background/control.rs
@@ -1,4 +1,4 @@
-use std::sync::{Arc, RwLock};
+use std::sync::RwLock;
 
 use crate::repo::{RepoRef, SyncStatus};
 
@@ -15,7 +15,7 @@ enum ControlEvent {
 pub struct SyncPipes {
     reporef: RepoRef,
     progress: super::ProgressStream,
-    event: Arc<RwLock<Option<ControlEvent>>>,
+    event: RwLock<Option<ControlEvent>>,
 }
 
 impl SyncPipes {

--- a/server/bleep/src/background/sync.rs
+++ b/server/bleep/src/background/sync.rs
@@ -18,7 +18,7 @@ pub(crate) struct SyncHandle {
     pub(crate) reporef: RepoRef,
     pub(crate) new_branch_filters: Option<crate::repo::BranchFilter>,
     pub(crate) app: Application,
-    pub(super) pipes: Arc<SyncPipes>,
+    pub(super) pipes: SyncPipes,
     exited: flume::Sender<SyncStatus>,
     exit_signal: flume::Receiver<SyncStatus>,
 }
@@ -94,7 +94,7 @@ impl SyncHandle {
         new_branch_filters: Option<crate::repo::BranchFilter>,
     ) -> Arc<Self> {
         let (exited, exit_signal) = flume::bounded(1);
-        let pipes = SyncPipes::new(reporef.clone(), status).into();
+        let pipes = SyncPipes::new(reporef.clone(), status);
         let sh = Self {
             app: app.clone(),
             reporef: reporef.clone(),

--- a/server/bleep/src/ee/background.rs
+++ b/server/bleep/src/ee/background.rs
@@ -18,7 +18,8 @@ impl BoundSyncQueue {
             reporef,
             self.1.progress.clone(),
             Some(new_branches),
-        );
+        )
+        .await;
         self.1.queue.push(handle).await;
     }
 }

--- a/server/bleep/src/periodic/remotes.rs
+++ b/server/bleep/src/periodic/remotes.rs
@@ -138,6 +138,10 @@ async fn update_credentials(app: &Application) {
 }
 
 pub(crate) async fn check_repo_updates(app: Application) {
+    while app.credentials.github().is_none() {
+        sleep(Duration::from_millis(100)).await
+    }
+
     let handles: Arc<scc::HashMap<RepoRef, JoinHandle<_>>> = Arc::default();
     loop {
         app.repo_pool

--- a/server/bleep/src/remotes/github.rs
+++ b/server/bleep/src/remotes/github.rs
@@ -128,14 +128,14 @@ impl Auth {
 }
 
 impl Auth {
-    pub(crate) async fn clone_repo(&self, repo: Repository) -> Result<()> {
-        self.check_repo(&repo).await?;
+    pub(crate) async fn clone_repo(&self, repo: &Repository) -> Result<()> {
+        self.check_repo(repo).await?;
         git_clone(self.git_cred(), &repo.remote.to_string(), &repo.disk_path).await
     }
 
-    pub(crate) async fn pull_repo(&self, repo: Repository) -> Result<()> {
-        self.check_repo(&repo).await?;
-        git_pull(self.git_cred(), &repo).await
+    pub(crate) async fn pull_repo(&self, repo: &Repository) -> Result<()> {
+        self.check_repo(repo).await?;
+        git_pull(self.git_cred(), repo).await
     }
 
     pub async fn check_repo(&self, repo: &Repository) -> Result<()> {

--- a/server/bleep/src/repo/iterator/git.rs
+++ b/server/bleep/src/repo/iterator/git.rs
@@ -58,7 +58,7 @@ impl GitWalker {
         let head_name = head
             .clone()
             .try_into_referent()
-            .map(|r| r.name().to_owned());
+            .map(|r| format!("origin/{}", human_readable_branch_name(&r)));
 
         let refs = local_git.references()?;
         let trees = if head_name.is_none() && matches!(branches, BranchFilter::Head) {
@@ -73,12 +73,13 @@ impl GitWalker {
             refs.all()?
                 .filter_map(Result::ok)
                 .map(|r| {
+                    let name = human_readable_branch_name(&r);
                     (
                         head_name
                             .as_ref()
-                            .map(|head| head.as_ref() == r.name())
+                            .map(|head| head == &name)
                             .unwrap_or_default(),
-                        human_readable_branch_name(&r),
+                        name,
                         r,
                     )
                 })

--- a/server/bleep/src/repo/iterator/git.rs
+++ b/server/bleep/src/repo/iterator/git.rs
@@ -82,6 +82,7 @@ impl GitWalker {
                         r,
                     )
                 })
+                .filter(|(_, name, _)| name.starts_with("origin/"))
                 .filter(|(is_head, name, _)| branches.filter(*is_head, name))
                 .filter_map(|(is_head, branch, r)| -> Option<_> {
                     Some((
@@ -134,7 +135,7 @@ impl GitWalker {
                     }
 
                     // the HEAD branch will not have an origin prefix
-                    branches.insert(format!("origin/{}", branch.trim_start_matches("origin/")));
+                    branches.insert(branch);
                     acc
                 },
             );


### PR DESCRIPTION
Fixes bugs where:
 * Upstream repository changes aren't consistently picked up by the indexer
 * Race condition where Bloop tries to update repositories before credentials are available
 * If more than the number of worker threads repositories are queued, they aren't immediately reflected on the UI, only when they become active in the sync queue.