### PR TITLE
Use 0-based indexes for line offsets in code chunks

### DIFF
--- a/client/src/components/Chat/AllCoversations/index.tsx
+++ b/client/src/components/Chat/AllCoversations/index.tsx
@@ -135,7 +135,7 @@ const AllConversations = ({
               title={c.title}
               subtitle={format(
                 new Date(c.created_at * 1000),
-                'EEEE, MMMM d, h:m a',
+                'EEEE, MMMM d, HH:mm',
                 getDateFnsLocale(locale),
               )}
               onClick={() => onClick(c.thread_id)}

--- a/client/src/components/Chat/index.tsx
+++ b/client/src/components/Chat/index.tsx
@@ -312,8 +312,8 @@ const Chat = () => {
       userQuery = t(
         `Explain lines {{lineStart}} - {{lineEnd}} in {{filePath}}`,
         {
-          lineStart: Number(lineStart),
-          lineEnd: Number(lineEnd),
+          lineStart: Number(lineStart) + 1,
+          lineEnd: Number(lineEnd) + 1,
           filePath,
         },
       );

--- a/client/src/components/CodeBlock/CodeFull/ExplainButton.tsx
+++ b/client/src/components/CodeBlock/CodeFull/ExplainButton.tsx
@@ -121,14 +121,14 @@ const ExplainButton = ({
                       setConversation([]);
                       setThreadId('');
                       setSelectedLines([
-                        currentSelection[0]![0] + 1,
-                        currentSelection[1]![0] + 1,
+                        currentSelection[0]![0],
+                        currentSelection[1]![0],
                       ]);
                       setRightPanelOpen(false);
                       setSubmittedQuery(
-                        `#explain_${relativePath}:${
-                          currentSelection[0]![0] + 1
-                        }-${currentSelection[1]![0] + 1}-${Date.now()}`,
+                        `#explain_${relativePath}:${currentSelection[0]![0]}-${
+                          currentSelection[1]![0]
+                        }-${Date.now()}`,
                       );
                       setChatOpen(true);
                       setPopupPosition(null);

--- a/client/src/components/MarkdownWithCode/CodeRenderer.tsx
+++ b/client/src/components/MarkdownWithCode/CodeRenderer.tsx
@@ -85,12 +85,12 @@ const CodeRenderer = ({
   );
 
   const linesToUse: [number, number] | undefined = useMemo(
-    () => [lines[0] - 1, (lines[1] ?? lines[0]) - 1],
+    () => [lines[0], lines[1] ?? lines[0]],
     [lines],
   );
 
   const handleChipClick = useCallback(() => {
-    updateScrollToIndex(`${lines[0] - 1}_${(lines[1] ?? lines[0]) - 1}`);
+    updateScrollToIndex(`${lines[0]}_${lines[1] ?? lines[0]}`);
   }, [updateScrollToIndex, lines]);
 
   return (
@@ -116,7 +116,7 @@ const CodeRenderer = ({
               language={matchLang?.[1] || ''}
               filePath={matchPath?.[1] || ''}
               onResultClick={openFileModal}
-              startLine={lines[0] ? lines[0] - 1 : null}
+              startLine={lines[0] ? lines[0] : null}
               repoName={repoName}
             />
           )

--- a/client/src/components/MarkdownWithCode/LinkRenderer.tsx
+++ b/client/src/components/MarkdownWithCode/LinkRenderer.tsx
@@ -65,16 +65,13 @@ const LinkRenderer = ({
   }, [children]);
 
   const linesToUse: [number, number] | undefined = useMemo(() => {
-    return hideCode && start ? [start - 1, (end ?? start) - 1] : undefined;
+    return hideCode && start ? [start, end ?? start] : undefined;
   }, [hideCode, start, end]);
 
   const handleClickFile = useCallback(() => {
     hideCode
-      ? updateScrollToIndex(`${start - 1}_${(end ?? start) - 1}`)
-      : openFileModal(
-          filePath,
-          start ? `${start - 1}_${(end ?? start) - 1}` : undefined,
-        );
+      ? updateScrollToIndex(`${start}_${end ?? start}`)
+      : openFileModal(filePath, start ? `${start}_${end ?? start}` : undefined);
   }, [hideCode, updateScrollToIndex, start, end, filePath]);
 
   const handleClickFolder = useCallback(() => {

--- a/server/bleep/src/agent/tools/answer.rs
+++ b/server/bleep/src/agent/tools/answer.rs
@@ -240,7 +240,7 @@ impl Agent {
             spans_by_path
                 .entry(c.path.clone())
                 .or_default()
-                .push(c.start_line..c.end_line + 1);
+                .push(c.start_line..c.end_line);
         }
 
         debug!(?spans_by_path, "expanding spans");

--- a/server/bleep/src/agent/tools/answer.rs
+++ b/server/bleep/src/agent/tools/answer.rs
@@ -66,7 +66,7 @@ impl Agent {
                 .snippet
                 .lines()
                 .enumerate()
-                .map(|(i, line)| format!("{} {line}\n", i + chunk.start_line))
+                .map(|(i, line)| format!("{} {line}\n", i + chunk.start_line + 1))
                 .collect::<String>();
 
             let formatted_snippet = format!("### {} ###\n{snippet}\n\n", chunk.path);
@@ -279,8 +279,7 @@ impl Agent {
                 .iter()
                 .flat_map(|(path, spans)| spans.iter().map(move |s| (path, s)))
                 .map(|(path, span)| {
-                    let range = span.start.saturating_sub(1)..span.end.saturating_sub(1);
-                    let snippet = lines_by_file.get(path).unwrap()[range].join("\n");
+                    let snippet = lines_by_file.get(path).unwrap()[span.clone()].join("\n");
                     bpe.encode_ordinary(&snippet).len()
                 })
                 .sum::<usize>();
@@ -305,14 +304,11 @@ impl Agent {
 
                     let old_span = span.clone();
 
-                    // Decrease the start line, but make sure that we don't end up with 0, as our lines
-                    // are 1-based.
-                    span.start = span.start.saturating_sub(range_step).max(1);
+                    span.start = span.start.saturating_sub(range_step);
 
-                    // Expand the end line forwards, capping at the total number of lines (NB: this is
-                    // also 1-based).
+                    // Expand the end line forwards, capping at the total number of lines.
                     span.end += range_step;
-                    span.end = span.end.min(file_lines);
+                    span.end = span.end.min(file_lines.saturating_sub(1));
 
                     if *span != old_span {
                         debug!(?path, "growing span");

--- a/server/bleep/src/agent/tools/code.rs
+++ b/server/bleep/src/agent/tools/code.rs
@@ -42,8 +42,8 @@ impl Agent {
                     path: relative_path.clone(),
                     alias: self.get_path_alias(&relative_path),
                     snippet: chunk.text,
-                    start_line: (chunk.start_line as usize).saturating_add(1),
-                    end_line: (chunk.end_line as usize).saturating_add(1),
+                    start_line: chunk.start_line as usize,
+                    end_line: chunk.end_line as usize,
                 }
             })
             .collect::<Vec<_>>();

--- a/server/bleep/src/agent/tools/proc.rs
+++ b/server/bleep/src/agent/tools/proc.rs
@@ -124,7 +124,7 @@ impl Agent {
                     })
                     .map(|r| Range {
                         start: r.start - 1,
-                        end: r.end - 1,
+                        end: r.end,
                     })
                     .collect();
 

--- a/server/bleep/src/agent/tools/proc.rs
+++ b/server/bleep/src/agent/tools/proc.rs
@@ -71,7 +71,8 @@ impl Agent {
                     .unwrap()
                     .0
                     .parse::<usize>()
-                    .unwrap();
+                    .unwrap()
+                    - 1;
 
                 // We store the lines separately, so that we can reference them later to trim
                 // this snippet by line number.
@@ -121,6 +122,10 @@ impl Agent {
                         r.end = r.end.min(r.start + MAX_CHUNK_LINE_LENGTH); // Cap relevant chunk size by line number
                         r
                     })
+                    .map(|r| Range {
+                        start: r.start - 1,
+                        end: r.end - 1,
+                    })
                     .collect();
 
                 line_ranges.sort();
@@ -146,7 +151,7 @@ impl Agent {
                             code: lines
                                 .get(
                                     range.start.saturating_sub(start_line)
-                                        ..range.end.saturating_sub(start_line),
+                                        ..=range.end.saturating_sub(start_line),
                                 )?
                                 .iter()
                                 .map(|line| line.split_once(' ').unwrap().1)

--- a/server/bleep/src/agent/transcoder.rs
+++ b/server/bleep/src/agent/transcoder.rs
@@ -136,8 +136,8 @@ pub fn encode(markdown: &str, conclusion: Option<&str>) -> String {
                 let lang = attributes.get("lang")?;
                 let mut lines = attributes.get("lines")?.split('-');
 
-                let start_line = lines.next()?;
-                let end_line = lines.next()?;
+                let start_line = lines.next()?.parse::<usize>().ok()? + 1;
+                let end_line = lines.next()?.parse::<usize>().ok()? + 1;
 
                 Some(format!(
                     "<QuotedCode>\n\
@@ -340,8 +340,8 @@ impl CodeChunk {
                 code,
                 language,
                 path.as_str(),
-                *start_line,
-                *end_line,
+                start_line.map(|n| n.saturating_sub(1)),
+                end_line.map(|n| n.saturating_sub(1)),
             ),
             CodeChunk::GeneratedCode { code, language } => {
                 ("Generated", code, language, "", None, None)

--- a/server/bleep/src/agent/transcoder.rs
+++ b/server/bleep/src/agent/transcoder.rs
@@ -713,7 +713,7 @@ fn foo<T>(t: T) -> bool {
 
 Then, we test some quoted code:
 
-``` type:Quoted,lang:Rust,path:src/main.rs,lines:10-12
+``` type:Quoted,lang:Rust,path:src/main.rs,lines:9-11
 fn foo<T>(t: T) -> bool {
     &foo < &bar<i32>(t)
 }
@@ -874,7 +874,7 @@ export const saveBugReport = (report: {
 
 Here is the relevant code:
 
-``` type:Quoted,lang:TypeScript,path:client/src/services/api.ts,lines:168-172
+``` type:Quoted,lang:TypeScript,path:client/src/services/api.ts,lines:167-171
 export const saveBugReport = (report: {
   email: string;
   name: string;
@@ -927,7 +927,7 @@ Hello again, world.
     fn test_encode() {
         let input = "Foo
 
-``` type:Quoted,lang:Rust,path:src/main.rs,lines:1-3
+``` type:Quoted,lang:Rust,path:src/main.rs,lines:0-2
 fn main() {
     println!(\"hello world\");
 }
@@ -979,7 +979,7 @@ fn main() {
     fn test_encode_summarized() {
         let input = "Foo
 
-``` type:Quoted,lang:Rust,path:src/main.rs,lines:1-3
+``` type:Quoted,lang:Rust,path:src/main.rs,lines:0-2
 fn main() {
     println!(\"hello world\");
 }

--- a/server/bleep/src/webserver/answer.rs
+++ b/server/bleep/src/webserver/answer.rs
@@ -380,7 +380,9 @@ pub async fn explain(
     let virtual_req = Answer {
         q: format!(
             "Explain lines {} - {} in {}",
-            params.line_start, params.line_end, params.relative_path
+            params.line_start + 1,
+            params.line_end + 1,
+            params.relative_path
         ),
         repo_ref: params.repo_ref,
         thread_id: params.thread_id,

--- a/server/bleep/src/webserver/answer.rs
+++ b/server/bleep/src/webserver/answer.rs
@@ -419,8 +419,8 @@ pub async fn explain(
 
     let snippet = file_content
         .lines()
-        .skip(params.line_start.saturating_sub(1))
-        .take(params.line_end + 1 - params.line_start)
+        .skip(params.line_start)
+        .take(params.line_end - params.line_start)
         .collect::<Vec<_>>()
         .join("\n");
 


### PR DESCRIPTION
Here, we swap the internal line range logic to use 0-based indexes. We make a concession for links, as they are generated directly by the LLM and not normally process, and so we add additional processing to change the indexing base.

In the future, we can test the model with generating 0-based indexes directly, and remove the new extra processing logic if this works.

Closes BLO-1375 and BLO-1390.