### PR TITLE
Initial Code Studio API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -299,6 +299,7 @@ checksum = "a6a1de45611fdb535bfde7b7de4fd54f4fd2b17b1737c0a59b69bf9b92074b8c"
 dependencies = [
  "async-trait",
  "axum-core",
+ "axum-macros",
  "bitflags 1.3.2",
  "bytes",
  "futures-util",
@@ -362,6 +363,18 @@ dependencies = [
  "tower-http",
  "tower-layer",
  "tower-service",
+]
+
+[[package]]
+name = "axum-macros"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdca6a10ecad987bda04e95606ef85a5417dcaac1a78455242d72e031e2b6b62"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.27",
 ]
 
 [[package]]

--- a/server/bleep/Cargo.toml
+++ b/server/bleep/Cargo.toml
@@ -70,7 +70,7 @@ petgraph = { version = "0.6.3", default-features = false, features = ["serde-1"]
 
 # webserver
 serde_json = "1.0.100"
-axum = { version = "0.6.18", features = ["http2", "headers"] }
+axum = { version = "0.6.18", features = ["http2", "headers", "macros"] }
 axum-extra = { version = "0.7.4", features = ["cookie", "cookie-private"] }
 tower = "0.4.13"
 tower-http = { version = "0.4.1", features = ["auth", "cors", "catch-panic", "fs"] }

--- a/server/bleep/migrations/20230821131141_code_studio.sql
+++ b/server/bleep/migrations/20230821131141_code_studio.sql
@@ -1,0 +1,11 @@
+CREATE TABLE studios (
+    -- UUID
+    id TEXT NOT NULL,
+
+    name TEXT NOT NULL,
+    modified_at DATETIME NOT NULL DEFAULT (datetime('now')),
+
+    -- JSON serialized fields
+    context TEXT NOT NULL,
+    messages TEXT NOT NULL
+);

--- a/server/bleep/sqlx-data.json
+++ b/server/bleep/sqlx-data.json
@@ -1,5 +1,15 @@
 {
   "db": "SQLite",
+  "0b8661afb0bd1a3806b96d07902fc6ba520b4efd1665f04b53f51c8dcd544343": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Right": 4
+      }
+    },
+    "query": "INSERT INTO studios (id, name, context, messages) VALUES (?, ?, ?, ?)"
+  },
   "13d9aec6f721a649ab89c29c770ae5aa9f1bf34a0e30f6e608b697772774568e": {
     "describe": {
       "columns": [],
@@ -9,6 +19,78 @@
       }
     },
     "query": "INSERT INTO conversations (user_id, thread_id, repo_ref, title, exchanges, created_at) VALUES (?, ?, ?, ?, ?, strftime('%s', 'now'))"
+  },
+  "18d1bdc46f4448448cb7121db7b2952076e6b17ba00ce370c919419d20d0fe07": {
+    "describe": {
+      "columns": [
+        {
+          "name": "id",
+          "ordinal": 0,
+          "type_info": "Text"
+        },
+        {
+          "name": "name",
+          "ordinal": 1,
+          "type_info": "Text"
+        },
+        {
+          "name": "modified_at",
+          "ordinal": 2,
+          "type_info": "Datetime"
+        }
+      ],
+      "nullable": [
+        false,
+        false,
+        false
+      ],
+      "parameters": {
+        "Right": 0
+      }
+    },
+    "query": "SELECT id, name, modified_at FROM studios"
+  },
+  "21dfa10d31da4ec906483d92c4e885536b8020630f989306fb00fd5b861378e5": {
+    "describe": {
+      "columns": [
+        {
+          "name": "id",
+          "ordinal": 0,
+          "type_info": "Text"
+        },
+        {
+          "name": "name",
+          "ordinal": 1,
+          "type_info": "Text"
+        },
+        {
+          "name": "context",
+          "ordinal": 2,
+          "type_info": "Text"
+        },
+        {
+          "name": "messages",
+          "ordinal": 3,
+          "type_info": "Text"
+        },
+        {
+          "name": "modified_at",
+          "ordinal": 4,
+          "type_info": "Datetime"
+        }
+      ],
+      "nullable": [
+        false,
+        false,
+        false,
+        false,
+        false
+      ],
+      "parameters": {
+        "Right": 1
+      }
+    },
+    "query": "SELECT id, name, context, messages, modified_at\n         FROM studios\n         WHERE id = ?"
   },
   "392b563bb3af6711817fe99335d053691750426762dcde7b0381dc9f69cd804e": {
     "describe": {
@@ -62,6 +144,16 @@
     },
     "query": "SELECT cache_hash FROM file_cache WHERE repo_ref = ?"
   },
