### PR TITLE
Use sqlite for chunk cache

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1689192006,
-        "narHash": "sha256-QM0f0d8oPphOTYJebsHioR9+FzJcy1QNIzREyubB91U=",
+        "lastModified": 1690272529,
+        "narHash": "sha256-MakzcKXEdv/I4qJUtq/k/eG+rVmyOZLnYNC2w1mB59Y=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "2de8efefb6ce7f5e4e75bdf57376a96555986841",
+        "rev": "ef99fa5c5ed624460217c31ac4271cfb5cb2502c",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -27,6 +27,11 @@
         else
           llvm.stdenv;
 
+        mkShell = if stdenv.isLinux then
+          pkgs.mkShell.override { inherit stdenv; }
+        else
+          pkgs.mkShell;
+
         rustPlatform = pkgs.makeRustPlatform {
           cargo = pkgs.cargo;
           rustc = pkgs.rustc;
@@ -90,8 +95,8 @@
           ORT_STRATEGY = "system";
           ORT_LIB_LOCATION = "${onnxruntime14}/lib";
           ORT_DYLIB_PATH = "${onnxruntime14}/lib/${onnxruntime_lib}";
-          RUSTFLAGS =
-            lib.optionalString stdenv.isLinux "-C link-arg=-fuse-ld=mold";
+        } // lib.optionalAttrs stdenv.isLinux {
+          RUSTFLAGS = "-C link-arg=-fuse-ld=mold";
         };
 
         bleep =
@@ -185,7 +190,7 @@
         };
 
         devShells = {
-          default = (pkgs.mkShell.override { inherit stdenv; } {
+          default = (mkShell {
             buildInputs = buildDeps ++ runtimeDeps ++ guiDeps ++ (with pkgs; [
               git-lfs
               rustfmt
@@ -198,7 +203,7 @@
 
             src = pkgs.lib.sources.cleanSource ./.;
 
-            BLOOP_LOG="bleep=debug";
+            BLOOP_LOG = "bleep=debug";
           }).overrideAttrs (old: envVars);
         };
 

--- a/server/bleep/migrations/20230613143506_file-cache.sql
+++ b/server/bleep/migrations/20230613143506_file-cache.sql
@@ -1,6 +1,11 @@
 -- Add migration script here
 CREATE TABLE file_cache (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    repo_ref TEXT NOT NULL,
-    cache_hash TEXT NOT NULL
+    cache_hash TEXT PRIMARY KEY NOT NULL,
+    repo_ref TEXT NOT NULL
+);
+
+CREATE TABLE chunk_cache (
+    chunk_hash TEXT NOT NULL,
+    file_hash TEXT NOT NULL,
+    branches TEXT NOT NULL
 );

--- a/server/bleep/migrations/20230613143506_file-cache.sql
+++ b/server/bleep/migrations/20230613143506_file-cache.sql
@@ -7,5 +7,6 @@ CREATE TABLE file_cache (
 CREATE TABLE chunk_cache (
     chunk_hash TEXT NOT NULL,
     file_hash TEXT NOT NULL,
-    branches TEXT NOT NULL
+    branches TEXT NOT NULL,
+    repo_ref TEXT NOT NULL
 );

--- a/server/bleep/sqlx-data.json
+++ b/server/bleep/sqlx-data.json
@@ -82,16 +82,6 @@
     },
     "query": "DELETE FROM chunk_cache WHERE chunk_hash = ? AND file_hash = ?"
   },
-  "5b0b28e943795c0d2485bcda52aa08ba3103c4b8300dd59d4828162de3d83b4e": {
-    "describe": {
-      "columns": [],
-      "nullable": [],
-      "parameters": {
-        "Right": 3
-      }
-    },
-    "query": "INSERT INTO chunk_cache (chunk_hash, file_hash, branches) VALUES (?, ?, ?)"
-  },
   "6d8b70a52e6a1f0b18a7981604386ca4ef264d57d2c22958f2e31cb5eaad9b02": {
     "describe": {
       "columns": [
@@ -172,6 +162,16 @@
     },
     "query": "SELECT raw_query FROM query_log WHERE created_at > ?"
   },
+  "b3ebaeec21c90aa9ebc59a808e03c661839d0a0eaa86ad2bf4251e895f8e0a03": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Right": 4
+      }
+    },
+    "query": "INSERT INTO chunk_cache (chunk_hash, file_hash, branches, repo_ref) VALUES (?, ?, ?, ?)"
+  },
   "bc60b0f34fd20feba2da3f16458770424534eacaba75e6f45b8218f32767671b": {
     "describe": {
       "columns": [
@@ -251,5 +251,15 @@
       }
     },
     "query": "INSERT INTO file_cache (repo_ref, cache_hash) VALUES (?, ?)"
+  },
+  "ed6379e37c16064198f48dbfb91899d74eb346533e3c9ab3814ba67b68d71f51": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Right": 1
+      }
+    },
+    "query": "DELETE FROM chunk_cache WHERE repo_ref = ?"
   }
 }

