### PR TITLE
Qdrant performance tuning

### DIFF
--- a/helm/bloop/templates/bloop-deployment.yaml
+++ b/helm/bloop/templates/bloop-deployment.yaml
@@ -58,6 +58,7 @@ spec:
           - --model-dir=/model
           - --dylib-dir=/dylib
           - --frontend-dist=/frontend
+          - --max-threads={{ .Values.bloop.maxThreads }}
           - --answer-api-url={{ .Values.bloop.answerApiUrl }}
           - --qdrant-url=http://{{ include "qdrant.fullname" . }}:6334
           - --instance-domain={{ .Values.bloop.instanceDomain }}

--- a/helm/bloop/values.yaml
+++ b/helm/bloop/values.yaml
@@ -191,7 +191,7 @@ qdrant:
       enabled: true
       p2p:
         port: 6335
-      concensus:
+      consensus:
         tick_period_ms: 100
     storage:
       snapshots_path: /qdrant/storage/snapshots

--- a/helm/bloop/values.yaml
+++ b/helm/bloop/values.yaml
@@ -188,24 +188,11 @@ qdrant:
   config:
     telemetry_disabled: true
     cluster:
-      enabled: false
+      enabled: true
       p2p:
         port: 6335
       consensus:
         tick_period_ms: 100
     storage:
+      async_scorer: true
       snapshots_path: /qdrant/storage/snapshots
-      on_disk_payload: true
-      wal:
-        wal_capacity_mb: 64
-        wal_segments_ahead: 8
-      hnsw_index:
-        max_indexing_threads: 4
-
-      optimizers:
-        max_optimization_threads: 4
-        max_segment_size_kb: 16384
-        memmap_threshold_kb: 4096
-        indexing_threshold_kb: 8192
-        vacuum_min_vector_number: 100
-        flush_interval_sec: 1

--- a/helm/bloop/values.yaml
+++ b/helm/bloop/values.yaml
@@ -195,7 +195,7 @@ qdrant:
         tick_period_ms: 100
     storage:
       snapshots_path: /qdrant/storage/snapshots
-      on_disk_payload: false
+      on_disk_payload: true
       wal:
         wal_capacity_mb: 128
         wal_segments_ahead: 4

--- a/helm/bloop/values.yaml
+++ b/helm/bloop/values.yaml
@@ -197,8 +197,15 @@ qdrant:
       snapshots_path: /qdrant/storage/snapshots
       on_disk_payload: true
       wal:
-        wal_capacity_mb: 128
-        wal_segments_ahead: 4
+        wal_capacity_mb: 64
+        wal_segments_ahead: 8
+      hnsw_index:
+        max_indexing_threads: 4
+
       optimizers:
-        max_optimization_threads: 1
-        flush_interval_sec: 2
+        max_optimization_threads: 4
+        max_segment_size_kb: 16384
+        memmap_threshold_kb: 4096
+        indexing_threshold_kb: 8192
+        vacuum_min_vector_number: 100
+        flush_interval_sec: 1

--- a/helm/bloop/values.yaml
+++ b/helm/bloop/values.yaml
@@ -200,5 +200,5 @@ qdrant:
         wal_capacity_mb: 128
         wal_segments_ahead: 4
       optimizers:
-        max_optimization_threads: 2
+        max_optimization_threads: 1
         flush_interval_sec: 2

--- a/helm/bloop/values.yaml
+++ b/helm/bloop/values.yaml
@@ -197,3 +197,11 @@ qdrant:
       async_scorer: true
       snapshots_path: /qdrant/storage/snapshots
       storage_path: /qdrant/storage/storage
+      on_disk_payload: true
+      wal:
+        wal_capacity_mb: 128
+        wal_segments_ahead: 8
+
+      optimizers:
+        memmap_threshold_kb: 1
+        flush_interval_sec: 1

--- a/helm/bloop/values.yaml
+++ b/helm/bloop/values.yaml
@@ -20,6 +20,7 @@ bloop:
   sentryDsnFE: ""
   #
   logLevel: info
+  maxThreads: 3
 
 image:
   repository: ""
@@ -185,11 +186,19 @@ qdrant:
 
   #modification example for configuration to overwrite defaults
   config:
+    telemetry_disabled: true
     cluster:
       enabled: true
       p2p:
         port: 6335
-      consensus:
+      concensus:
         tick_period_ms: 100
     storage:
       snapshots_path: /qdrant/storage/snapshots
+      on_disk_payload: false
+      wal:
+        wal_capacity_mb: 128
+        wal_segments_ahead: 4
+      optimizers:
+        max_optimization_threads: 2
+        flush_interval_sec: 2

--- a/helm/bloop/values.yaml
+++ b/helm/bloop/values.yaml
@@ -196,3 +196,4 @@ qdrant:
     storage:
       async_scorer: true
       snapshots_path: /qdrant/storage/snapshots
+      storage_path: /qdrant/storage/storage

--- a/helm/bloop/values.yaml
+++ b/helm/bloop/values.yaml
@@ -20,7 +20,7 @@ bloop:
   sentryDsnFE: ""
   #
   logLevel: info
-  maxThreads: 3
+  maxThreads: 2
 
 image:
   repository: ""

--- a/helm/bloop/values.yaml
+++ b/helm/bloop/values.yaml
@@ -188,7 +188,7 @@ qdrant:
   config:
     telemetry_disabled: true
     cluster:
-      enabled: true
+      enabled: false
       p2p:
         port: 6335
       consensus:

