### PR TITLE
Fix file icon in breadcrumbs

### DIFF
--- a/client/src/components/IdeNavigation/index.tsx
+++ b/client/src/components/IdeNavigation/index.tsx
@@ -13,7 +13,7 @@ const IdeNavigation = () => {
   const { tab } = useContext(UIContext);
   const { selectedBranch } = useContext(SearchContext);
   const [files, setFiles] = useState<DirectoryEntry[]>([]);
-  const { navigateRepoPath } = useContext(AppNavigationContext);
+  const { navigateFullResult } = useContext(AppNavigationContext);
 
   const fetchFiles = useCallback(
     async (path?: string) => {
@@ -40,9 +40,9 @@ const IdeNavigation = () => {
 
   const navigateToPath = useCallback(
     (path: string) => {
-      navigateRepoPath(tab.repoName, path);
+      navigateFullResult(tab.repoName, path);
     },
-    [tab.repoName, navigateRepoPath],
+    [tab.repoName, navigateFullResult],
   );
 
   return (


### PR DESCRIPTION
use full-result navigation instead of repo path to fix icon in breadcrumbs