### PR TITLE
Even better qdrant killing

### DIFF
--- a/apps/desktop/src-tauri/src/backend.rs
+++ b/apps/desktop/src-tauri/src/backend.rs
@@ -3,7 +3,6 @@ use std::sync::Arc;
 use bleep::{analytics, Application, Configuration, Environment};
 use once_cell::sync::OnceCell;
 use sentry::ClientInitGuard;
-use tauri::{plugin::Plugin, Invoke};
 use tracing::{error, warn};
 
 use super::{Manager, Payload, Runtime};


### PR DESCRIPTION
Make the second attempt fail gracefully. There's not much point panicing here, as the app is supposed to be shutting down anyway.

It seems like `ExitRequested` is skipped on a Mac when using eg. CMD-Q to quit.