### PR TITLE
Format code and paths returned by functions

### DIFF
--- a/server/bleep/src/agent/exchange.rs
+++ b/server/bleep/src/agent/exchange.rs
@@ -1,5 +1,5 @@
 use crate::query::parser::SemanticQuery;
-use std::mem;
+use std::{fmt, mem};
 
 use chrono::prelude::{DateTime, Utc};
 
@@ -165,6 +165,12 @@ impl CodeChunk {
     /// Returns true if a code-chunk contains an empty snippet or a snippet with only whitespace
     pub fn is_empty(&self) -> bool {
         self.snippet.trim().is_empty()
+    }
+}
+
+impl fmt::Display for CodeChunk {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}: {}\n{}", self.alias, self.path, self.snippet)
     }
 }
 

--- a/server/bleep/src/agent/tools/code.rs
+++ b/server/bleep/src/agent/tools/code.rs
@@ -56,7 +56,12 @@ impl Agent {
                 .push(chunk.clone())
         }
 
-        let response = serde_json::to_string(&chunks).unwrap();
+        let response = chunks
+            .iter()
+            .filter(|c| !c.is_empty())
+            .map(|c| c.to_string())
+            .collect::<Vec<_>>()
+            .join("\n\n");
 
         self.update(Update::ReplaceStep(SearchStep::Code {
             query: query.clone(),

--- a/server/bleep/src/agent/tools/path.rs
+++ b/server/bleep/src/agent/tools/path.rs
@@ -43,12 +43,17 @@ impl Agent {
             paths = semantic_paths;
         }
 
-        let formatted_paths = paths
+        let mut paths = paths
             .iter()
-            .map(|p| (p.to_string(), self.get_path_alias(p)))
+            .map(|p| (self.get_path_alias(p), p.to_string()))
             .collect::<Vec<_>>();
+        paths.sort_by(|a: &(usize, String), b| a.0.cmp(&b.0)); // Sort by alias
 
-        let response = serde_json::to_string(&formatted_paths).unwrap();
+        let response = paths
+            .iter()
+            .map(|(alias, path)| format!("{}: {}", alias, path))
+            .collect::<Vec<_>>()
+            .join("\n");
 
         self.update(Update::ReplaceStep(SearchStep::Path {
             query: query.clone(),

--- a/server/bleep/src/semantic.rs
+++ b/server/bleep/src/semantic.rs
@@ -729,7 +729,7 @@ fn mean_pool(embeddings: Vec<Vec<f32>>) -> Vec<f32> {
 //    - "novelty" or, the measure of how minimal the similarity is
 //      to existing documents in the selection
 //      The value of lambda skews the weightage in favor of either relevance or novelty.
-//    - we add a language diversity factor to the score to encourage a range of languages in the results
+//    - we add a language diversity factor to the score to encourage a range of langauges in the results
 //    - we also add a path diversity factor to the score to encourage a range of paths in the results
 //  k: the number of embeddings to select
 pub fn deduplicate_with_mmr(


### PR DESCRIPTION
Format code and paths returned by `path`, `code`, or `proc` actions. Before these were stored in the history as JSON, which made debugging tricky and which may degrade agent reasoning.

Also insert the instruction to call a function as a separate `user` message. GPT seems to adhere to it better this way.