### PR TITLE
log into files in addition to stderr

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,6 +524,7 @@ dependencies = [
  "tower",
  "tower-http",
  "tracing",
+ "tracing-appender",
  "tracing-subscriber",
  "tree-sitter",
  "tree-sitter-c",
@@ -7441,6 +7442,17 @@ dependencies = [
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09d48f71a791638519505cefafe162606f706c25592e4bde4d97600c0195312e"
+dependencies = [
+ "crossbeam-channel",
+ "time 0.3.23",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,4 +40,4 @@ COPY model /model
 COPY --from=builder /bleep /
 COPY --from=builder /dylib /dylib
 COPY --from=frontend /build/client/dist /frontend
-ENTRYPOINT ["/bleep", "--host=0.0.0.0", "--source-dir=/repos", "--index-dir=/data", "--model-dir=/model", "--dylib-dir=/dylib"]
+ENTRYPOINT ["/bleep", "--host=0.0.0.0", "--source-dir=/repos", "--index-dir=/data", "--model-dir=/model", "--dylib-dir=/dylib", "--disable-log-write"]

--- a/apps/desktop/src-tauri/src/backend.rs
+++ b/apps/desktop/src-tauri/src/backend.rs
@@ -69,6 +69,8 @@ where
         )
     };
 
+    Application::install_logging(&configuration);
+
     if let Some(dsn) = &configuration.sentry_dsn {
         initialize_sentry(dsn);
     }

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -3,8 +3,6 @@
     windows_subsystem = "windows"
 )]
 
-use bleep::Application;
-
 mod backend;
 mod qdrant;
 
