### PR TITLE
Allow frontend to send backend logs on request.

### DIFF
--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -36,7 +36,7 @@ fn relative_command_path(command: impl AsRef<str>) -> Option<PathBuf> {
 async fn main() {
     tauri::Builder::default()
         .plugin(qdrant::QdrantSupervisor::default())
-        .setup(backend::bleep)
+        .plugin(backend::BloopBackend::default())
         .invoke_handler(tauri::generate_handler![
             show_folder_in_finder,
             enable_telemetry,

--- a/client/src/CloudApp.tsx
+++ b/client/src/CloudApp.tsx
@@ -35,7 +35,7 @@ const CloudApp = () => {
         platform: '',
         version: '',
       },
-      invokeTauriCommand: () => {},
+      invokeTauriCommand: () => Promise.resolve(''),
       release: packageJson.version,
       apiUrl: import.meta.env.API_URL || '/api',
       isRepoManagementAllowed: true,

--- a/client/src/components/ReportBugModal/index.tsx
+++ b/client/src/components/ReportBugModal/index.tsx
@@ -38,11 +38,13 @@ const ReportBugModal = ({
     emailError: '',
   });
   const [isSubmitted, setSubmitted] = useState(false);
+  const [serverLog, setServerLog] = useState('');
   const [serverCrashedMessage, setServerCrashedMessage] = useState('');
   const { isBugReportModalOpen, setBugReportModalOpen } = useContext(
     UIContext.BugReport,
   );
-  const { envConfig, listen, os, release } = useContext(DeviceContext);
+  const { envConfig, listen, os, release, invokeTauriCommand } =
+    useContext(DeviceContext);
   const { handleRemoveTab, setActiveTab, activeTab } = useContext(TabsContext);
 
   const userForm = useMemo(
@@ -50,6 +52,14 @@ const ReportBugModal = ({
       getJsonFromStorage(USER_DATA_FORM),
     [],
   );
+
+  useEffect(() => {
+    if (isBugReportModalOpen) {
+      invokeTauriCommand('plugin:bleep|get_last_log_file').then((log) => {
+        setServerLog(log);
+      });
+    }
+  }, [isBugReportModalOpen]);
 
   useEffect(() => {
     listen('server-crashed', (event) => {
@@ -94,6 +104,7 @@ const ReportBugModal = ({
           info: serverCrashedMessage,
           metadata: JSON.stringify(os),
           app_version: release,
+          server_log: serverLog,
         });
       } else {
         const { emailError, ...values } = form;
@@ -102,11 +113,12 @@ const ReportBugModal = ({
           unique_id: envConfig.tracking_id || '',
           app_version: release,
           metadata: JSON.stringify(os),
+          server_log: serverLog,
         });
       }
       setSubmitted(true);
     },
-    [form, envConfig.tracking_id, release],
+    [form, envConfig.tracking_id, release, serverLog],
   );
   const resetState = useCallback(() => {
     if (serverCrashedMessage) {

--- a/client/src/context/deviceContext.ts
+++ b/client/src/context/deviceContext.ts
@@ -20,7 +20,7 @@ export type DeviceContextType = {
     platform: string;
     version: string;
   };
-  invokeTauriCommand: (c: string, payload?: any) => void;
+  invokeTauriCommand: (c: string, payload?: any) => Promise<any>;
   relaunch: () => void;
   release: string;
   apiUrl: string;
@@ -44,7 +44,7 @@ export const DeviceContext = createContext<DeviceContextType>({
     platform: '',
     version: '',
   },
-  invokeTauriCommand: () => {},
+  invokeTauriCommand: () => Promise.resolve(''),
   relaunch: () => {},
   release: '0.0.0',
   apiUrl: '',

--- a/client/src/services/api.ts
+++ b/client/src/services/api.ts
@@ -175,6 +175,7 @@ export const saveBugReport = (report: {
   unique_id: string;
   app_version: string;
   metadata: string;
+  server_log: string;
 }) => axios.post(`${DB_API}/bug_reports`, report).then((r) => r.data);
 
 export const saveCrashReport = (report: {
@@ -183,6 +184,7 @@ export const saveCrashReport = (report: {
   info: string;
   metadata: string;
   app_version: string;
+  server_log: string;
 }) => axios.post(`${DB_API}/crash_reports`, report).then((r) => r.data);
 
 export const saveUpvote = (upvote: {

--- a/server/bleep/src/config.rs
+++ b/server/bleep/src/config.rs
@@ -6,7 +6,7 @@ use secrecy::{ExposeSecret, SecretString};
 use serde::{Deserialize, Serialize, Serializer};
 use std::path::{Path, PathBuf};
 
-#[derive(Serialize, Deserialize, Parser, Debug)]
+#[derive(Serialize, Deserialize, Parser, Debug, Clone)]
 #[clap(author, version, about, long_about = None)]
 pub struct Configuration {
     //


### PR DESCRIPTION
The `get_last_log_file` Tauri call will return the last written log file to the frontend for error & crash reporting. We can expand this in the future.