### PR TITLE
Make semantic search threshold configurable

### DIFF
--- a/server/bleep/src/semantic.rs
+++ b/server/bleep/src/semantic.rs
@@ -319,6 +319,7 @@ impl Semantic {
         vector: Embedding,
         limit: u64,
         offset: u64,
+        threshold: f32,
     ) -> anyhow::Result<Vec<ScoredPoint>> {
         let response = self
             .qdrant
@@ -327,7 +328,7 @@ impl Semantic {
                 vector,
                 collection_name: COLLECTION_NAME.to_string(),
                 offset: Some(offset),
-                score_threshold: Some(SCORE_THRESHOLD),
+                score_threshold: Some(threshold),
                 with_payload: Some(WithPayloadSelector {
                     selector_options: Some(with_payload_selector::SelectorOptions::Enable(true)),
                 }),
@@ -351,6 +352,7 @@ impl Semantic {
         vectors: Vec<Embedding>,
         limit: u64,
         offset: u64,
+        threshold: f32,
     ) -> anyhow::Result<Vec<ScoredPoint>> {
         // FIXME: This method uses `search_points` internally, and not `search_batch_points`. It's
         // not clear why, but it seems that the `batch` variant of the `qdrant` calls leads to
@@ -406,6 +408,7 @@ impl Semantic {
         parsed_query: &SemanticQuery<'a>,
         limit: u64,
         offset: u64,
+        threshold: f32,
         retrieve_more: bool,
     ) -> anyhow::Result<Vec<Payload>> {
         let Some(query) = parsed_query.target() else {
@@ -422,6 +425,7 @@ impl Semantic {
                 vector.clone(),
                 if retrieve_more { limit * 2 } else { limit }, // Retrieve double `limit` and deduplicate
                 offset,
+                threshold,
             )
             .await
             .map(|raw| {
@@ -437,6 +441,7 @@ impl Semantic {
         parsed_queries: &[&SemanticQuery<'a>],
         limit: u64,
         offset: u64,
+        threshold: f32,
         retrieve_more: bool,
     ) -> anyhow::Result<Vec<Payload>> {
         if parsed_queries.iter().any(|q| q.target().is_none()) {
@@ -456,6 +461,7 @@ impl Semantic {
                 vectors.clone(),
                 if retrieve_more { limit * 2 } else { limit }, // Retrieve double `limit` and deduplicate
                 offset,
+                threshold,
             )
             .await;
 

--- a/server/bleep/src/semantic/execute.rs
+++ b/server/bleep/src/semantic/execute.rs
@@ -22,6 +22,7 @@ pub async fn execute(
             &query,
             params.page_size as u64,
             ((params.page + 1) * params.page_size) as u64,
+            0.0,
             false,
         )
         .await?;

--- a/server/bleep/src/webserver/answer.rs
+++ b/server/bleep/src/webserver/answer.rs
@@ -522,14 +522,14 @@ impl Agent {
         .await?;
 
         let mut results = self
-            .semantic_search(query.into(), CODE_SEARCH_LIMIT, 0, true)
+            .semantic_search(query.into(), CODE_SEARCH_LIMIT, 0, 0.0, true)
             .await?;
 
         let hyde_docs = self.hyde(query).await?;
         if !hyde_docs.is_empty() {
             let hyde_doc = hyde_docs.first().unwrap().into();
             let hyde_results = self
-                .semantic_search(hyde_doc, CODE_SEARCH_LIMIT, 0, true)
+                .semantic_search(hyde_doc, CODE_SEARCH_LIMIT, 0, 0.3, true)
                 .await?;
             results.extend(hyde_results);
         }
@@ -597,7 +597,7 @@ impl Agent {
         // If there are no lexical results, perform a semantic search.
         if paths.is_empty() {
             let semantic_paths = self
-                .semantic_search(query.into(), 30, 0, true)
+                .semantic_search(query.into(), 30, 0, 0.0, true)
                 .await?
                 .into_iter()
                 .map(|chunk| chunk.relative_path)
@@ -1194,6 +1194,7 @@ impl Agent {
         query: Literal<'_>,
         limit: u64,
         offset: u64,
+        threshold: f32,
         retrieve_more: bool,
     ) -> Result<Vec<semantic::Payload>> {
         let query = SemanticQuery {
@@ -1207,7 +1208,7 @@ impl Agent {
             .semantic
             .as_ref()
             .unwrap()
-            .search(&query, limit, offset, retrieve_more)
+            .search(&query, limit, offset, threshold, retrieve_more)
             .await
     }
 
@@ -1217,6 +1218,7 @@ impl Agent {
         queries: Vec<Literal<'_>>,
         limit: u64,
         offset: u64,
+        threshold: f32,
         retrieve_more: bool,
     ) -> Result<Vec<semantic::Payload>> {
         let queries = queries
@@ -1235,7 +1237,7 @@ impl Agent {
             .semantic
             .as_ref()
             .unwrap()
-            .batch_search(queries.as_slice(), limit, offset, retrieve_more)
+            .batch_search(queries.as_slice(), limit, offset, threshold, retrieve_more)
             .await
     }
 


### PR DESCRIPTION
Make the `threshold` for semantic search configurable. We want to use different thresholds for HyDE and non-HyDE queries.