### PR TITLE
add file metadata to open responses

### DIFF
--- a/client/src/mappers/results.ts
+++ b/client/src/mappers/results.ts
@@ -149,6 +149,8 @@ export const mapFileResult = (fileItem: FileItem) => {
     code: fileItem.data.contents,
     hoverableRanges: [],
     repoName: fileItem.data.repo_name,
+    size: fileItem.data.size,
+    loc: fileItem.data.sloc,
   };
 };
 

--- a/client/src/pages/ResultFull/index.tsx
+++ b/client/src/pages/ResultFull/index.tsx
@@ -8,6 +8,7 @@ import { mapFileResult, mapRanges } from '../../mappers/results';
 import { FullResult } from '../../types/results';
 import {
   breadcrumbsItemPath,
+  humanFileSize,
   isWindowsPath,
   splitPathForBreadcrumbs,
 } from '../../utils';
@@ -116,19 +117,16 @@ const ResultFull = ({ data, isLoading, selectedBranch }: Props) => {
               </div>
             )}
           </div>
-          {/*<div className="flex gap-2">*/}
-          {/*<SelectToggleButton onlyIcon title="Star">*/}
-          {/*  <Star />*/}
-          {/*</SelectToggleButton>*/}
-          {/*<Button variant="primary" onClick={() => setShareOpen(true)}>*/}
-          {/*  Share*/}
-          {/*  <ArrowBoxOut />*/}
-          {/*</Button>*/}
-          {/*</div>*/}
-          <FileMenu
-            relativePath={result?.relativePath || ''}
-            repoPath={result?.repoPath || ''}
-          />
+          <div className="flex-shrink-0 flex items-center gap-2">
+            <p className="code-s flex-shrink-0 text-label-base">
+              {result?.code.split('\n').length} lines ({result?.loc} loc) ·{' '}
+              {result?.size ? humanFileSize(result?.size) : ''}
+            </p>
+            <FileMenu
+              relativePath={result?.relativePath || ''}
+              repoPath={result?.repoPath || ''}
+            />
+          </div>
         </div>
         <div className="overflow-scroll flex-1" id="result-full-code-container">
           <div className={`flex py-3 px-8 h-full`}>

--- a/client/src/types/api.ts
+++ b/client/src/types/api.ts
@@ -136,6 +136,9 @@ export interface File {
   contents: string;
   repo_ref: string;
   siblings: DirectoryEntry[];
+  size: number;
+  loc: number;
+  sloc: number;
 }
 
 export interface FileResponse {

--- a/client/src/types/results.ts
+++ b/client/src/types/results.ts
@@ -131,6 +131,8 @@ export type FullResult = {
   language: string;
   hoverableRanges: Record<number, Range[]>;
   repoName: string;
+  size: number;
+  loc: number;
 };
 
 export type DirectoryResult = {

--- a/client/src/utils/index.ts
+++ b/client/src/utils/index.ts
@@ -298,3 +298,31 @@ export const escapeHtml = (unsafe: string) => {
     .replaceAll('"', '&quot;')
     .replaceAll("'", '&#039;');
 };
+
+export function humanFileSize(
+  bytes: number,
+  si: boolean = true,
+  dp: number = 1,
+) {
+  const thresh = si ? 1000 : 1024;
+
+  if (Math.abs(bytes) < thresh) {
+    return bytes + ' B';
+  }
+
+  const units = si
+    ? ['kB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB']
+    : ['KiB', 'MiB', 'GiB', 'TiB', 'PiB', 'EiB', 'ZiB', 'YiB'];
+  let u = -1;
+  const r = 10 ** dp;
+
+  do {
+    bytes /= thresh;
+    ++u;
+  } while (
+    Math.round(Math.abs(bytes) * r) / r >= thresh &&
+    u < units.length - 1
+  );
+
+  return bytes.toFixed(dp) + ' ' + units[u];
+}

--- a/server/bleep/src/indexes/reader.rs
+++ b/server/bleep/src/indexes/reader.rs
@@ -251,6 +251,7 @@ pub struct OpenDocument {
     pub repo_ref: String,
     pub lang: Option<String>,
     pub content: String,
+    pub line_end_indices: Vec<u32>,
 }
 
 #[async_trait]
@@ -310,6 +311,14 @@ impl DocumentRead for OpenReader {
         let repo_ref = read_text_field(&doc, schema.repo_ref);
         let lang = read_lang_field(&doc, schema.lang);
         let content = read_text_field(&doc, schema.content);
+        let line_end_indices = doc
+            .get_first(schema.line_end_indices)
+            .unwrap()
+            .as_bytes()
+            .unwrap()
+            .chunks_exact(4)
+            .map(|c| u32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+            .collect();
 
         Self::Document {
             relative_path,
@@ -317,6 +326,7 @@ impl DocumentRead for OpenReader {
             repo_ref,
             lang,
             content,
+            line_end_indices,
         }
     }
 }

--- a/server/bleep/src/query/execute.rs
+++ b/server/bleep/src/query/execute.rs
@@ -159,6 +159,8 @@ pub struct FileData {
     lang: Option<String>,
     contents: String,
     siblings: Vec<DirEntry>,
+    size: usize,
+    loc: usize,
 }
 
 #[derive(Serialize)]
@@ -671,6 +673,8 @@ impl ExecuteQuery for OpenReader {
                         repo_ref: doc.repo_ref.to_owned(),
                         lang: doc.lang.clone(),
                         contents: doc.content.clone(),
+                        size: doc.content.len(),
+                        loc: doc.line_end_indices.len(),
                         siblings: vec![],
                     });
 

--- a/server/bleep/src/query/execute.rs
+++ b/server/bleep/src/query/execute.rs
@@ -161,6 +161,7 @@ pub struct FileData {
     siblings: Vec<DirEntry>,
     size: usize,
     loc: usize,
+    sloc: usize,
 }
 
 #[derive(Serialize)]
@@ -675,6 +676,13 @@ impl ExecuteQuery for OpenReader {
                         contents: doc.content.clone(),
                         size: doc.content.len(),
                         loc: doc.line_end_indices.len(),
+                        sloc: doc
+                            .line_end_indices
+                            .iter()
+                            .zip(doc.line_end_indices.iter().skip(1))
+                            .filter(|(&prev, &next)| next - prev != 1)
+                            .count()
+                            .saturating_add(1),
                         siblings: vec![],
                     });
 


### PR DESCRIPTION
- `size`: size of the file in bytes
- `loc`: number of lines in the file

these fields are present only on responses with `kind` set to 'file'.