+  "4aacc9795c1a466afdc7c5cedcdf1a6b67652a7ddcdee0399e67024e087d75a9": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Right": 2
+      }
+    },
+    "query": "UPDATE studios SET name = ? WHERE id = ?"
+  },
   "4bf8d04acb2c99669237578467e50ac6822cb46053bced5d7d7a9dc374353e0d": {
     "describe": {
       "columns": [],
@@ -92,6 +184,16 @@
     },
     "query": "DELETE FROM chunk_cache WHERE chunk_hash = ? AND file_hash = ?"
   },
+  "757d0afca2629937d717f9d6fc02df5dada4412e7b09bfed57423aa9b5f07b40": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Right": 2
+      }
+    },
+    "query": "UPDATE studios SET modified_at = ? WHERE id = ?"
+  },
   "9146d9c8a7f17cc65c017cb364d1a853a9163b5ece336c0a6ef4e28e8df56a6b": {
     "describe": {
       "columns": [],
@@ -111,6 +213,16 @@
       }
     },
     "query": "DELETE FROM file_cache WHERE repo_ref = ?"
+  },
+  "a65012ef1100880ed0a93569a397b4c0632e0f4f8d9be9577fbb5bcc8c31b8cf": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Right": 2
+      }
+    },
+    "query": "UPDATE studios SET context = ? WHERE id = ?"
   },
   "ac1299cb16ae8ff77ded6a11241b84414352c12e55ce40b89e5b85109c7dc523": {
     "describe": {
@@ -139,6 +251,24 @@
       }
     },
     "query": "INSERT INTO chunk_cache (chunk_hash, file_hash, branches, repo_ref) VALUES (?, ?, ?, ?)"
+  },
+  "b5bdd5f1da56c714031b94983c70a1ff4526d3b02d21addfd76f5f8641a5eecc": {
+    "describe": {
+      "columns": [
+        {
+          "name": "id",
+          "ordinal": 0,
+          "type_info": "Text"
+        }
+      ],
+      "nullable": [
+        false
+      ],
+      "parameters": {
+        "Right": 1
+      }
+    },
+    "query": "SELECT id FROM studios WHERE id = ?"
   },
   "bc60b0f34fd20feba2da3f16458770424534eacaba75e6f45b8218f32767671b": {
     "describe": {
@@ -169,6 +299,16 @@
       }
     },
     "query": "SELECT thread_id, created_at, title FROM conversations WHERE user_id = ? AND repo_ref = ? ORDER BY created_at DESC"
+  },
+  "d5d1d85ebd2740431593367145770ec13ab3b3f0eb23cfefacabb7a5711dbd99": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Right": 1
+      }
+    },
+    "query": "UPDATE studios SET modified_at = datetime('now') WHERE id = ?"
   },
   "d5ee5becde7005920d7094fca5b7974bbf19713b3625fbf6d1a3e198e7cf4de4": {
     "describe": {
@@ -210,6 +350,24 @@
     },
     "query": "INSERT INTO file_cache (repo_ref, cache_hash) VALUES (?, ?)"
   },
