### PR TITLE
Local repositories without remotes were incorrectly indexed

### DIFF
--- a/server/bleep/src/indexes.rs
+++ b/server/bleep/src/indexes.rs
@@ -68,7 +68,7 @@ impl<'a> GlobalWriteHandle<'a> {
         sync_handle: &SyncHandle,
         repo: &Repository,
     ) -> Result<Arc<RepoMetadata>, RepoError> {
-        let metadata = repo.get_repo_metadata().await?;
+        let metadata = repo.get_repo_metadata().await;
 
         futures::future::join_all(self.handles.iter().map(|handle| {
             handle.index(&sync_handle.reporef, repo, &metadata, sync_handle.pipes())

--- a/server/bleep/src/repo/iterator/fs.rs
+++ b/server/bleep/src/repo/iterator/fs.rs
@@ -34,7 +34,7 @@ impl FileWalker {
     }
 }
 
-static HEAD: &str = "head";
+static HEAD: &str = "HEAD";
 
 impl FileSource for FileWalker {
     fn len(&self) -> usize {

--- a/server/bleep/src/webserver/repos.rs
+++ b/server/bleep/src/webserver/repos.rs
@@ -52,7 +52,13 @@ impl From<(&RepoRef, &Repository)> for Repo {
                 .head()
                 .ok()
                 .and_then(|head| head.try_into_referent())
-                .map(|r| format!("origin/{}", r.name().shorten()))
+                .map(|r| {
+                    if key.is_local() {
+                        r.name().shorten().to_string()
+                    } else {
+                        format!("origin/{}", r.name().shorten().to_string())
+                    }
+                })
                 .unwrap_or_else(|| default.0.clone());
 
             let Ok(refs) = git.references()

--- a/server/bleep/src/webserver/repos.rs
+++ b/server/bleep/src/webserver/repos.rs
@@ -56,7 +56,7 @@ impl From<(&RepoRef, &Repository)> for Repo {
                     if key.is_local() {
                         r.name().shorten().to_string()
                     } else {
-                        format!("origin/{}", r.name().shorten().to_string())
+                        format!("origin/{}", r.name().shorten())
                     }
                 })
                 .unwrap_or_else(|| default.0.clone());


### PR DESCRIPTION
This resulted in branch filters messing up queries and making it impossible to get results from purely local repos.

In this patch, the detection of whether or not it's a Git repository is changed from looking for a Git remote (which may not exist), to simply checking if it's a Git repository at all by signaling if we have detected a last commit timestamp.

Additionally, add explicit support local repositories in the Git file iterator so we only force remote branches when it's a remote repository.