### PR TITLE
Fix file browsing on Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -469,7 +469,6 @@ dependencies = [
  "console-subscriber",
  "criterion",
  "directories",
- "dunce",
  "either",
  "erased-serde",
  "expect-test",

--- a/server/bleep/Cargo.toml
+++ b/server/bleep/Cargo.toml
@@ -129,9 +129,6 @@ comrak = { default-features = false, git = "https://github.com/kivikakk/comrak" 
 lazy-regex = "3.0.0"
 quick-xml = { version = "0.29.0", features = ["serialize"] }
 
-[target.'cfg(windows)'.dependencies]
-dunce = "1.0.4"
-
 [dev-dependencies]
 criterion = { version = "0.5.1", features = ["async_tokio"] }
 pretty_assertions = "1.3.0"

--- a/server/bleep/src/indexes/file.rs
+++ b/server/bleep/src/indexes/file.rs
@@ -1,6 +1,6 @@
 use std::{
     collections::{HashMap, HashSet},
-    path::{Path, PathBuf, MAIN_SEPARATOR},
+    path::{Path, PathBuf},
     sync::{
         atomic::{AtomicU64, Ordering},
         Arc,
@@ -263,7 +263,7 @@ impl Indexer<File> {
                     .map(|f| f.is_match(&doc.relative_path))
                     .unwrap_or_default()
             })
-            .filter(|doc| !doc.relative_path.ends_with(MAIN_SEPARATOR)) // omit directories
+            .filter(|doc| !doc.relative_path.ends_with('/')) // omit directories
             .take(limit)
     }
 
@@ -531,7 +531,9 @@ impl RepoDir {
         last_commit: u64,
         tantivy_cache_key: String,
     ) -> tantivy::schema::Document {
-        let relative_path_str = format!("{}{MAIN_SEPARATOR}", relative_path.to_string_lossy());
+        let relative_path_str = format!("{}/", relative_path.to_string_lossy());
+        #[cfg(windows)]
+        let relative_path_str = relative_path_str.replace('\\', "/");
 
         let branches = self.branches.join("\n");
 
@@ -576,6 +578,9 @@ impl RepoFile {
         file_cache: &FileCache,
     ) -> Option<tantivy::schema::Document> {
         let relative_path_str = relative_path.to_string_lossy().to_string();
+        #[cfg(windows)]
+        let relative_path_str = relative_path_str.replace('\\', "/");
+
         let branches = self.branches.join("\n");
         let lang_str = repo_metadata
             .langs

--- a/server/bleep/src/indexes/reader.rs
+++ b/server/bleep/src/indexes/reader.rs
@@ -1,5 +1,3 @@
-use std::path::MAIN_SEPARATOR;
-
 use anyhow::Result;
 use async_trait::async_trait;
 use tantivy::{
@@ -339,9 +337,7 @@ impl DocumentRead for OpenReader {
 /// - `"bar/" -> "bar/"`
 /// - `"foo.txt" -> ""`
 pub fn base_name(path: &str) -> &str {
-    path.rfind(MAIN_SEPARATOR)
-        .map(|i| &path[..i + 1])
-        .unwrap_or("")
+    path.rfind('/').map(|i| &path[..i + 1]).unwrap_or("")
 }
 
 fn read_text_field(doc: &tantivy::Document, field: Field) -> String {
@@ -371,9 +367,8 @@ mod test {
 
     #[test]
     fn test_base_name() {
-        let s = MAIN_SEPARATOR;
-        assert_eq!(base_name(&format!("bar{s}foo.txt")), format!("bar{s}"));
-        assert_eq!(base_name(&format!("bar{s}")), format!("bar{s}"));
+        assert_eq!(base_name(&format!("bar/foo.txt")), format!("bar/"));
+        assert_eq!(base_name(&format!("bar/")), format!("bar/"));
         assert_eq!(base_name("foo.txt"), "");
     }
 }

--- a/server/bleep/src/lib.rs
+++ b/server/bleep/src/lib.rs
@@ -20,12 +20,8 @@ use git_version as _;
 #[cfg(all(feature = "debug", not(tokio_unstable)))]
 use console_subscriber as _;
 
-#[cfg(windows)]
-use dunce::canonicalize;
-
 use secrecy::SecretString;
 use state::PersistedState;
-#[cfg(not(windows))]
 use std::fs::canonicalize;
 use user::UserProfile;
 

--- a/server/bleep/src/query/execute.rs
+++ b/server/bleep/src/query/execute.rs
@@ -1,6 +1,5 @@
 use std::{
     collections::{HashMap, HashSet},
-    path::MAIN_SEPARATOR,
     sync::Arc,
 };
 
@@ -627,14 +626,14 @@ impl ExecuteQuery for OpenReader {
                 // because the `BytesFilterCollector` operates on one field. So we sort through this
                 // later. It's unlikely that a search will use more than one open query.
                 relative_paths.iter().any(|rp| {
-                    let rp = rp.trim_end_matches(|c| c != MAIN_SEPARATOR);
+                    let rp = rp.trim_end_matches(|c| c != '/');
 
                     matches!(
                         // Trim trailing suffix and avoid returning results for an empty string
                         // (this means that the document we are looking at is the folder itself; a
                         // redundant result).
-                        relative_path.strip_prefix(rp).map(|p| p.trim_end_matches(MAIN_SEPARATOR)),
-                        Some(p) if !p.is_empty() && !p.contains(MAIN_SEPARATOR)
+                        relative_path.strip_prefix(rp).map(|p| p.trim_end_matches('/')),
+                        Some(p) if !p.is_empty() && !p.contains('/')
                     )
                 })
             },
@@ -653,7 +652,7 @@ impl ExecuteQuery for OpenReader {
         // Set of (repo_name, relative_path) that should be returned.
         let directories = open_directives
             .iter()
-            .filter(|d| d.relative_path.is_empty() || d.relative_path.ends_with(MAIN_SEPARATOR))
+            .filter(|d| d.relative_path.is_empty() || d.relative_path.ends_with('/'))
             .map(|d| (&d.repo_name, &d.relative_path))
             .collect::<HashSet<_>>();
 
@@ -694,7 +693,7 @@ impl ExecuteQuery for OpenReader {
                 if let Some(entry) = doc
                     .relative_path
                     .strip_prefix(relative_path)
-                    .and_then(|s| s.split_inclusive(MAIN_SEPARATOR).next())
+                    .and_then(|s| s.split_inclusive('/').next())
                 {
                     dir_entries
                         .entry((&directive.repo_name, relative_path))
@@ -702,7 +701,7 @@ impl ExecuteQuery for OpenReader {
                         .1
                         .insert(DirEntry {
                             name: entry.to_owned(),
-                            entry_data: if entry.contains(MAIN_SEPARATOR) {
+                            entry_data: if entry.contains('/') {
                                 EntryData::Directory
                             } else {
                                 EntryData::File {

--- a/server/bleep/src/repo/iterator/git.rs
+++ b/server/bleep/src/repo/iterator/git.rs
@@ -3,7 +3,7 @@ use super::*;
 use anyhow::Result;
 use gix::ThreadSafeRepository;
 use regex::RegexSet;
-use tracing::error;
+use tracing::{error, trace};
 
 use std::{
     collections::{BTreeSet, HashMap},
@@ -125,6 +125,7 @@ impl GitWalker {
                     .map(move |entry| {
                         let strpath = String::from_utf8_lossy(entry.filepath.as_ref());
                         let full_path = root_dir.join(strpath.as_ref());
+                        trace!(?strpath, ?full_path, "got path from gix");
                         (
                             is_head,
                             branch.clone(),
@@ -171,6 +172,7 @@ impl FileSource for GitWalker {
         self.entries
             .into_par_iter()
             .filter_map(|((path, kind, oid), branches)| {
+                trace!(?path, "walking over path");
                 let git = self.git.to_thread_local();
                 let Ok(Some(object)) = git.try_find_object(oid) else {
                     error!(?path, ?branches, "can't find object for file");

--- a/server/bleep/src/state.rs
+++ b/server/bleep/src/state.rs
@@ -151,9 +151,6 @@ impl StateSource {
     }
 
     pub(crate) fn initialize_pool(&self) -> Result<RepositoryPool, RepoError> {
-        #[cfg(target = "windows")]
-        use dunce::canonicalize;
-        #[cfg(not(target = "windows"))]
         use std::fs::canonicalize;
 
         match (self.directory.as_ref(), self.state_file.as_ref()) {


### PR DESCRIPTION
To enforce consistency, we now use forward slashes (`/`) throughout the app, on both unix and Windows platforms.