+  "db80c758eb137530e6aad6e83778efcea787dfdf42f95b896ac482d3ffac2cfe": {
+    "describe": {
+      "columns": [
+        {
+          "name": "context",
+          "ordinal": 0,
+          "type_info": "Text"
+        }
+      ],
+      "nullable": [
+        false
+      ],
+      "parameters": {
+        "Right": 1
+      }
+    },
+    "query": "SELECT context FROM studios WHERE id = ?"
+  },
   "e444f39d4fc9219873c7a8565a13e65e4646658631b785431cb64ca0cc5d6ab9": {
     "describe": {
       "columns": [
@@ -243,5 +401,15 @@
       }
     },
     "query": "DELETE FROM chunk_cache WHERE repo_ref = ?"
+  },
+  "fcd51dfbd5e468d2517a9b21a444998cdf8fc9564a2b60961bddc4f5f9f49e2c": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Right": 2
+      }
+    },
+    "query": "UPDATE studios SET messages = ? WHERE id = ?"
   }
 }

--- a/server/bleep/src/webserver.rs
+++ b/server/bleep/src/webserver.rs
@@ -3,7 +3,7 @@ use crate::{env::Feature, Application};
 use axum::{
     http::StatusCode,
     response::IntoResponse,
-    routing::{get, post},
+    routing::{get, patch, post},
     Extension, Json,
 };
 use std::{borrow::Cow, net::SocketAddr};
@@ -25,6 +25,8 @@ pub mod middleware;
 mod query;
 pub mod repos;
 mod search;
+mod semantic;
+mod studio;
 
 pub type Router<S = Application> = axum::Router<S>;
 
@@ -69,7 +71,11 @@ pub async fn start(app: Application) -> anyhow::Result<()> {
             "/answer/conversations/:thread_id",
             get(answer::conversations::thread),
         )