--- a/server/bleep/sqlx-data.json
+++ b/server/bleep/sqlx-data.json
@@ -10,6 +10,30 @@
     },
     "query": "DELETE FROM conversations WHERE user_id = ? AND thread_id = ?"
   },
+  "49f204678451d2c045fc1569707957e41bc170ea2ede754e2a5e660c14347bba": {
+    "describe": {
+      "columns": [
+        {
+          "name": "chunk_hash",
+          "ordinal": 0,
+          "type_info": "Text"
+        },
+        {
+          "name": "branches",
+          "ordinal": 1,
+          "type_info": "Text"
+        }
+      ],
+      "nullable": [
+        false,
+        false
+      ],
+      "parameters": {
+        "Right": 1
+      }
+    },
+    "query": "SELECT chunk_hash, branches FROM chunk_cache WHERE file_hash = ?"
+  },
   "4a279b8dbb55668f4073a19e7269ae280051183079d994faa8b8d9d8ebac424f": {
     "describe": {
       "columns": [
@@ -47,6 +71,26 @@
       }
     },
     "query": "INSERT INTO query_log (raw_query) VALUES (?)"
+  },
+  "5128142bf657cfde043a1b53834d40980caa3e9ae5fd6f4d7f30d89be512f105": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Right": 2
+      }
+    },
+    "query": "DELETE FROM chunk_cache WHERE chunk_hash = ? AND file_hash = ?"
+  },
+  "5b0b28e943795c0d2485bcda52aa08ba3103c4b8300dd59d4828162de3d83b4e": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Right": 3
+      }
+    },
+    "query": "INSERT INTO chunk_cache (chunk_hash, file_hash, branches) VALUES (?, ?, ?)"
   },
   "6d8b70a52e6a1f0b18a7981604386ca4ef264d57d2c22958f2e31cb5eaad9b02": {
     "describe": {
@@ -89,6 +133,16 @@
       }
     },
     "query": "SELECT repo_ref, llm_history, exchanges, path_aliases, code_chunks FROM conversations WHERE user_id = ? AND thread_id = ?"
