### PR TITLE
Open focus view when answer is based upon only a single file

### DIFF
--- a/server/bleep/src/agent/exchange.rs
+++ b/server/bleep/src/agent/exchange.rs
@@ -62,6 +62,9 @@ impl Exchange {
                 self.response_timestamp = Some(Utc::now());
                 self.conclusion = Some(conclusion);
             }
+            Update::Focus(chunk) => {
+                self.focused_chunk = Some(chunk);
+            }
         }
     }
 
@@ -187,4 +190,5 @@ pub enum Update {
     ReplaceStep(SearchStep),
     Article(String),
     Conclude(String),
+    Focus(FocusedChunk),
 }

--- a/server/bleep/src/agent/tools/proc.rs
+++ b/server/bleep/src/agent/tools/proc.rs
@@ -22,7 +22,7 @@ impl Agent {
         let paths = path_aliases
             .iter()
             .copied()
-            .map(|i| self.paths().get(i).ok_or(i).cloned())
+            .map(|i| self.paths().nth(i).ok_or(i).map(str::to_owned))
             .collect::<Result<Vec<_>, _>>()
             .map_err(|i| anyhow!("invalid path alias {i}"))?;
 


### PR DESCRIPTION
Depends on #836 

Now, we detect when `["none", [...]]` is passed only a single file, and store this as the focused chunk for an exchange. This opens the focused view on the front-end and displays the file's contents.

Closes BLO-1392