### PR TITLE
Add PUT endpoint that will overwrite specific fields in the config

### DIFF
--- a/client/src/components/Chat/NLInput.tsx
+++ b/client/src/components/Chat/NLInput.tsx
@@ -13,8 +13,8 @@ import ClearButton from '../ClearButton';
 import Tooltip from '../Tooltip';
 import { ChatLoadingStep } from '../../types/general';
 import LiteLoader from '../Loaders/LiteLoader';
-import { getPlainFromStorage, PROMPT_GUIDE_DONE } from '../../services/storage';
 import { UIContext } from '../../context/uiContext';
+import { DeviceContext } from '../../context/deviceContext';
 import InputLoader from './InputLoader';
 
 type Props = {
@@ -52,6 +52,7 @@ const NLInput = ({
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const [isComposing, setComposition] = useState(false);
   const { setPromptGuideOpen } = useContext(UIContext);
+  const { envConfig } = useContext(DeviceContext);
 
   useEffect(() => {
     if (inputRef.current) {
@@ -85,10 +86,10 @@ const NLInput = ({
   );
 
   const handleInputFocus = useCallback(() => {
-    if (!getPlainFromStorage(PROMPT_GUIDE_DONE)) {
+    if (envConfig?.bloop_user_profile?.prompt_guide !== 'dismissed') {
       setPromptGuideOpen(true);
     }
-  }, []);
+  }, [envConfig?.bloop_user_profile?.prompt_guide]);
 
   return (
     <div

--- a/client/src/components/PromptGuidePopup/index.tsx
+++ b/client/src/components/PromptGuidePopup/index.tsx
@@ -5,18 +5,25 @@ import Button from '../Button';
 import { CloseSign } from '../../icons';
 import { DeviceContext } from '../../context/deviceContext';
 import { UIContext } from '../../context/uiContext';
-import { PROMPT_GUIDE_DONE, savePlainToStorage } from '../../services/storage';
+import { getConfig, putConfig } from '../../services/api';
 import PromptSvg from './PromptSvg';
 
 const PromptGuidePopup = () => {
   const { t } = useTranslation();
-  const { openLink } = useContext(DeviceContext);
+  const { openLink, setEnvConfig, envConfig } = useContext(DeviceContext);
   const { isPromptGuideOpen, setPromptGuideOpen } = useContext(UIContext);
 
   const handlePromptGuideClose = useCallback(() => {
     setPromptGuideOpen(false);
-    savePlainToStorage(PROMPT_GUIDE_DONE, 'true');
-  }, []);
+    putConfig({
+      bloop_user_profile: {
+        ...(envConfig?.bloop_user_profile || {}),
+        prompt_guide: 'dismissed',
+      },
+    }).then(() => {
+      getConfig().then(setEnvConfig);
+    });
+  }, [envConfig?.bloop_user_profile]);
 
   return (
     <ModalOrSidebar

--- a/client/src/services/api.ts
+++ b/client/src/services/api.ts
@@ -9,7 +9,7 @@ import {
   SuggestionsResponse,
   TokenInfoResponse,
 } from '../types/api';
-import { RepoType } from '../types/general';
+import { EnvConfig, RepoType } from '../types/general';
 
 const DB_API = 'https://api.bloop.ai';
 let http: AxiosInstance;
@@ -202,6 +202,8 @@ export const githubWebLogin = (redirect_to: string) =>
     .then((r) => r.data);
 
 export const getConfig = () => http.get('/config').then((r) => r.data);
+export const putConfig = (data: Partial<EnvConfig>) =>
+  http.put('/config', data).then((r) => r.data);
 
 export const getAllConversations = (
   repo_ref: string,

--- a/client/src/types/general.ts
+++ b/client/src/types/general.ts
@@ -249,4 +249,7 @@ export type EnvConfig = {
     login: string;
     avatar_url: string;
   };
+  bloop_user_profile?: {
+    prompt_guide?: string;
+  };
 };

--- a/server/bleep/src/user.rs
+++ b/server/bleep/src/user.rs
@@ -1,0 +1,22 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+#[serde(rename_all = "snake_case")]
+pub enum PromptGuideState {
+    Dismissed,
+    Active,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+#[serde(rename_all = "snake_case")]
+pub struct UserProfile {
+    prompt_guide: PromptGuideState,
+}
+
+impl Default for UserProfile {
+    fn default() -> Self {
+        UserProfile {
+            prompt_guide: PromptGuideState::Active,
+        }
+    }
+}

--- a/server/bleep/src/webserver.rs
+++ b/server/bleep/src/webserver.rs
@@ -41,7 +41,7 @@ pub async fn start(app: Application) -> anyhow::Result<()> {
     let bind = SocketAddr::new(app.config.host.parse()?, app.config.port);
 
     let mut api = Router::new()
-        .route("/config", get(config::handle))
+        .route("/config", get(config::get).put(config::put))
         // querying
         .route("/q", get(query::handle))
         // autocomplete

--- a/server/bleep/src/webserver/middleware.rs
+++ b/server/bleep/src/webserver/middleware.rs
@@ -10,11 +10,12 @@ use axum::{
 };
 use sentry::{Hub, SentryFutureExt};
 
-#[derive(Clone)]
+#[derive(Serialize, Clone)]
 pub enum User {
     Unknown,
     Authenticated {
         login: String,
+        #[serde(skip)]
         crab: Arc<dyn Fn() -> anyhow::Result<octocrab::Octocrab> + Send + Sync>,
     },
 }


### PR DESCRIPTION
A PUT request to the `/api/config` endpoint will fully overwrite the, whole newly introduced, `bloop_user_profile` object.

Eg.: `http -j PUT "localhost:7878/api/config" bloop_user_profile[prompt_guide]=dismissed`