### PR TITLE
Fix `Exchange::answer` return value order

### DIFF
--- a/server/bleep/src/agent/exchange.rs
+++ b/server/bleep/src/agent/exchange.rs
@@ -74,8 +74,8 @@ impl Exchange {
     ///
     /// This returns a tuple of `(full_text, conclusion)`.
     pub fn answer(&self) -> Option<(&str, &str)> {
-        match (&self.conclusion, &self.answer) {
-            (Some(conclusion), Some(answer)) => Some((conclusion.as_str(), answer.as_str())),
+        match (&self.answer, &self.conclusion) {
+            (Some(answer), Some(conclusion)) => Some((answer.as_str(), conclusion.as_str())),
             _ => None,
         }
     }


### PR DESCRIPTION
Previously, when building the full agent history, we would re-encode an exchange using `Exchange::answer`, mistakenly swapping the conclusion and summary. This had some knock-on effects, for example it would not re-encode quoted/generated code blocks (as they were accidentally in the summary). This led to the model generating *markdown*-style blocks in future conversation turns, with hallucinated line ranges.