### PR TITLE
Single file article prompt

### DIFF
--- a/client/src/components/Chat/index.tsx
+++ b/client/src/components/Chat/index.tsx
@@ -310,7 +310,7 @@ const Chat = () => {
         lineEnd,
       };
       userQuery = t(
-        `Explain lines {{lineStart}} - {{lineEnd}} in {{filePath}}`,
+        `Explain the purpose of the file {{filePath}}, from lines {{lineStart}} - {{lineEnd}}`,
         {
           lineStart: Number(lineStart) + 1,
           lineEnd: Number(lineEnd) + 1,

--- a/server/bleep/src/agent/prompts.rs
+++ b/server/bleep/src/agent/prompts.rs
@@ -169,7 +169,7 @@ Your output will be interpreted as bloop-markdown which renders with the followi
 */
 
 pub fn answer_article_prompt(aliases: &[usize], context: &str) -> String {
-    // If there is only one alias, return "one" otherwise return "many"
+    // Return different prompts depending on whether there is one or many aliases
     let one_prompt = format!(
         r#"{context}#####
 
@@ -251,7 +251,7 @@ println!("hello world!");
     } else {
         many_prompt
     };
-    one_or_many.to_string()
+    one_or_many
 }
 
 pub fn hypothetical_document_prompt(query: &str) -> String {

--- a/server/bleep/src/agent/prompts.rs
+++ b/server/bleep/src/agent/prompts.rs
@@ -173,7 +173,7 @@ pub fn answer_article_prompt(aliases: &[usize], context: &str) -> String {
     let one_prompt = format!(
         r#"{context}#####
 
-A user is looking at the code above, they'd like you to answer their queries.
+A user is looking at the code above, your job is to write an article answering their query.
 
 Your output will be interpreted as bloop-markdown which renders with the following rules:
 - Inline code must be expressed as a link to the correct line of code using the URL format: `[bar](src/foo.rs#L50)` or `[bar](src/foo.rs#L50-L54)`
@@ -181,6 +181,7 @@ Your output will be interpreted as bloop-markdown which renders with the followi
   - E.g. Do not simply write `Bar`, write [`Bar`](src/bar.rs#L100-L105).
   - E.g. Do not simply write "Foos are functions that create `Foo` values out of thin air." Instead, write: "Foos are functions that create [`Foo`](src/foo.rs#L80-L120) values out of thin air."
 - Only internal links to the current file work
+- Basic markdown text formatting rules are allowed, and you should use titles to improve readability
 
 Here is an example response:
 

--- a/server/bleep/src/agent/prompts.rs
+++ b/server/bleep/src/agent/prompts.rs
@@ -246,12 +246,11 @@ println!("hello world!");
 - You MUST use XML code blocks instead of markdown."#
     );
 
-    let one_or_many = if aliases.len() == 1 {
+    if aliases.len() == 1 {
         one_prompt
     } else {
         many_prompt
-    };
-    one_or_many
+    }
 }
 
 pub fn hypothetical_document_prompt(query: &str) -> String {

--- a/server/bleep/src/agent/prompts.rs
+++ b/server/bleep/src/agent/prompts.rs
@@ -172,16 +172,20 @@ pub fn answer_article_prompt(aliases: &[usize], context: &str) -> String {
     // If there is only one alias, return "one" otherwise return "many"
     let one_prompt = format!(
         r#"{context}#####
-        
-        A user is looking at the code above, they'd like you to answer their queries.
+
+A user is looking at the code above, they'd like you to answer their queries.
 
 Your output will be interpreted as bloop-markdown which renders with the following rules:
-- All github-markdown rules are accepted
-- Lines of code can be referenced using the URL format: [foo.rs](src/foo.rs#L50-L78)
-  - In this example, the link is to the file src/foo.rs and the lines 50 to 78
-  - Links should be semantically named to help the user understand when they're clicking on
-- When referring to lines of code, you must use a link
-- When referring to code symbols (functions, methods, fields, classes, structs, types, variables, values, definitions, directories, etc), you must use a link"#
+- Inline code must be expressed as a link to the correct line of code using the URL format: `[bar](src/foo.rs#L50)` or `[bar](src/foo.rs#L50-L54)`
+- Do NOT output bare symbols. ALL symbols must include a link
+  - E.g. Do not simply write `Bar`, write [`Bar`](src/bar.rs#L100-L105).
+  - E.g. Do not simply write "Foos are functions that create `Foo` values out of thin air." Instead, write: "Foos are functions that create [`Foo`](src/foo.rs#L80-L120) values out of thin air."
+- Only internal links to the current file work
+
+Here is an example response:
+
+A function [`openCanOfBeans`](src/beans/open.py#L7-L19) is defined. This function is used to handle the opening of beans. It includes the variable [`openCanOfBeans`](src/beans/open.py#L9) which is used to store the value of the tin opener.
+"#
     );
 
     let many_prompt = format!(
@@ -191,7 +195,6 @@ Provide only as much information and code as is necessary to answer the query, b
 When referring to code, you must provide an example in a code block.
 
 Respect these rules at all times:
-- Previous messages in the history may not have been subject to these rules, but you must follow them now
 - Do not refer to paths by alias, expand to the full path
 - Link ALL paths AND code symbols (functions, methods, fields, classes, structs, types, variables, values, definitions, directories, etc) by embedding them in a markdown link, with the URL corresponding to the full path, and the anchor following the form `LX` or `LX-LY`, where X represents the starting line number, and Y represents the ending line number, if the reference is more than one line.
   - For example, to refer to lines 50 to 78 in a sentence, respond with something like: The compiler is initialized in [`src/foo.rs`](src/foo.rs#L50-L78)

--- a/server/bleep/src/agent/prompts.rs
+++ b/server/bleep/src/agent/prompts.rs
@@ -150,14 +150,48 @@ A: "#
     )
 }
 
-pub fn answer_article_prompt(context: &str) -> String {
+/*
+
     format!(
+        r#"{context}#####
+
+        A user is looking at the code above, they'd like you to answer their queries.
+
+Your output will be interpreted as bloop-markdown which renders with the following rules:
+- All github-markdown rules are accepted
+- Lines of code can be referenced using the URL format: [foo.rs](src/foo.rs#L50-L78)
+  - In this example, the link is to the file src/foo.rs and the lines 50 to 78
+  - Links should be semantically named to help the user understand when they're clicking on
+- When referring to lines of code, you must use a link
+- When referring to code symbols (functions, methods, fields, classes, structs, types, variables, values, definitions, directories, etc), you must use a link"#
+    )
+
+*/
+
+pub fn answer_article_prompt(aliases: &[usize], context: &str) -> String {
+    // If there is only one alias, return "one" otherwise return "many"
+    let one_prompt = format!(
+        r#"{context}#####
+        
+        A user is looking at the code above, they'd like you to answer their queries.
+
+Your output will be interpreted as bloop-markdown which renders with the following rules:
+- All github-markdown rules are accepted
+- Lines of code can be referenced using the URL format: [foo.rs](src/foo.rs#L50-L78)
+  - In this example, the link is to the file src/foo.rs and the lines 50 to 78
+  - Links should be semantically named to help the user understand when they're clicking on
+- When referring to lines of code, you must use a link
+- When referring to code symbols (functions, methods, fields, classes, structs, types, variables, values, definitions, directories, etc), you must use a link"#
+    );
+
+    let many_prompt = format!(
         r#"{context}Your job is to answer a query about a codebase using the information above.
 
 Provide only as much information and code as is necessary to answer the query, but be concise. Keep number of quoted lines to a minimum when possible. If you do not have enough information needed to answer the query, do not make up an answer.
 When referring to code, you must provide an example in a code block.
 
 Respect these rules at all times:
+- Previous messages in the history may not have been subject to these rules, but you must follow them now
 - Do not refer to paths by alias, expand to the full path
 - Link ALL paths AND code symbols (functions, methods, fields, classes, structs, types, variables, values, definitions, directories, etc) by embedding them in a markdown link, with the URL corresponding to the full path, and the anchor following the form `LX` or `LX-LY`, where X represents the starting line number, and Y represents the ending line number, if the reference is more than one line.
   - For example, to refer to lines 50 to 78 in a sentence, respond with something like: The compiler is initialized in [`src/foo.rs`](src/foo.rs#L50-L78)
@@ -207,7 +241,14 @@ println!("hello world!");
   - Note: the line range is inclusive
 - When writing example code blocks, use `<GeneratedCode>`, and when quoting existing code, use `<QuotedCode>`.
 - You MUST use XML code blocks instead of markdown."#
-    )
+    );
+
+    let one_or_many = if aliases.len() == 1 {
+        one_prompt
+    } else {
+        many_prompt
+    };
+    one_or_many.to_string()
 }
 
 pub fn hypothetical_document_prompt(query: &str) -> String {

--- a/server/bleep/src/agent/tools/answer.rs
+++ b/server/bleep/src/agent/tools/answer.rs
@@ -22,7 +22,7 @@ impl Agent {
         debug!("creating article response");
 
         let context = self.answer_context(aliases, ANSWER_MODEL).await?;
-        let system_prompt = prompts::answer_article_prompt(&context);
+        let system_prompt = prompts::answer_article_prompt(&aliases, &context);
         let system_message = llm_gateway::api::Message::system(&system_prompt);
         let history = {
             let h = self.utter_history().collect::<Vec<_>>();

--- a/server/bleep/src/agent/tools/answer.rs
+++ b/server/bleep/src/agent/tools/answer.rs
@@ -22,7 +22,7 @@ impl Agent {
         debug!("creating article response");
 
         let context = self.answer_context(aliases, ANSWER_MODEL).await?;
-        let system_prompt = prompts::answer_article_prompt(&aliases, &context);
+        let system_prompt = prompts::answer_article_prompt(aliases, &context);
         let system_message = llm_gateway::api::Message::system(&system_prompt);
         let history = {
             let h = self.utter_history().collect::<Vec<_>>();


### PR DESCRIPTION
This creates a separate prompt for article explanation when there is only one file in the context. As the code is shown next to the explanation we do not need the ability to quote code.

Concerns and mitigations:
- If conversation starts with one file in context, and follow up includes multiple files, are future explanations bias towards single file explanation format because of conversation history?
  - A: yes, future explanations after a single file explanation will feature fewer quoted blocks of code, but if the user explicitly asks for code it is able to quote code
- What if the user's query should be answered by generating new code?
  - The explanation generates new code in md format, I haven't noticed any issues
- Summary has been purposefully omitted from single file explanation, I don't think it makes sense in this case