### PR TITLE
Lowercase organisation name

### DIFF
--- a/server/bleep/src/webserver/aaa.rs
+++ b/server/bleep/src/webserver/aaa.rs
@@ -353,7 +353,7 @@ async fn user_auth(
         let org_name = {
             let cred = app.credentials.github().unwrap();
             match cred.auth {
-                remotes::github::Auth::App { org, .. } => org.clone(),
+                remotes::github::Auth::App { org, .. } => org.to_lowercase(),
                 _ => panic!("backend has invalid github credentials"),
             }
         };


### PR DESCRIPTION
We currently operate on cased GitHub organisation names. This is unnecessary as the GitHub API `org` parameter is case insensitive.