### PR TITLE
Fix LLM responses which include an inline `[^summary]`

### DIFF
--- a/server/bleep/src/agent/transcoder.rs
+++ b/server/bleep/src/agent/transcoder.rs
@@ -1040,4 +1040,31 @@ quux";
         assert_eq!(limit_tokens("fn 🚨() {}", bpe.clone(), 5), "fn 🚨()");
         assert_eq!(limit_tokens("fn 🚨() {}", bpe, 6), "fn 🚨() {}");
     }
+
+    #[test]
+    fn test_mid_block_summary() {
+        let input = "Dummy code block:
+
+<GeneratedCode>
+<Code>
+println!(\"[^summary]\");
+</Code>
+<Language>Rust</Language>
+</GeneratedCode>
+
+Foo *bar* quux. [^summary]: Baz fred **thud** corge.\n\n";
+
+let expected = "Dummy code block:
+
+``` type:Generated,lang:Rust,path:,lines:0-0
+println!(\"[^summary]\");
+```
+
+Foo *bar* quux.";
+
+        let (body, conclusion) = decode(input);
+
+        assert_eq!(expected, body);
+        assert_eq!("Baz fred **thud** corge.", conclusion.unwrap());
+    }
 }


### PR DESCRIPTION
Depends on #811.

Some LLM articles contain a final paragraph like so:

```
The `ScopeGraph` struct also provides methods for inserting local scopes, local definitions, hoisted definitions,
global definitions, local imports, and references into the graph. These methods are used to build the scope
graph based on the provided source code. [^summary]: Scope graphs are built using the `build_scope` method
of the `ResolutionMethod` enum. This method uses a specific resolution function (like `scope_res_generic` for
the `Generic` resolution method) to create a `ScopeGraph` and populate it based on the provided query, root
node, source, and language. The `ScopeGraph` represents a graph of scopes and names in a single syntax tree,
and provides methods for inserting different types of nodes into the graph.
```

In this instance, the LLM has accidentally attached the summary to the end of the final markdown paragraph, instead of putting the summary (which is a markdown footnote definition) into its own block. To correct for this, we utilize `comrak` to examine all top-level `Paragraph` nodes, and extract a summary, if one is found in plain text.

Note: This implementation **will** work for cases where a code snippet contains `[^summary]: ...`, and it will also work when there is inline code, such as article that writes: ``Summaries are created by attaching `[^summary]:` to``. These complex test cases are accounted for with the addition of a new unit test.

---

Closes BLO-1369