### PR TITLE
Empty pending exchange queue after each `step`

### DIFF
--- a/server/bleep/src/webserver/answer.rs
+++ b/server/bleep/src/webserver/answer.rs
@@ -214,8 +214,7 @@ pub(super) async fn _handle(
             complete: false,
         };
 
-        let mut left_stream = tokio_stream::wrappers::ReceiverStream::new(exchange_rx)
-            .map(Either::Left);
+        let mut exchange_rx = tokio_stream::wrappers::ReceiverStream::new(exchange_rx);
 
         let result = 'outer: loop {
             // The main loop. Here, we create two streams that operate simultaneously; the update
@@ -225,6 +224,7 @@ pub(super) async fn _handle(
 
             use futures::future::FutureExt;
 
+            let left_stream = (&mut exchange_rx).map(Either::Left);
             let right_stream = agent
                 .step(action)
                 .into_stream()
@@ -234,7 +234,7 @@ pub(super) async fn _handle(
 
             let mut next = None;
             for await item in tokio_stream::StreamExt::timeout(
-                stream::select(&mut left_stream, right_stream),
+                stream::select(left_stream, right_stream),
                 timeout,
             ) {
                 match item {
@@ -245,6 +245,15 @@ pub(super) async fn _handle(
                     },
                     Err(_) => break 'outer Err(AgentError::Timeout(timeout)),
                 }
+            }
+
+            // NB: Sending updates after all other `await` points in the final `step` call will
+            // likely not return a pending future due to the internal receiver queue. So, the call
+            // stack usually continues onwards, ultimately resulting in a `Poll::Ready`, backing out
+            // of the above loop without ever processing the final message. Here, we empty the
+            // queue.
+            while let Some(Some(exchange)) = exchange_rx.next().now_or_never() {
+                yield exchange;
             }
 
             match next {
@@ -679,15 +688,6 @@ impl Agent {
                     AnswerMode::Filesystem => self.answer_filesystem(paths).await?,
                     AnswerMode::Article => self.answer_article(paths).await?,
                 }
-
-                // NB: We have to yield right before returning here. This is the final return from
-                // `step` as it returns `None`. Sending updates after all `await` points in the
-                // final `step` call will likely not return a pending future due to the internal
-                // receiver queue. So, this call stack usually continues onwards, ultimately
-                // resulting in a `Poll::Ready`, backing out of the driving loop. Yielding gives a
-                // chance for any remaining updates to be processed before we process the final
-                // result of this `step` call.
-                tokio::task::yield_now().await;
 
                 return Ok(None);
             }


### PR DESCRIPTION
If a step internally pushes an exchange to the exchange channel while executing, there is a chance that this exchange will be missed in the `Agent` driving loop. This can happen if the update does not back up the channel, leading to an immediate success that returns `Poll::Ready`, and if there are no further await points in the final `step` call which
return `Poll::Pending`.

We fix this by emptying out the exchange channel after every step, picking up all stream items that immediately resolve.