### PR TITLE
Add more logging instrumentation, log more errors

### DIFF
--- a/server/bleep/src/agent.rs
+++ b/server/bleep/src/agent.rs
@@ -178,7 +178,8 @@ impl Agent {
                     })
                 },
             )
-            .await?;
+            .await
+            .context("failed to fold LLM function call output")?;
 
         self.track_query(
             EventData::output_stage("llm_reply")
@@ -189,7 +190,9 @@ impl Agent {
                 .with_payload("raw_response", &raw_response),
         );
 
-        let action = Action::deserialize_gpt(&raw_response)?;
+        let action =
+            Action::deserialize_gpt(&raw_response).context("failed to deserialize LLM output")?;
+
         Ok(Some(action))
     }
 

--- a/server/bleep/src/agent.rs
+++ b/server/bleep/src/agent.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use anyhow::{anyhow, Context, Result};
 use futures::TryStreamExt;
 use tokio::sync::mpsc::Sender;
-use tracing::debug;
+use tracing::{debug, info, instrument};
 
 use crate::{
     analytics::{EventData, QueryEvent},
@@ -85,6 +85,7 @@ impl Agent {
     }
 
     /// Update the last exchange
+    #[instrument(skip(self), level = "debug")]
     async fn update(&mut self, update: Update) -> Result<()> {
         self.last_exchange_mut().apply_update(update);
 
@@ -132,8 +133,9 @@ impl Agent {
         }
     }
 
+    #[instrument(skip(self))]
     pub async fn step(&mut self, action: Action) -> Result<Option<Action>> {
-        debug!(?action, %self.thread_id, "executing next action");
+        info!(?action, %self.thread_id, "executing next action");
 
         match &action {
             Action::Query(s) => {

--- a/server/bleep/src/agent/tools/code.rs
+++ b/server/bleep/src/agent/tools/code.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use futures::TryStreamExt;
-use tracing::info;
+use tracing::{info, instrument};
 
 use crate::{
     agent::{
@@ -12,6 +12,7 @@ use crate::{
 };
 
 impl Agent {
+    #[instrument(skip(self))]
     pub async fn code_search(&mut self, query: &String) -> Result<String> {
         const CODE_SEARCH_LIMIT: u64 = 10;
         self.update(Update::StartStep(SearchStep::Code {

--- a/server/bleep/src/agent/tools/path.rs
+++ b/server/bleep/src/agent/tools/path.rs
@@ -1,6 +1,7 @@
 use std::collections::HashSet;
 
 use anyhow::Result;
+use tracing::instrument;
 
 use crate::{
     agent::{
@@ -11,6 +12,7 @@ use crate::{
 };
 
 impl Agent {
+    #[instrument(skip(self))]
     pub async fn path_search(&mut self, query: &String) -> Result<String> {
         self.update(Update::StartStep(SearchStep::Path {
             query: query.clone(),

--- a/server/bleep/src/agent/tools/proc.rs
+++ b/server/bleep/src/agent/tools/proc.rs
@@ -1,7 +1,7 @@
 use anyhow::{anyhow, Context, Result};
 use futures::{stream, StreamExt, TryStreamExt};
 use tiktoken_rs::CoreBPE;
-use tracing::debug;
+use tracing::{debug, instrument};
 
 use crate::{
     agent::{
@@ -13,6 +13,7 @@ use crate::{
 };
 
 impl Agent {
+    #[instrument(skip(self))]
     pub async fn process_files(&mut self, query: &str, path_aliases: &[usize]) -> Result<String> {
         const MAX_CHUNK_LINE_LENGTH: usize = 20;
         const CHUNK_MERGE_DISTANCE: usize = 10;

--- a/server/bleep/src/webserver/answer.rs
+++ b/server/bleep/src/webserver/answer.rs
@@ -13,7 +13,7 @@ use axum::{
 use futures::{future::Either, stream, StreamExt};
 use reqwest::StatusCode;
 use serde_json::json;
-use tracing::warn;
+use tracing::{error, warn};
 
 use self::conversations::ConversationId;
 
@@ -174,6 +174,8 @@ async fn execute_agent(
     .await;
 
     if let Err(err) = response.as_ref() {
+        error!(?err, "failed to handle /answer query");
+
         app.track_query(
             &user,
             &QueryEvent {


### PR DESCRIPTION
Now, we have spans to give context to logs, which can be used to create much easier to understand logs.

For example, this is a log for the query "how does the query compiler work?", with `BLOOP_LOG=bleep=info,bleep::agent=debug`:

```
2023-08-14T21:05:46.534563Z  INFO step{action=Query("how does the query compiler work")}: bleep::agent: executing next action action=Query("how does the query compiler work") self.thread_id=f0b4bc8d-5736-49a8-b9c7-da36dcd94530
2023-08-14T21:05:48.458720Z  INFO step{action=Code { query: "query compiler" }}: bleep::agent: executing next action action=Code { query: "query compiler" } self.thread_id=f0b4bc8d-5736-49a8-b9c7-da36dcd94530
2023-08-14T21:05:48.458773Z DEBUG step{action=Code { query: "query compiler" }}:code_search{query="query compiler"}: bleep::agent: executing semantic query query=SemanticQuery { repos: {Plain("BloopAI/bloop")}, paths: {}, langs: {}, branch: {Plain("origin/main")}, target: Some(Plain("query compiler")) } self.thread_id=f0b4bc8d-5736-49a8-b9c7-da36dcd94530
2023-08-14T21:05:49.712732Z  INFO step{action=Code { query: "query compiler" }}:code_search{query="query compiler"}: bleep::agent::tools::code: got hyde doc doc="java\npublic class QueryCompiler {\n    public static void main(String[] args) {\n        String query = \"SELECT * FROM table WHERE column = value\";\n        String compiledQuery = compileQuery(query);\n        System.out.println(compiledQuery);\n    }\n\n    public static String compileQuery(String query) {\n        // Code to compile the query\n        return \"Compiled query\";\n    }\n}"
2023-08-14T21:05:49.712777Z DEBUG step{action=Code { query: "query compiler" }}:code_search{query="query compiler"}: bleep::agent: executing semantic query query=SemanticQuery { repos: {Plain("BloopAI/bloop")}, paths: {}, langs: {}, branch: {Plain("origin/main")}, target: Some(Plain("java\npublic class QueryCompiler {\n    public static void main(String[] args) {\n        String query = \"SELECT * FROM table WHERE column = value\";\n        String compiledQuery = compileQuery(query);\n        System.out.println(compiledQuery);\n    }\n\n    public static String compileQuery(String query) {\n        // Code to compile the query\n        return \"Compiled query\";\n    }\n}")) } self.thread_id=f0b4bc8d-5736-49a8-b9c7-da36dcd94530
2023-08-14T21:05:51.881609Z  INFO step{action=Proc { query: "query compiler", paths: [0] }}: bleep::agent: executing next action action=Proc { query: "query compiler", paths: [0] } self.thread_id=f0b4bc8d-5736-49a8-b9c7-da36dcd94530
2023-08-14T21:05:51.881637Z DEBUG step{action=Proc { query: "query compiler", paths: [0] }}:process_files{query="query compiler" path_aliases=[0]}: bleep::agent::tools::proc: invoking proc query="query compiler" paths=["server/bleep/src/agent/transcoder.rs"]
2023-08-14T21:05:51.881676Z DEBUG step{action=Proc { query: "query compiler", paths: [0] }}:process_files{query="query compiler" path_aliases=[0]}: bleep::agent::tools::proc: reading file path="server/bleep/src/agent/transcoder.rs"
2023-08-14T21:05:51.881690Z DEBUG step{action=Proc { query: "query compiler", paths: [0] }}:process_files{query="query compiler" path_aliases=[0]}: bleep::agent: executing file search self.repo_ref=github.com/BloopAI/bloop path="server/bleep/src/agent/transcoder.rs" branch=Some("origin/main") self.thread_id=f0b4bc8d-5736-49a8-b9c7-da36dcd94530
2023-08-14T21:05:51.949755Z DEBUG step{action=Proc { query: "query compiler", paths: [0] }}:process_files{query="query compiler" path_aliases=[0]}: bleep::agent::tools::proc: calling chat API on file path="server/bleep/src/agent/transcoder.rs"
2023-08-14T21:05:54.702908Z  INFO step{action=Answer { paths: [0] }}: bleep::agent: executing next action action=Answer { paths: [0] } self.thread_id=f0b4bc8d-5736-49a8-b9c7-da36dcd94530
2023-08-14T21:05:54.702945Z DEBUG step{action=Answer { paths: [0] }}:answer{aliases=[0]}: bleep::agent::tools::answer: creating article response
2023-08-14T21:05:54.702962Z DEBUG step{action=Answer { paths: [0] }}:answer{aliases=[0]}:answer_context{aliases=[0] gpt_model="gpt-4-0613"}: bleep::agent::tools::answer: created filtered path alias list paths=["server/bleep/src/agent/transcoder.rs"] aliases=[0]
2023-08-14T21:05:54.702978Z DEBUG step{action=Answer { paths: [0] }}:answer{aliases=[0]}:answer_context{aliases=[0] gpt_model="gpt-4-0613"}: bleep::agent::tools::answer: canonicalizing code chunks aliases=[0]
2023-08-14T21:05:54.759094Z DEBUG step{action=Answer { paths: [0] }}:answer{aliases=[0]}:answer_context{aliases=[0] gpt_model="gpt-4-0613"}: bleep::agent::tools::answer: expanding spans spans_by_path={"server/bleep/src/agent/transcoder.rs": [759..776, 855..876, 832..849, 731..744, 787..800, 879..897, 805..827, 892..907, 776..793, 832..849, 731..744, 799..820, 855..876, 747..767, 848..851, 878..881]}
2023-08-14T21:05:54.759123Z DEBUG step{action=Answer { paths: [0] }}:answer{aliases=[0]}:answer_context{aliases=[0] gpt_model="gpt-4-0613"}: bleep::agent: executing file search self.repo_ref=github.com/BloopAI/bloop path="server/bleep/src/agent/transcoder.rs" branch=Some("origin/main") self.thread_id=f0b4bc8d-5736-49a8-b9c7-da36dcd94530
2023-08-14T21:05:54.768339Z DEBUG step{action=Answer { paths: [0] }}:answer{aliases=[0]}:answer_context{aliases=[0] gpt_model="gpt-4-0613"}: bleep::agent::tools::answer: expanded spans spans_by_path={"server/bleep/src/agent/transcoder.rs": [478..1160]}
2023-08-14T21:05:54.863370Z DEBUG step{action=Answer { paths: [0] }}:answer{aliases=[0]}:answer_context{aliases=[0] gpt_model="gpt-4-0613"}: bleep::agent::tools::answer: 2573
```

It is now possible to see what steps the model takes towards answering the query. We can clearly see a `code` step, a `proc` step, and a final `answer` step.

With a slightly different configuration `BLOOP_LOG=bleep=info,bleep::agent=debug,bleep::agent::tools::answer=trace`, we can also obtain the model output generated by the answer module:

````
2023-08-14T21:08:14.031568Z  INFO step{action=Query("how does the query compiler work")}: bleep::agent: executing next action action=Query("how does the query compiler work") self.thread_id=4d6362f1-d192-4325-95ef-5ba7273dc6af
2023-08-14T21:08:15.706610Z  INFO step{action=Code { query: "query compiler" }}: bleep::agent: executing next action action=Code { query: "query compiler" } self.thread_id=4d6362f1-d192-4325-95ef-5ba7273dc6af
2023-08-14T21:08:15.706654Z DEBUG step{action=Code { query: "query compiler" }}:code_search{query="query compiler"}: bleep::agent: executing semantic query query=SemanticQuery { repos: {Plain("BloopAI/bloop")}, paths: {}, langs: {}, branch: {Plain("origin/main")}, target: Some(Plain("query compiler")) } self.thread_id=4d6362f1-d192-4325-95ef-5ba7273dc6af
2023-08-14T21:08:16.750427Z  INFO step{action=Code { query: "query compiler" }}:code_search{query="query compiler"}: bleep::agent::tools::code: got hyde doc doc="java\npublic class QueryCompiler {\n    public static void main(String[] args) {\n        String query = \"SELECT * FROM table WHERE column = value\";\n        String compiledQuery = compileQuery(query);\n        System.out.println(compiledQuery);\n    }\n\n    public static String compileQuery(String query) {\n        // Code to compile the query\n        return \"Compiled query\";\n    }\n}"
2023-08-14T21:08:16.750477Z DEBUG step{action=Code { query: "query compiler" }}:code_search{query="query compiler"}: bleep::agent: executing semantic query query=SemanticQuery { repos: {Plain("BloopAI/bloop")}, paths: {}, langs: {}, branch: {Plain("origin/main")}, target: Some(Plain("java\npublic class QueryCompiler {\n    public static void main(String[] args) {\n        String query = \"SELECT * FROM table WHERE column = value\";\n        String compiledQuery = compileQuery(query);\n        System.out.println(compiledQuery);\n    }\n\n    public static String compileQuery(String query) {\n        // Code to compile the query\n        return \"Compiled query\";\n    }\n}")) } self.thread_id=4d6362f1-d192-4325-95ef-5ba7273dc6af
2023-08-14T21:08:18.737589Z  INFO step{action=Proc { query: "query compiler", paths: [0] }}: bleep::agent: executing next action action=Proc { query: "query compiler", paths: [0] } self.thread_id=4d6362f1-d192-4325-95ef-5ba7273dc6af
2023-08-14T21:08:18.737618Z DEBUG step{action=Proc { query: "query compiler", paths: [0] }}:process_files{query="query compiler" path_aliases=[0]}: bleep::agent::tools::proc: invoking proc query="query compiler" paths=["server/bleep/src/agent/transcoder.rs"]
2023-08-14T21:08:18.737669Z DEBUG step{action=Proc { query: "query compiler", paths: [0] }}:process_files{query="query compiler" path_aliases=[0]}: bleep::agent::tools::proc: reading file path="server/bleep/src/agent/transcoder.rs"
2023-08-14T21:08:18.737682Z DEBUG step{action=Proc { query: "query compiler", paths: [0] }}:process_files{query="query compiler" path_aliases=[0]}: bleep::agent: executing file search self.repo_ref=github.com/BloopAI/bloop path="server/bleep/src/agent/transcoder.rs" branch=Some("origin/main") self.thread_id=4d6362f1-d192-4325-95ef-5ba7273dc6af
2023-08-14T21:08:18.810154Z DEBUG step{action=Proc { query: "query compiler", paths: [0] }}:process_files{query="query compiler" path_aliases=[0]}: bleep::agent::tools::proc: calling chat API on file path="server/bleep/src/agent/transcoder.rs"
2023-08-14T21:08:20.509663Z  INFO step{action=Answer { paths: [0] }}: bleep::agent: executing next action action=Answer { paths: [0] } self.thread_id=4d6362f1-d192-4325-95ef-5ba7273dc6af
2023-08-14T21:08:20.509690Z DEBUG step{action=Answer { paths: [0] }}:answer{aliases=[0]}: bleep::agent::tools::answer: creating article response
2023-08-14T21:08:20.509709Z DEBUG step{action=Answer { paths: [0] }}:answer{aliases=[0]}:answer_context{aliases=[0] gpt_model="gpt-4-0613"}: bleep::agent::tools::answer: created filtered path alias list paths=["server/bleep/src/agent/transcoder.rs"] aliases=[0]
2023-08-14T21:08:20.509725Z DEBUG step{action=Answer { paths: [0] }}:answer{aliases=[0]}:answer_context{aliases=[0] gpt_model="gpt-4-0613"}: bleep::agent::tools::answer: canonicalizing code chunks aliases=[0]
2023-08-14T21:08:20.564383Z DEBUG step{action=Answer { paths: [0] }}:answer{aliases=[0]}:answer_context{aliases=[0] gpt_model="gpt-4-0613"}: bleep::agent::tools::answer: expanding spans spans_by_path={"server/bleep/src/agent/transcoder.rs": [759..776, 855..876, 832..849, 731..744, 787..800, 879..897, 805..827, 892..907, 776..793, 832..849, 731..744, 799..820, 855..876, 747..767, 848..851, 878..881]}
2023-08-14T21:08:20.564416Z DEBUG step{action=Answer { paths: [0] }}:answer{aliases=[0]}:answer_context{aliases=[0] gpt_model="gpt-4-0613"}: bleep::agent: executing file search self.repo_ref=github.com/BloopAI/bloop path="server/bleep/src/agent/transcoder.rs" branch=Some("origin/main") self.thread_id=4d6362f1-d192-4325-95ef-5ba7273dc6af
2023-08-14T21:08:20.566920Z TRACE step{action=Answer { paths: [0] }}:answer{aliases=[0]}:answer_context{aliases=[0] gpt_model="gpt-4-0613"}: bleep::agent::tools::answer: growing span path="server/bleep/src/agent/transcoder.rs"
2023-08-14T21:08:20.566935Z TRACE step{action=Answer { paths: [0] }}:answer{aliases=[0]}:answer_context{aliases=[0] gpt_model="gpt-4-0613"}: bleep::agent::tools::answer: growing span path="server/bleep/src/agent/transcoder.rs"
2023-08-14T21:08:20.566944Z TRACE step{action=Answer { paths: [0] }}:answer{aliases=[0]}:answer_context{aliases=[0] gpt_model="gpt-4-0613"}: bleep::agent::tools::answer: growing span path="server/bleep/src/agent/transcoder.rs"
2023-08-14T21:08:20.566951Z TRACE step{action=Answer { paths: [0] }}:answer{aliases=[0]}:answer_context{aliases=[0] gpt_model="gpt-4-0613"}: bleep::agent::tools::answer: growing span path="server/bleep/src/agent/transcoder.rs"
2023-08-14T21:08:20.566959Z TRACE step{action=Answer { paths: [0] }}:answer{aliases=[0]}:answer_context{aliases=[0] gpt_model="gpt-4-0613"}: bleep::agent::tools::answer: growing span path="server/bleep/src/agent/transcoder.rs"
2023-08-14T21:08:20.566966Z TRACE step{action=Answer { paths: [0] }}:answer{aliases=[0]}:answer_context{aliases=[0] gpt_model="gpt-4-0613"}: bleep::agent::tools::answer: growing span path="server/bleep/src/agent/transcoder.rs"
2023-08-14T21:08:20.566973Z TRACE step{action=Answer { paths: [0] }}:answer{aliases=[0]}:answer_context{aliases=[0] gpt_model="gpt-4-0613"}: bleep::agent::tools::answer: growing span path="server/bleep/src/agent/transcoder.rs"
2023-08-14T21:08:20.566981Z TRACE step{action=Answer { paths: [0] }}:answer{aliases=[0]}:answer_context{aliases=[0] gpt_model="gpt-4-0613"}: bleep::agent::tools::answer: growing span path="server/bleep/src/agent/transcoder.rs"
2023-08-14T21:08:20.566988Z TRACE step{action=Answer { paths: [0] }}:answer{aliases=[0]}:answer_context{aliases=[0] gpt_model="gpt-4-0613"}: bleep::agent::tools::answer: growing span path="server/bleep/src/agent/transcoder.rs"
2023-08-14T21:08:20.566994Z TRACE step{action=Answer { paths: [0] }}:answer{aliases=[0]}:answer_context{aliases=[0] gpt_model="gpt-4-0613"}: bleep::agent::tools::answer: growing span path="server/bleep/src/agent/transcoder.rs"
2023-08-14T21:08:20.567001Z TRACE step{action=Answer { paths: [0] }}:answer{aliases=[0]}:answer_context{aliases=[0] gpt_model="gpt-4-0613"}: bleep::agent::tools::answer: growing span path="server/bleep/src/agent/transcoder.rs"
2023-08-14T21:08:20.567009Z TRACE step{action=Answer { paths: [0] }}:answer{aliases=[0]}:answer_context{aliases=[0] gpt_model="gpt-4-0613"}: bleep::agent::tools::answer: growing span path="server/bleep/src/agent/transcoder.rs"
2023-08-14T21:08:20.567016Z TRACE step{action=Answer { paths: [0] }}:answer{aliases=[0]}:answer_context{aliases=[0] gpt_model="gpt-4-0613"}: bleep::agent::tools::answer: growing span path="server/bleep/src/agent/transcoder.rs"
2023-08-14T21:08:20.567024Z TRACE step{action=Answer { paths: [0] }}:answer{aliases=[0]}:answer_context{aliases=[0] gpt_model="gpt-4-0613"}: bleep::agent::tools::answer: growing span path="server/bleep/src/agent/transcoder.rs"
2023-08-14T21:08:20.567031Z TRACE step{action=Answer { paths: [0] }}:answer{aliases=[0]}:answer_context{aliases=[0] gpt_model="gpt-4-0613"}: bleep::agent::tools::answer: growing span path="server/bleep/src/agent/transcoder.rs"
2023-08-14T21:08:20.567040Z TRACE step{action=Answer { paths: [0] }}:answer{aliases=[0]}:answer_context{aliases=[0] gpt_model="gpt-4-0613"}: bleep::agent::tools::answer: growing span path="server/bleep/src/agent/transcoder.rs"
2023-08-14T21:08:20.567921Z TRACE step{action=Answer { paths: [0] }}:answer{aliases=[0]}:answer_context{aliases=[0] gpt_model="gpt-4-0613"}: bleep::agent::tools::answer: growing span path="server/bleep/src/agent/transcoder.rs"
2023-08-14T21:08:20.568773Z TRACE step{action=Answer { paths: [0] }}:answer{aliases=[0]}:answer_context{aliases=[0] gpt_model="gpt-4-0613"}: bleep::agent::tools::answer: growing span path="server/bleep/src/agent/transcoder.rs"
2023-08-14T21:08:20.569814Z TRACE step{action=Answer { paths: [0] }}:answer{aliases=[0]}:answer_context{aliases=[0] gpt_model="gpt-4-0613"}: bleep::agent::tools::answer: growing span path="server/bleep/src/agent/transcoder.rs"
2023-08-14T21:08:20.571059Z TRACE step{action=Answer { paths: [0] }}:answer{aliases=[0]}:answer_context{aliases=[0] gpt_model="gpt-4-0613"}: bleep::agent::tools::answer: growing span path="server/bleep/src/agent/transcoder.rs"
2023-08-14T21:08:20.572541Z TRACE step{action=Answer { paths: [0] }}:answer{aliases=[0]}:answer_context{aliases=[0] gpt_model="gpt-4-0613"}: bleep::agent::tools::answer: growing span path="server/bleep/src/agent/transcoder.rs"
2023-08-14T21:08:20.574420Z DEBUG step{action=Answer { paths: [0] }}:answer{aliases=[0]}:answer_context{aliases=[0] gpt_model="gpt-4-0613"}: bleep::agent::tools::answer: expanded spans spans_by_path={"server/bleep/src/agent/transcoder.rs": [478..1160]}
2023-08-14T21:08:20.663741Z DEBUG step{action=Answer { paths: [0] }}:answer{aliases=[0]}:answer_context{aliases=[0] gpt_model="gpt-4-0613"}: bleep::agent::tools::answer: 2573
2023-08-14T21:08:38.424535Z TRACE step{action=Answer { paths: [0] }}:answer{aliases=[0]}: bleep::agent::tools::answer: generated answer article=The `Compiler` struct in [`server/bleep/src/query/compiler.rs`](server/bleep/src/query/compiler.rs) is used to compile a list of queries into a single Tantivy query that matches any of them. Here is an example of its usage:

``` type:Quoted,lang:Rust,path:server/bleep/src/query/compiler.rs,lines:0-0
let mut compiler = Compiler::new();
compiler.literal(schema.name, |q| q.repo.clone());
let compiled_query = compiler.compile(queries, tantivy_index);
```

In this example, the `Compiler` is first initialized. Then, the `literal` method is called on the `Compiler` instance, which adds a literal query to the compiler. The `literal` method takes two arguments: the field to search and a closure that takes a `Query` and returns a `Query`. In this case, the closure clones the `repo` field of the `Query`.

Finally, the `compile` method is called on the `Compiler` instance, which takes the queries and the Tantivy index as arguments and returns the compiled query.
````

Closes BLO-929