-        .route("/answer/vote", post(answer::vote));
+        .route("/answer/vote", post(answer::vote))
+        .route("/studio", post(studio::create))
+        .route("/studio", get(studio::list))
+        .route("/studio/:id", get(studio::get))
+        .route("/studio/:id", patch(studio::patch));
 
     if app.env.allow(Feature::AnyPathScan) {
         api = api.route("/repos/scan", get(repos::scan_local));

--- a/server/bleep/src/webserver.rs
+++ b/server/bleep/src/webserver.rs
@@ -25,7 +25,6 @@ pub mod middleware;
 mod query;
 pub mod repos;
 mod search;
-mod semantic;
 mod studio;
 
 pub type Router<S = Application> = axum::Router<S>;

--- a/server/bleep/src/webserver/studio.rs
+++ b/server/bleep/src/webserver/studio.rs
@@ -1,0 +1,245 @@
+use std::ops::Range;
+
+use anyhow::Context;
+use axum::{extract::Query, Extension, Json};
+use chrono::NaiveDateTime;
+use futures::{stream, StreamExt, TryStreamExt};
+use uuid::Uuid;
+
+use super::{Error, ErrorKind};
+use crate::{repo::RepoRef, webserver, Application};
+
+#[derive(serde::Deserialize)]
+pub struct Create {
+    name: String,
+}
+
+pub async fn create(app: Extension<Application>, params: Json<Create>) -> webserver::Result<()> {
+    let id = Uuid::new_v4().to_string();
+
+    sqlx::query! {
+        "INSERT INTO studios (id, name, context, messages) VALUES (?, ?, ?, ?)",
+        id,
+        params.name,
+        "[]",
+        "[]"
+    }
+    .execute(&*app.sql)
+    .await
+    .map_err(Error::internal)?;
+
+    Ok(())
+}
+
+#[derive(serde::Serialize)]
+pub struct ListItem {
+    id: String,
+    name: String,
+    modified_at: NaiveDateTime,
+}
+
+pub async fn list(app: Extension<Application>) -> webserver::Result<Json<Vec<ListItem>>> {
+    sqlx::query_as! { ListItem, "SELECT id, name, modified_at FROM studios" }
+        .fetch_all(&*app.sql)
+        .await
+        .map_err(Error::internal)
+        .map(Json)
+}
+
+#[derive(serde::Deserialize)]
+pub struct Get {
+    id: String,
+}
+
+#[derive(serde::Serialize)]
+pub struct Studio {
+    name: String,
+    modified_at: NaiveDateTime,
+    context: Vec<ContextFile>,
+    messages: Vec<Message>,
+    token_count: usize,
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+struct ContextFile {
+    path: String,
+    hidden: bool,
+    repo: RepoRef,
+    branch: String,
+    ranges: Vec<Range<usize>>,
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+enum Message {
+    User(String),
+    Assistant(String),
+}
+
+pub async fn get(
+    app: Extension<Application>,
+    params: Query<Get>,
+) -> webserver::Result<Json<Studio>> {
+    let row = sqlx::query! {
+        "SELECT id, name, context, messages, modified_at
+         FROM studios
+         WHERE id = ?",
+         params.id
+    }
+    .fetch_optional(&*app.sql)
+    .await
+    .map_err(Error::internal)?
+    .ok_or_else(|| Error::new(ErrorKind::NotFound, "unknown studio ID"))?;
+
+    let context: Vec<ContextFile> =
+        serde_json::from_str(&row.context).context("failed to deserialize context")?;
+    let messages: Vec<Message> =
+        serde_json::from_str(&row.messages).context("failed to deserialize message list")?;
+
+    Ok(Json(Studio {
+        modified_at: row.modified_at,
+        name: row.name,
+        context,
+        messages,
+        token_count: 0,
+    }))
+}
+
+#[derive(serde::Deserialize)]
+pub struct Patch {
+    id: String,
+}
+
+#[derive(serde::Deserialize)]
+pub struct PatchFields {
+    name: Option<String>,
+    modified_at: Option<NaiveDateTime>,
+    context: Option<Vec<ContextFile>>,
+    messages: Option<Vec<Message>>,
+}
+
+#[axum::debug_handler]
+pub async fn patch(
+    app: Extension<Application>,
+    Query(Patch { id }): Query<Patch>,
+    Json(patch): Json<PatchFields>,
+) -> webserver::Result<Json<TokenCounts>> {
+    let mut transaction = app.sql.begin().await.map_err(Error::internal)?;
+
+    // Ensure the ID is valid first.
+    sqlx::query!("SELECT id FROM studios WHERE id = ?", id)
+        .fetch_optional(&mut transaction)
+        .await
+        .map_err(Error::internal)?
+        .ok_or_else(|| Error::new(ErrorKind::NotFound, "unknown code studio ID"))?;
+
+    if let Some(name) = patch.name {
+        sqlx::query!("UPDATE studios SET name = ? WHERE id = ?", name, id)
+            .execute(&mut transaction)
+            .await
+            .map_err(Error::internal)?;
+    }
+
+    if let Some(modified_at) = patch.modified_at {
+        sqlx::query!(
+            "UPDATE studios SET modified_at = ? WHERE id = ?",
+            modified_at,
+            id
+        )
+        .execute(&mut transaction)
+        .await
+        .map_err(Error::internal)?;
+    }
+
+    if let Some(context) = patch.context {
+        let json = serde_json::to_string(&context).unwrap();
+        sqlx::query!("UPDATE studios SET context = ? WHERE id = ?", json, id)
+            .execute(&mut transaction)
+            .await
+            .map_err(Error::internal)?;
+    }
+
+    if let Some(messages) = patch.messages {
+        let json = serde_json::to_string(&messages).unwrap();
+        sqlx::query!("UPDATE studios SET messages = ? WHERE id = ?", json, id)
+            .execute(&mut transaction)
+            .await
+            .map_err(Error::internal)?;
+    }
+
+    sqlx::query!("UPDATE studios SET modified_at = datetime('now') WHERE id = ?", id)
+        .execute(&mut transaction)
+        .await
+        .map_err(Error::internal)?;
+
+    // Re-fetch the context in case we didn't change it. If we did, this will now be the updated
+    // value.
+    let context_json = sqlx::query!("SELECT context FROM studios WHERE id = ?", id)
+        .fetch_optional(&mut transaction)
+        .await
+        .map_err(Error::internal)?
+        .map(|r| r.context)
+        .unwrap_or_default();
+
+    let context: Vec<ContextFile> =
+        serde_json::from_str(&context_json).context("invalid context JSON")?;
+
+    let counts = token_counts((*app).clone(), &context).await?;
+
+    transaction.commit().await.map_err(Error::internal)?;
+
+    Ok(Json(counts))
+}
+
+#[derive(serde::Serialize)]
+pub struct TokenCounts {
+    total: usize,
+    per_file: Vec<usize>,
+}
+
+async fn token_counts(app: Application, context: &[ContextFile]) -> webserver::Result<TokenCounts> {
+    let per_file = stream::iter(context)
+        .filter(|file| async { !file.hidden })
+        .then(|file| {
+            let app = app.clone();
+
+            async move {
+                let doc = app
+                    .indexes
+                    .file
+                    .by_path(&file.repo, &file.path, Some(&file.branch))
+                    .await
+                    .map_err(Error::internal)?
+                    .with_context(|| {
+                        format!(
+                            "file `{}` did not exist in repo `{}`, branch `{}`",
+                            file.path, file.repo, file.branch
+                        )
+                    })?;
+
+                let lines = doc.content.lines().collect::<Vec<_>>();
+
+                let mut token_count = 0;
+                for range in &file.ranges {
+                    let chunk = lines
+                        .iter()
+                        .copied()
+                        .skip(range.start)
+                        .take(range.end - range.start)
+                        .collect::<Vec<_>>()
+                        .join("\n");
+
+                    let core_bpe = tiktoken_rs::get_bpe_from_model("gpt-4-0613").unwrap();
+                    token_count += core_bpe.encode_ordinary(&chunk).len();
+                }
+
+                Ok::<_, Error>(token_count)
+            }
+        })
+        .try_collect::<Vec<_>>()
+        .await?;
+
+    Ok(TokenCounts {
+        total: per_file.iter().sum(),
+        per_file,
+    })
+}

--- a/server/bleep/src/webserver/studio.rs
+++ b/server/bleep/src/webserver/studio.rs
@@ -14,7 +14,10 @@ pub struct Create {
     name: String,
 }
 
-pub async fn create(app: Extension<Application>, params: Json<Create>) -> webserver::Result<()> {
+pub async fn create(
+    app: Extension<Application>,
+    params: Json<Create>,
+) -> webserver::Result<String> {
     let id = Uuid::new_v4().to_string();
 
     sqlx::query! {
@@ -28,7 +31,7 @@ pub async fn create(app: Extension<Application>, params: Json<Create>) -> webser
     .await
     .map_err(Error::internal)?;
 
-    Ok(())
+    Ok(id)
 }
 
 #[derive(serde::Serialize)]

--- a/server/bleep/src/webserver/studio.rs
+++ b/server/bleep/src/webserver/studio.rs
@@ -52,7 +52,7 @@ pub struct Studio {
     modified_at: NaiveDateTime,
     context: Vec<ContextFile>,
     messages: Vec<Message>,
-    token_count: usize,
+    token_counts: TokenCounts,
 }
 
 #[derive(serde::Serialize, serde::Deserialize)]
@@ -93,9 +93,9 @@ pub async fn get(
     Ok(Json(Studio {
         modified_at: row.modified_at,
         name: row.name,
+        token_counts: token_counts((*app).clone(), &context).await?,
         context,
         messages,
-        token_count: 0,
     }))
 }
 


### PR DESCRIPTION
This adds some new routes:

- `POST /studio`: Takes a body like `{ "name": "hello world" }`, returns an ID
- `GET /studio`: Returns a list of studios: `[{id: string, name: string, modified_at: string (e.g. 2023-08-23T14:25:23)}]`
- `GET /studio/:id`: Returns a specific studio: `{name, modified_at, context, messages, token_counts}`
- `PATCH /studio/:id`: Allows patching a studio by-field: `{name, modified_at, context, messages}`

The `context`, `messages`, and `token_counts` types are described here:

```
context: [
  {
    path: string,
    branch: string,
    repo: RepoRef (string),
    hidden: boolean,
    ranges: [ { start: 0-based line index, end: 0-based line index (exclusive) } ],
  }
]
```

```
messages: [
  { "User" || "Assistant": string }
]
```

```
token_counts: {
  total: number,
  per_file: [number],
}
```

The `token_count.per_file` array returns a list of numbers corresponding to token counts of *all* files in the context, in the *order* which these context files are stored.

Closes BLO-1449 and BLO-1451