+  },
+  "9146d9c8a7f17cc65c017cb364d1a853a9163b5ece336c0a6ef4e28e8df56a6b": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Right": 2
+      }
+    },
+    "query": "UPDATE chunk_cache SET branches = ? WHERE chunk_hash = ?"
   },
   "9f862a56e79cc9ae6e9b896064a0057335b40225be0a8c8d29d9227de12ae364": {
     "describe": {

--- a/server/bleep/src/background/sync.rs
+++ b/server/bleep/src/background/sync.rs
@@ -314,7 +314,7 @@ impl SyncHandle {
                 .await;
         }
 
-        FileCache::new(sql, &self.reporef)
+        FileCache::for_repo(sql, &self.reporef)
             .delete()
             .await
             .map_err(SyncError::Sql)?;

--- a/server/bleep/src/cache.rs
+++ b/server/bleep/src/cache.rs
@@ -5,7 +5,7 @@ use qdrant_client::{
     qdrant::{PointId, PointStruct},
 };
 use sqlx::Sqlite;
-use tracing::{debug, trace};
+use tracing::trace;
 use uuid::Uuid;
 
 use crate::{
@@ -306,7 +306,8 @@ impl<'a> ChunkCache<'a> {
         //
         let new: Vec<_> = std::mem::take(self.new.write().unwrap().as_mut());
         let new_size = new.len();
-        for (p, branches) in std::mem::take(&mut *self.new_sql.write().unwrap()) {
+        let new_sql = std::mem::take(&mut *self.new_sql.write().unwrap());
+        for (p, branches) in new_sql {
             sqlx::query! {
                 "INSERT INTO chunk_cache (chunk_hash, file_hash, branches) \
                  VALUES (?, ?, ?)",

--- a/server/bleep/src/cache.rs
+++ b/server/bleep/src/cache.rs
@@ -51,16 +51,20 @@ impl<T> From<T> for FreshValue<T> {
 /// representative at a single point in time
 pub(crate) type FileCacheSnapshot = Arc<scc::HashMap<String, FreshValue<()>>>;
 
-/// Unique content in a repository, where every entry is a file
-/// The cache keys are directly mirrored in Tantivy, as Tantivy can't
-/// upsert content
+/// Manage the SQL cache for a repository, establishing a
+/// content-addressed space for files in it.
+///
+/// The cache keys are should be directly mirrored in Tantivy for each
+/// file entry, as Tantivy can't upsert content.
+///
+/// NB: consistency with Tantivy state is NOT ensured here.
 pub(crate) struct FileCache<'a> {
     db: &'a SqlDb,
     reporef: &'a RepoRef,
 }
 
 impl<'a> FileCache<'a> {
-    pub(crate) fn new(db: &'a SqlDb, reporef: &'a RepoRef) -> Self {
+    pub(crate) fn for_repo(db: &'a SqlDb, reporef: &'a RepoRef) -> Self {
         Self { db, reporef }
     }
 
@@ -84,7 +88,7 @@ impl<'a> FileCache<'a> {
 
     pub(crate) async fn persist(&self, cache: FileCacheSnapshot) -> anyhow::Result<()> {
         let mut tx = self.db.begin().await?;
-        self.delete_tx(&mut tx).await?;
+        self.delete_files(&mut tx).await?;
 
         let keys = {
             let mut keys = vec![];
@@ -112,14 +116,14 @@ impl<'a> FileCache<'a> {
 
     pub(crate) async fn delete(&self) -> anyhow::Result<()> {
         let mut tx = self.db.begin().await?;
-        self.delete_tx(&mut tx).await?;
+        self.delete_files(&mut tx).await?;
         self.delete_chunks(&mut tx).await?;
         tx.commit().await?;
 
         Ok(())
     }
 
-    async fn delete_tx(&self, tx: &mut sqlx::Transaction<'_, Sqlite>) -> anyhow::Result<()> {
+    async fn delete_files(&self, tx: &mut sqlx::Transaction<'_, Sqlite>) -> anyhow::Result<()> {
         let repo_str = self.reporef.to_string();
         sqlx::query! {
             "DELETE FROM file_cache \
@@ -150,6 +154,10 @@ impl<'a> FileCache<'a> {
     }
 }
 
+/// Manage both the SQL cache and the underlying qdrant database to
+/// ensure consistency.
+///
+/// Operates on a single file's level.
 pub struct ChunkCache<'a> {
     sql: &'a SqlDb,
     reporef: &'a RepoRef,
@@ -197,20 +205,20 @@ impl<'a> ChunkCache<'a> {
         payload: Payload,
     ) -> anyhow::Result<()> {
         let id = self.cache_key(data);
-        let branches = blake3::hash(payload.branches.join("\n").as_ref()).to_string();
+        let branches_hash = blake3::hash(payload.branches.join("\n").as_ref()).to_string();
 
         match self.cache.entry(id) {
             scc::hash_map::Entry::Occupied(mut existing) => {
                 let key = existing.key();
                 trace!(?key, "found; not upserting new");
-                if existing.get().value != branches {
+                if existing.get().value != branches_hash {
                     self.update
-                        .entry((payload.branches, branches.clone()))
+                        .entry((payload.branches, branches_hash.clone()))
                         .or_insert_with(Vec::new)
                         .get_mut()
                         .push(existing.key().to_owned());
                 }
-                *existing.get_mut() = branches.into();
+                *existing.get_mut() = branches_hash.into();
             }
             scc::hash_map::Entry::Vacant(vacant) => {
                 let key = vacant.key();
@@ -218,7 +226,7 @@ impl<'a> ChunkCache<'a> {
                 self.new_sql
                     .write()
                     .unwrap()
-                    .push((vacant.key().to_owned(), branches.clone()));
+                    .push((vacant.key().to_owned(), branches_hash.clone()));
 
                 self.new.write().unwrap().push(PointStruct {
                     id: Some(PointId::from(vacant.key().clone())),
@@ -226,63 +234,77 @@ impl<'a> ChunkCache<'a> {
                     payload: payload.into_qdrant(),
                 });
 
-                vacant.insert_entry(branches.into());
+                vacant.insert_entry(branches_hash.into());
             }
         }
 
         Ok(())
     }
 
+    /// Commit both qdrant and cache changes to the respective databases.
+    ///
+    /// The SQLite operations mirror qdrant changes 1:1, so any
+    /// discrepancy between the 2 should be minimized.
+    ///
+    /// In addition, the SQLite cache is committed only AFTER all
+    /// qdrant writes have successfully completed, meaning they're in
+    /// qdrant's pipelines.
+    ///
+    /// Since qdrant changes are pipelined on their end, data written
+    /// here is not necessarily available for querying when the
+    /// commit's completed.
     pub async fn commit(self, qdrant: &QdrantClient) -> anyhow::Result<(usize, usize, usize)> {
-        let mut update_size = 0;
-        let mut updates = vec![];
         let mut tx = self.sql.begin().await?;
 
-        //
-        // Update points
-        //
-        let mut next = self.update.first_occupied_entry();
-        while let Some(entry) = next {
-            let (branches_list, branches) = entry.key();
-            let points = entry.get();
-            update_size += points.len();
+        let update_size = self.commit_branch_updates(&mut tx, qdrant).await?;
+        let delete_size = self.commit_deletes(&mut tx, qdrant).await?;
+        let new_size = self.commit_inserts(&mut tx, qdrant).await?;
 
-            for p in entry.get() {
-                sqlx::query! {
-                    "UPDATE chunk_cache SET branches = ? \
-                     WHERE chunk_hash = ?",
-                     branches,
-                     p
-                }
-                .execute(&mut *tx)
-                .await?;
+        tx.commit().await?;
+
+        Ok((new_size, update_size, delete_size))
+    }
+
+    /// Insert new additions to both qdrant and sqlite.
+    ///
+    /// The qdrant write uses `upsert`, because we simply want to
+    /// express "these points should be in this state", without
+    /// being pedantic.
+    async fn commit_inserts(
+        &self,
+        tx: &mut sqlx::Transaction<'_, Sqlite>,
+        qdrant: &QdrantClient,
+    ) -> Result<usize, anyhow::Error> {
+        let new: Vec<_> = std::mem::take(self.new.write().unwrap().as_mut());
+        let new_sql = std::mem::take(&mut *self.new_sql.write().unwrap());
+        let new_size = new.len();
+
+        let repo_str = self.reporef.to_string();
+        for (p, branches) in new_sql {
+            sqlx::query! {
+                "INSERT INTO chunk_cache (chunk_hash, file_hash, branches, repo_ref) \
+                 VALUES (?, ?, ?, ?)",
+                 p, self.file_cache_key, branches, repo_str
             }
-
-            let id = points
-                .iter()
-                .cloned()
-                .map(PointId::from)
-                .collect::<Vec<_>>()
-                .into();
-            let payload = qdrant_client::client::Payload::new_from_hashmap(
-                [("branches".to_string(), branches_list.to_owned().into())].into(),
-            );
-
-            updates.push(async move {
-                qdrant
-                    .set_payload_blocking(semantic::COLLECTION_NAME, &id, payload, None)
-                    .await
-            });
-            next = entry.next();
+            .execute(&mut *tx)
+            .await?;
         }
-        futures::future::join_all(updates.into_iter())
-            .await
-            .into_iter()
-            .collect::<Result<Vec<_>, _>>()?;
 
-        //
-        // Delete points
-        //
+        // qdrant doesn't like empty payloads.
+        if !new.is_empty() {
+            qdrant
+                .upsert_points_blocking(semantic::COLLECTION_NAME, new, None)
+                .await?;
+        }
+        Ok(new_size)
+    }
+
+    /// Delete points that have expired in the latest index.
+    async fn commit_deletes(
+        &self,
+        tx: &mut sqlx::Transaction<'_, Sqlite>,
+        qdrant: &QdrantClient,
+    ) -> Result<usize, anyhow::Error> {
         let mut to_delete = vec![];
         self.cache
             .scan_async(|id, p| {
@@ -303,6 +325,7 @@ impl<'a> ChunkCache<'a> {
             .execute(&mut *tx)
             .await?;
         }
+
         if !to_delete.is_empty() {
             qdrant
                 .delete_points(
@@ -316,33 +339,66 @@ impl<'a> ChunkCache<'a> {
                 )
                 .await?;
         }
+        Ok(delete_size)
+    }
 
-        //
-        // Upsert points
-        //
-        let new: Vec<_> = std::mem::take(self.new.write().unwrap().as_mut());
-        let new_size = new.len();
-        let new_sql = std::mem::take(&mut *self.new_sql.write().unwrap());
-        let repo_str = self.reporef.to_string();
-        for (p, branches) in new_sql {
-            sqlx::query! {
-                "INSERT INTO chunk_cache (chunk_hash, file_hash, branches, repo_ref) \
-                 VALUES (?, ?, ?, ?)",
-                 p, self.file_cache_key, branches, repo_str
-            }
-            .execute(&mut *tx)
-            .await?;
-        }
+    /// Update points where the list of branches in which they're
+    /// searchable has changed.
+    async fn commit_branch_updates(
+        &self,
+        tx: &mut sqlx::Transaction<'_, Sqlite>,
+        qdrant: &QdrantClient,
+    ) -> Result<usize, anyhow::Error> {
+        let mut update_size = 0;
+        let mut qdrant_updates = vec![];
 
-        if !new.is_empty() {
-            qdrant
-                .upsert_points_blocking(semantic::COLLECTION_NAME, new, None)
+        let mut next = self.update.first_occupied_entry();
+        while let Some(entry) = next {
+            let (branches_list, branches_hash) = entry.key();
+            let points = entry.get();
+            update_size += points.len();
+
+            for p in entry.get() {
+                sqlx::query! {
+                    "UPDATE chunk_cache SET branches = ? \
+                     WHERE chunk_hash = ?",
+                     branches_hash,
+                     p
+                }
+                .execute(&mut *tx)
                 .await?;
+            }
+
+            let id = points
+                .iter()
+                .cloned()
+                .map(PointId::from)
+                .collect::<Vec<_>>()
+                .into();
+
+            let payload = qdrant_client::client::Payload::new_from_hashmap(
+                [("branches".to_string(), branches_list.to_owned().into())].into(),
+            );
+
+            qdrant_updates.push(async move {
+                qdrant
+                    .set_payload_blocking(semantic::COLLECTION_NAME, &id, payload, None)
+                    .await
+            });
+            next = entry.next();
         }
 
-        tx.commit().await?;
+        // Note these actions aren't actually parallel, merely
+        // concurrent.
+        //
+        // This should be fine since the number of updates would be
+        // reasonably small.
+        futures::future::join_all(qdrant_updates.into_iter())
+            .await
+            .into_iter()
+            .collect::<Result<Vec<_>, _>>()?;
 
-        Ok((new_size, update_size, delete_size))
+        Ok(update_size)
     }
 
     /// Return the cache key for the file that contains these chunks

--- a/server/bleep/src/indexes.rs
+++ b/server/bleep/src/indexes.rs
@@ -108,7 +108,7 @@ impl Indexes {
             });
 
             for reporef in refs {
-                FileCache::new(&sql, &reporef).delete().await?;
+                FileCache::for_repo(&sql, &reporef).delete().await?;
             }
         }
         config.source.save_index_version()?;

--- a/server/bleep/src/indexes/file.rs
+++ b/server/bleep/src/indexes/file.rs
@@ -60,7 +60,7 @@ impl Indexable for File {
         writer: &IndexWriter,
         pipes: &SyncPipes,
     ) -> Result<()> {
-        let file_cache = Arc::new(FileCache::new(&self.sql, reporef));
+        let file_cache = Arc::new(FileCache::for_repo(&self.sql, reporef));
         let cache_snapshot = file_cache.retrieve().await;
         let repo_name = reporef.indexed_name();
         let processed = &AtomicU64::new(0);


### PR DESCRIPTION
The PR moves the chunk caching mechanism adjacent to qdrant in order to avoid querying it during intensive write cycles.
Before this patch we would need to wait for qdrant to become queryable periodically, stalling our own processing pipeline, which is problematic since the indexing operation on both sides is fairly expensive (and thus can take a lot of time). Therefore chunk caches now live in SQLite.

The chunks during a write operation are updated in parallel both in qdrant and SQLite.

If the sqlite db is deleted, it is possible that an inconsistency will leave stale objects in qdrant. Since chunk ids in qdrant are deterministic, an up-to-date cache will be built back up, although recalculating all embeddings will be necessary.