### PR TITLE
add code-navigation utilites to code-studio 

### DIFF
--- a/server/bleep/src/indexes/reader.rs
+++ b/server/bleep/src/indexes/reader.rs
@@ -28,6 +28,25 @@ pub struct ContentDocument {
     pub branches: Option<String>,
 }
 
+impl std::hash::Hash for ContentDocument {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.repo_ref.hash(state);
+        self.branches.hash(state);
+        self.relative_path.hash(state);
+        self.content.hash(state);
+    }
+}
+
+impl PartialEq for ContentDocument {
+    fn eq(&self, other: &Self) -> bool {
+        self.repo_ref == other.repo_ref
+            && self.branches == other.branches
+            && self.relative_path == other.relative_path
+            && self.content == other.content
+    }
+}
+impl Eq for ContentDocument {}
+
 impl ContentDocument {
     pub fn hoverable_ranges(&self) -> Option<Vec<TextRange>> {
         TreeSitterFile::try_build(self.content.as_bytes(), self.lang.as_ref()?)

--- a/server/bleep/src/intelligence/code_navigation.rs
+++ b/server/bleep/src/intelligence/code_navigation.rs
@@ -2,16 +2,16 @@
 //! - scope-graph based handler that operates only in the owning file
 //! - search based handler that operates on any file belonging to the repo
 
-use std::ops::Not;
+use std::{collections::HashSet, ops::Not};
 
 use super::NodeKind;
 use crate::{
     indexes::reader::ContentDocument,
-    repo::RepoRef,
     snippet::{Snipper, Snippet},
     text_range::TextRange,
 };
 
+use rayon::prelude::*;
 use serde::Serialize;
 
 #[derive(Debug, Serialize)]
@@ -46,14 +46,76 @@ pub enum OccurrenceKind {
 
 pub enum CodeNavigationError {}
 
-pub struct CodeNavigationContext<'a> {
-    pub repo_ref: RepoRef,
+pub struct CodeNavigationContext<'a, 'b> {
     pub token: Token<'a>,
-    pub all_docs: Vec<ContentDocument>,
+    pub all_docs: &'b [ContentDocument],
     pub source_document_idx: usize,
 }
 
-impl<'a> CodeNavigationContext<'a> {
+impl<'a, 'b> CodeNavigationContext<'a, 'b> {
+    pub fn related_files(
+        all_docs: &'b [ContentDocument],
+        source_document_idx: usize,
+    ) -> HashSet<&'b ContentDocument> {
+        // scope graph of the source document
+        let source_doc = all_docs.get(source_document_idx).unwrap();
+        let Some(source_sg) = source_doc.symbol_locations.scope_graph() else {
+            return HashSet::default();
+        };
+
+        source_sg
+            .graph
+            .node_indices()
+            .par_bridge()
+            .filter(|idx| source_sg.is_reference(*idx) || source_sg.is_import(*idx))
+            .filter(|idx| {
+                let range = source_sg.graph[*idx].range();
+                let token = Token {
+                    relative_path: &source_doc.relative_path,
+                    start_byte: range.start.byte,
+                    end_byte: range.end.byte,
+                };
+                let ctx = CodeNavigationContext {
+                    all_docs,
+                    source_document_idx,
+                    token,
+                };
+                ctx.local_definitions().is_none()
+            })
+            .flat_map_iter(|idx| {
+                let range = source_sg.graph[idx].range();
+                let token = Token {
+                    relative_path: &source_doc.relative_path,
+                    start_byte: range.start.byte,
+                    end_byte: range.end.byte,
+                };
+                let active_token_range = token.start_byte..token.end_byte;
+                let active_token_text =
+                    source_doc.content.as_str().get(active_token_range).unwrap();
+                all_docs
+                    .iter()
+                    .filter(|doc| doc.relative_path != source_doc.relative_path)
+                    .filter(|doc| {
+                        let Some(scope_graph) = doc.symbol_locations.scope_graph() else {
+                        return false;
+                    };
+                        let content = doc.content.as_bytes();
+                        scope_graph
+                            .graph
+                            .node_indices()
+                            .filter(|idx| scope_graph.is_top_level(*idx))
+                            .any(|idx| {
+                                if let Some(NodeKind::Def(d)) = scope_graph.get_node(idx) {
+                                    d.name(content) == active_token_text.as_bytes()
+                                } else {
+                                    false
+                                }
+                            })
+                    })
+            })
+            .collect::<HashSet<_>>()
+    }
+
     fn source_document(&self) -> &ContentDocument {
         self.all_docs.get(self.source_document_idx).unwrap()
     }

--- a/server/bleep/src/intelligence/language/r/mod.rs
+++ b/server/bleep/src/intelligence/language/r/mod.rs
@@ -251,4 +251,20 @@ mod tests {
             "#]],
         )
     }
+
+    #[test]
+    fn value_of_function_definition() {
+        let src = r#"foo <- function (a, b, c) { // 0
+                        a <- a + 1               // 1
+                        b <- a + 1               // 2
+                        c <- a + 1               // 3
+                    }                            // 4"#;
+
+        let sg = build_graph("R", src.as_bytes());
+        let foo_function = sg.find_node_by_name(src.as_bytes(), b"foo").unwrap();
+        let function_node = &sg.graph[sg.value_of_definition(foo_function).unwrap()];
+
+        assert_eq!(function_node.range().start.line, 0);
+        assert_eq!(function_node.range().end.line, 4);
+    }
 }

--- a/server/bleep/src/intelligence/language/test_utils.rs
+++ b/server/bleep/src/intelligence/language/test_utils.rs
@@ -47,12 +47,16 @@ pub fn assert_eq_defs(src: &[u8], lang_id: &str, defs: Vec<(&str, &str)>) {
 }
 
 pub fn test_scopes(lang_id: &str, src: &[u8], expected: Expect) {
+    let graph = build_graph(lang_id, src);
     let language = match Language::from_id(lang_id) {
         Language::Supported(config) => config,
         _ => panic!("testing unsupported language"),
     };
-    let tsf = TreeSitterFile::try_build(src, lang_id).unwrap();
-    let observed = tsf.scope_graph().unwrap().debug(src, language);
-
+    let observed = graph.debug(src, language);
     expected.assert_debug_eq(&observed)
+}
+
+pub fn build_graph(lang_id: &str, src: &[u8]) -> crate::intelligence::ScopeGraph {
+    let tsf = TreeSitterFile::try_build(src, lang_id).unwrap();
+    tsf.scope_graph().unwrap()
 }

--- a/server/bleep/src/webserver.rs
+++ b/server/bleep/src/webserver.rs
@@ -53,6 +53,8 @@ pub async fn start(app: Application) -> anyhow::Result<()> {
         // intelligence
         .route("/hoverable", get(hoverable::handle))
         .route("/token-info", get(intelligence::handle))
+        .route("/related-files", get(intelligence::related_files))
+        .route("/token-value", get(intelligence::token_value))
         // misc
         .route("/search", get(semantic::complex_search))
         .route("/file", get(file::handle))


### PR DESCRIPTION
- utility to extract the "value" of definitions:
  `ScopeGraph::value_of_definition` uses a heuristic to find a possible
  value for the definition. it is defined as the smallest surrounding
  scope or the largest adjacent scope. variable definitions or local
  definitions typically will not have an scope node "nearby", and their
  "value" can be assumed to span the containing line.

- add /related-files endpoint: uses scope-graphs to calculate a closure
  of files related to a target file. request and response schema are
  subject to change.

- add /token-value endpoint: exposes `ScopeGraph::value_of_definition`
  to the webserver. request and response schema are subject to change.