### PR TITLE
Move qdrant killing earlier

### DIFF
--- a/apps/desktop/src-tauri/src/qdrant.rs
+++ b/apps/desktop/src-tauri/src/qdrant.rs
@@ -47,8 +47,8 @@ where
     }
 
     fn on_event(&mut self, _app: &tauri::AppHandle<R>, event: &tauri::RunEvent) {
-        use tauri::RunEvent::Exit;
-        if let Exit = event {
+        use tauri::RunEvent::ExitRequested;
+        if matches!(event, ExitRequested { .. }) {
             self.child
                 .take()
                 .expect("qdrant not started")


### PR DESCRIPTION
Move killing qdrant earlier in the event loop, as we sometimes seem to leave it around. Maybe moving it earlier in the shutdown process helps?