--- a/server/bleep/src/cache.rs
+++ b/server/bleep/src/cache.rs
@@ -169,7 +169,7 @@ impl<'a> ChunkCache<'a> {
         let response = qdrant
             .scroll(&ScrollPoints {
                 collection_name: semantic::COLLECTION_NAME.to_string(),
-                limit: Some(1_000),
+                limit: Some(1_000_000),
                 filter: Some(Filter {
                     must: [make_kv_keyword_filter("content_hash", tantivy_cache_key)]
                         .into_iter()

--- a/server/bleep/src/cache.rs
+++ b/server/bleep/src/cache.rs
@@ -169,7 +169,7 @@ impl<'a> ChunkCache<'a> {
         let response = qdrant
             .scroll(&ScrollPoints {
                 collection_name: semantic::COLLECTION_NAME.to_string(),
-                limit: Some(1_000_000),
+                limit: Some(1_000),
                 filter: Some(Filter {
                     must: [make_kv_keyword_filter("content_hash", tantivy_cache_key)]
                         .into_iter()

--- a/server/bleep/src/cache.rs
+++ b/server/bleep/src/cache.rs
@@ -271,15 +271,6 @@ impl<'a> ChunkCache<'a> {
     }
 
     pub async fn commit(self) -> anyhow::Result<(usize, usize, usize)> {
-        let mut keys = vec![];
-        self.cache
-            .scan_async(|k, v| {
-                if v.fresh {
-                    keys.push(k.clone())
-                }
-            })
-            .await;
-
         let update: Vec<_> = std::mem::take(self.update.write().unwrap().as_mut());
         let update_size = update.len();
         futures::future::join_all(update.into_iter().map(|(id, p)| async move {

--- a/server/bleep/src/cache.rs
+++ b/server/bleep/src/cache.rs
@@ -286,7 +286,7 @@ impl<'a> ChunkCache<'a> {
             // need another async block to get around scoping issues
             // with referential `&id`
             self.qdrant
-                .set_payload(semantic::COLLECTION_NAME, &id, p, None)
+                .set_payload_blocking(semantic::COLLECTION_NAME, &id, p, None)
                 .await
         }))
         .await
@@ -313,7 +313,7 @@ impl<'a> ChunkCache<'a> {
         let new_size = new.len();
         if !new.is_empty() {
             self.qdrant
-                .upsert_points(semantic::COLLECTION_NAME, new, None)
+                .upsert_points_blocking(semantic::COLLECTION_NAME, new, None)
                 .await?;
         }
 

--- a/server/bleep/src/semantic.rs
+++ b/server/bleep/src/semantic.rs
@@ -22,7 +22,7 @@ use futures::{stream, StreamExt, TryStreamExt};
 use rand::{prelude::Distribution, thread_rng};
 use rayon::prelude::*;
 use thiserror::Error;
-use tracing::{debug, error, info, trace, warn};
+use tracing::{debug, info, trace, warn};
 
 pub mod chunk;
 pub mod execute;
@@ -489,7 +489,7 @@ impl Semantic {
                 match cache {
                     Ok(cache) => break 'cache Some(cache),
                     Err(err) => {
-                        error!(?err, "failed to initialize cache");
+                        warn!(?err, "failed to initialize cache");
                         tokio::time::sleep(tokio::time::Duration::from_millis(backoff)).await;
                     }
                 }

--- a/server/bleep/src/semantic.rs
+++ b/server/bleep/src/semantic.rs
@@ -478,7 +478,7 @@ impl Semantic {
             // threads should ping qdrant offset, and not dump new
             // queries on it simultaneously.
             let rand = rand::distributions::Uniform::new(500, 1500);
-            for (_, backoff) in (0..15).zip(rand.sample_iter(&mut thread_rng())) {
+            for (_, backoff) in (0..30).zip(rand.sample_iter(&mut thread_rng())) {
                 let cache = crate::cache::ChunkCache::for_file(
                     &self.qdrant,
                     tantivy_cache_key,

--- a/server/bleep/src/semantic.rs
+++ b/server/bleep/src/semantic.rs
@@ -469,6 +469,14 @@ impl Semantic {
         is_cold_run: bool,
     ) {
         let chunk_cache = 'cache: {
+            // Wait for some time here.
+            //
+            // In practice it looks like IF there's a backlog in
+            // qdrant, it will take a few seconds to resolve.
+            //
+            // To avoid exacerbating any issues, the individual worker
+            // threads should ping qdrant offset, and not dump new
+            // queries on it simultaneously.
             let rand = rand::distributions::Uniform::new(500, 1500);
             for (_, backoff) in (0..15).zip(rand.sample_iter(&mut thread_rng())) {
                 let cache = crate::cache::ChunkCache::for_file(

--- a/server/bleep/src/semantic.rs
+++ b/server/bleep/src/semantic.rs
@@ -477,7 +477,7 @@ impl Semantic {
             // To avoid exacerbating any issues, the individual worker
             // threads should ping qdrant offset, and not dump new
             // queries on it simultaneously.
-            let rand = rand::distributions::Uniform::new(500, 1500);
+            let rand = rand::distributions::Uniform::new(1000, 2000);
             for (_, backoff) in (0..30).zip(rand.sample_iter(&mut thread_rng())) {
                 let cache = crate::cache::ChunkCache::for_file(
                     &self.qdrant,


### PR DESCRIPTION
In Kube it seems like we need a bit more tolerance, as qdrant isn't as fast to consolidate writes as we'd like. Add random backoff to retries, wait for write confirmation during indexing, tune the qdrant WAL & keep more things in memory to get a faster resolution.