@@ -36,8 +34,6 @@ fn relative_command_path(command: impl AsRef<str>) -> Option<PathBuf> {
 
 #[tokio::main]
 async fn main() {
-    Application::install_logging();
-
     tauri::Builder::default()
         .plugin(qdrant::QdrantSupervisor::default())
         .setup(backend::bleep)

--- a/helm/bloop/templates/bloop-deployment.yaml
+++ b/helm/bloop/templates/bloop-deployment.yaml
@@ -72,6 +72,7 @@ spec:
           - --sentry-dsn={{ .Values.bloop.sentryDsn }}
           - --sentry-dsn-fe={{ .Values.bloop.sentryDsnFE }}
           - --analytics-key-fe={{ .Values.bloop.analyticsKeyFE }}
+          - --disable-log-write
           env:
           - name: BLOOP_LOG
             value: {{ .Values.bloop.logLevel }}

--- a/server/bleep/Cargo.toml
+++ b/server/bleep/Cargo.toml
@@ -128,6 +128,7 @@ thread-priority = "0.13.1"
 comrak = { default-features = false, git = "https://github.com/kivikakk/comrak" }
 lazy-regex = "3.0.0"
 quick-xml = { version = "0.29.0", features = ["serialize"] }
+tracing-appender = "0.2.2"
 
 [dev-dependencies]
 criterion = { version = "0.5.1", features = ["async_tokio"] }

--- a/server/bleep/Cargo.toml
+++ b/server/bleep/Cargo.toml
@@ -36,6 +36,7 @@ rayon = "1.7.0"
 clap = { version = "4.3.11", features = ["derive"] }
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter", "registry"] }
+tracing-appender = "0.2.2"
 color-eyre = "0.6.2"
 sqlx = { version = "0.6.3", features = ["sqlite", "migrate", "offline", "runtime-tokio-rustls", "chrono"] }
 
@@ -128,7 +129,6 @@ thread-priority = "0.13.1"
 comrak = { default-features = false, git = "https://github.com/kivikakk/comrak" }
 lazy-regex = "3.0.0"
 quick-xml = { version = "0.29.0", features = ["serialize"] }
-tracing-appender = "0.2.2"
 
 [dev-dependencies]
 criterion = { version = "0.5.1", features = ["async_tokio"] }

--- a/server/bleep/src/bin/bleep.rs
+++ b/server/bleep/src/bin/bleep.rs
@@ -3,14 +3,10 @@ use bleep::{Application, Configuration, Environment};
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    Application::install_logging();
-    let app = Application::initialize(
-        Environment::server(),
-        Configuration::cli_overriding_config_file()?,
-        None,
-        None,
-    )
-    .await?;
+    let config = Configuration::cli_overriding_config_file()?;
+
+    Application::install_logging(&config);
+    let app = Application::initialize(Environment::server(), config, None, None).await?;
 
     app.initialize_sentry();
     app.run().await

--- a/server/bleep/src/config.rs
+++ b/server/bleep/src/config.rs
@@ -41,6 +41,13 @@ pub struct Configuration {
     /// Disable system-native notification backends to detect new git commits immediately.
     pub disable_fsevents: bool,
 
+    #[clap(long, default_value_t = false)]
+    #[serde(default)]
+    /// Avoid writing logs to files.
+    ///
+    /// If this flag is not set to `true`, logs are written to <index_dir>/logs/bloop.log.YYYY-MM-DD-HH
+    pub disable_log_write: bool,
+
     #[clap(short, long, default_value_t = default_buffer_size())]
     #[serde(default = "default_buffer_size")]
     /// Size of memory to use for file indexes
@@ -225,6 +232,8 @@ impl Configuration {
             disable_background: b.disable_background | a.disable_background,
 
             disable_fsevents: b.disable_fsevents | a.disable_fsevents,
+
+            disable_log_write: b.disable_log_write | a.disable_log_write,
 
             buffer_size: right_if_default!(b.buffer_size, a.buffer_size, default_buffer_size()),
 

--- a/server/bleep/src/indexes/file.rs
+++ b/server/bleep/src/indexes/file.rs
@@ -603,10 +603,7 @@ impl RepoFile {
                 // we have a graph, use that
                 Ok(graph) => SymbolLocations::TreeSitter(graph),
                 // no graph, it's empty
-                Err(err) => {
-                    warn!(?err, %lang_str, "failed to build scope graph");
-                    SymbolLocations::Empty
-                }
+                Err(_) => SymbolLocations::Empty,
             }
         };
 

--- a/server/bleep/src/lib.rs
+++ b/server/bleep/src/lib.rs
@@ -349,14 +349,18 @@ fn tracing_subscribe(config: &Configuration) -> bool {
     let sentry_layer = sentry_layer();
     let log_writer_layer = (!config.disable_log_write).then(|| {
         let log_dir = config.index_dir.join("logs");
-        let file_appender = tracing_appender::rolling::hourly(log_dir, "bloop.log");
+        let file_appender = tracing_appender::rolling::daily(log_dir, "bloop.log");
         let (non_blocking, guard) = tracing_appender::non_blocking(file_appender);
         _ = LOGGER_GUARD.set(guard);
         fmt::layer()
             .with_writer(non_blocking)
             .with_ansi(false)
-            .with_filter(Targets::new().with_target("bleep", LevelFilter::DEBUG))
-            .with_filter(Targets::new().with_target("bleep::indexes::file", LevelFilter::WARN))
+            .with_filter(
+                Targets::new()
+                    .with_target("bleep", LevelFilter::DEBUG)
+                    .with_target("bleep::indexes::file", LevelFilter::WARN)
+                    .with_target("bleep::semantic", LevelFilter::WARN),
+            )
     });
 
     #[cfg(all(tokio_unstable, feature = "debug"))]

--- a/server/bleep/src/lib.rs
+++ b/server/bleep/src/lib.rs
@@ -356,6 +356,7 @@ fn tracing_subscribe(config: &Configuration) -> bool {
             .with_writer(non_blocking)
             .with_ansi(false)
             .with_filter(Targets::new().with_target("bleep", LevelFilter::DEBUG))
+            .with_filter(Targets::new().with_target("bleep::indexes::file", LevelFilter::WARN))
     });
 
     #[cfg(all(tokio_unstable, feature = "debug"))]


### PR DESCRIPTION
this changeset introduces persistent logging through the `tracing-appender` crate. logs are written into
`<index_dir>/logs/bloop.log.YYYY-MM-DD-HH` and rotated hourly. logs written to files are limited to the `bleep` crate.