### PR TITLE
Add `/studio/:id/generate` for response generation

### DIFF
--- a/server/bleep/sqlx-data.json
+++ b/server/bleep/sqlx-data.json
@@ -392,6 +392,30 @@
     },
     "query": "SELECT repo_ref, exchanges FROM conversations WHERE user_id = ? AND thread_id = ?"
   },
+  "e5aef852b8c69dd4fade0bf5deee0406aa883d5cf399740223e71659139188e2": {
+    "describe": {
+      "columns": [
+        {
+          "name": "messages",
+          "ordinal": 0,
+          "type_info": "Text"
+        },
+        {
+          "name": "context",
+          "ordinal": 1,
+          "type_info": "Text"
+        }
+      ],
+      "nullable": [
+        false,
+        false
+      ],
+      "parameters": {
+        "Right": 1
+      }
+    },
+    "query": "SELECT messages, context FROM studios WHERE id = ?"
+  },
   "ed6379e37c16064198f48dbfb91899d74eb346533e3c9ab3814ba67b68d71f51": {
     "describe": {
       "columns": [],

--- a/server/bleep/src/agent.rs
+++ b/server/bleep/src/agent.rs
@@ -19,8 +19,8 @@ use crate::{
 use self::exchange::{Exchange, SearchStep, Update};
 
 pub mod exchange;
-mod prompts;
-mod transcoder;
+pub mod prompts;
+pub mod transcoder;
 
 /// A collection of modules that each add methods to `Agent`.
 ///

--- a/server/bleep/src/agent/prompts.rs
+++ b/server/bleep/src/agent/prompts.rs
@@ -149,7 +149,10 @@ A: "#
     )
 }
 
-pub fn answer_article_prompt(aliases: &[usize], context: &str) -> String {
+/// Generate an answer article prompt.
+///
+/// The `multi` argument determines whether to use the "multiple file" variant of this prompt.
+pub fn answer_article_prompt(multi: bool, context: &str) -> String {
     // Return different prompts depending on whether there is one or many aliases
     let one_prompt = format!(
         r#"{context}#####
@@ -177,7 +180,6 @@ Provide only as much information and code as is necessary to answer the query, b
 When referring to code, you must provide an example in a code block.
 
 Respect these rules at all times:
-- Do not refer to paths by alias, expand to the full path
 - Link ALL paths AND code symbols (functions, methods, fields, classes, structs, types, variables, values, definitions, directories, etc) by embedding them in a markdown link, with the URL corresponding to the full path, and the anchor following the form `LX` or `LX-LY`, where X represents the starting line number, and Y represents the ending line number, if the reference is more than one line.
   - For example, to refer to lines 50 to 78 in a sentence, respond with something like: The compiler is initialized in [`src/foo.rs`](src/foo.rs#L50-L78)
   - For example, to refer to the `new` function on a struct, respond with something like: The [`new`](src/bar.rs#L26-53) function initializes the struct
@@ -228,10 +230,10 @@ println!("hello world!");
 - You MUST use XML code blocks instead of markdown."#
     );
 
-    if aliases.len() == 1 {
-        one_prompt
-    } else {
+    if multi {
         many_prompt
+    } else {
+        one_prompt
     }
 }
 

--- a/server/bleep/src/agent/prompts.rs
+++ b/server/bleep/src/agent/prompts.rs
@@ -237,6 +237,19 @@ println!("hello world!");
     }
 }
 
+pub fn studio_article_prompt(context: &str) -> String {
+    format!(
+        r#"{context}Your job is to answer a query about a codebase using the information above.
+
+Provide only as much information and code as is necessary to answer the query, but be concise. Keep number of quoted lines to a minimum when possible. If you do not have enough information needed to answer the query, do not make up an answer.
+When referring to code, you must provide an example in a code block.
+
+Respect these rules at all times:
+- Always begin your answer with an appropriate title
+"#
+    )
+}
+
 pub fn hypothetical_document_prompt(query: &str) -> String {
     format!(
         r#"Write a code snippet that could hypothetically be returned by a code search engine as the answer to the query: {query}

--- a/server/bleep/src/agent/tools/answer.rs
+++ b/server/bleep/src/agent/tools/answer.rs
@@ -41,7 +41,7 @@ impl Agent {
         }
 
         let context = self.answer_context(aliases, ANSWER_MODEL).await?;
-        let system_prompt = prompts::answer_article_prompt(aliases, &context);
+        let system_prompt = prompts::answer_article_prompt(aliases.len() != 1, &context);
         let system_message = llm_gateway::api::Message::system(&system_prompt);
         let history = {
             let h = self.utter_history().collect::<Vec<_>>();

--- a/server/bleep/src/webserver.rs
+++ b/server/bleep/src/webserver.rs
@@ -74,7 +74,8 @@ pub async fn start(app: Application) -> anyhow::Result<()> {
         .route("/studio", post(studio::create))
         .route("/studio", get(studio::list))
         .route("/studio/:id", get(studio::get))
-        .route("/studio/:id", patch(studio::patch));
+        .route("/studio/:id", patch(studio::patch))
+        .route("/studio/:id/generate", post(studio::generate));
 
     if app.env.allow(Feature::AnyPathScan) {
         api = api.route("/repos/scan", get(repos::scan_local));

--- a/server/bleep/src/webserver.rs
+++ b/server/bleep/src/webserver.rs
@@ -75,7 +75,7 @@ pub async fn start(app: Application) -> anyhow::Result<()> {
         .route("/studio", get(studio::list))
         .route("/studio/:id", get(studio::get))
         .route("/studio/:id", patch(studio::patch))
-        .route("/studio/:id/generate", post(studio::generate));
+        .route("/studio/:id/generate", get(studio::generate));
 
     if app.env.allow(Feature::AnyPathScan) {
         api = api.route("/repos/scan", get(repos::scan_local));

--- a/server/bleep/src/webserver/studio.rs
+++ b/server/bleep/src/webserver/studio.rs
@@ -364,15 +364,23 @@ async fn generate_llm_context(app: Application, context: Vec<ContextFile>) -> Re
                 )
             })?;
 
-        let lines = doc.content.lines().collect::<Vec<_>>();
+        let lines = doc.content.lines()
+            .enumerate()
+            .map(|(i, s)| format!("{} {s}\n", i + 1))
+            .collect::<Vec<_>>();
 
-        for range in &file.ranges {
+        let ranges = if file.ranges.is_empty() {
+            vec![0..lines.len()]
+        } else {
+            file.ranges.clone()
+        };
+
+        for range in ranges {
             let snippet = lines
                 .iter()
-                .enumerate()
                 .skip(range.start)
                 .take(range.end - range.start)
-                .map(|(i, s)| format!("{i} {s}\n"))
+                .map(String::as_str)
                 .collect::<String>();
 
             s += &format!("### {} ###\n{snippet}\n", file.path);

--- a/server/bleep/src/webserver/studio.rs
+++ b/server/bleep/src/webserver/studio.rs
@@ -1,13 +1,25 @@
-use std::ops::Range;
+use std::{iter, ops::Range, pin::Pin};
 
-use anyhow::Context;
-use axum::{extract::Path, Extension, Json};
+use anyhow::{Context, Result};
+use axum::{
+    extract::Path,
+    response::{sse, Sse},
+    Extension, Json,
+};
 use chrono::NaiveDateTime;
-use futures::{stream, StreamExt, TryStreamExt};
+use futures::{pin_mut, stream, StreamExt, TryStreamExt};
+use reqwest::StatusCode;
+use secrecy::ExposeSecret;
+use tracing::error;
 use uuid::Uuid;
 
 use super::{Error, ErrorKind};
-use crate::{repo::RepoRef, webserver, Application};
+use crate::{
+    agent::{prompts, transcoder},
+    llm_gateway,
+    repo::RepoRef,
+    webserver, Application,
+};
 
 #[derive(serde::Deserialize)]
 pub struct Create {
@@ -73,6 +85,31 @@ enum Message {
     Assistant(String),
 }
 
+impl Message {
+    fn encode(&self) -> Self {
+        match self {
+            Self::User(s) => Self::User(s.clone()),
+            Self::Assistant(s) => Self::Assistant(transcoder::encode(s, None)),
+        }
+    }
+
+    fn decode(&self) -> Self {
+        match self {
+            Self::User(s) => Self::User(s.clone()),
+            Self::Assistant(s) => Self::Assistant(transcoder::decode(s).0),
+        }
+    }
+}
+
+impl From<&Message> for llm_gateway::api::Message {
+    fn from(value: &Message) -> Self {
+        match value {
+            Message::User(s) => llm_gateway::api::Message::user(s),
+            Message::Assistant(s) => llm_gateway::api::Message::assistant(s),
+        }
+    }
+}
+
 pub async fn get(
     app: Extension<Application>,
     Path(id): Path<String>,
@@ -90,8 +127,11 @@ pub async fn get(
 
     let context: Vec<ContextFile> =
         serde_json::from_str(&row.context).context("failed to deserialize context")?;
-    let messages: Vec<Message> =
-        serde_json::from_str(&row.messages).context("failed to deserialize message list")?;
+    let messages = serde_json::from_str::<Vec<Message>>(&row.messages)
+        .context("failed to deserialize message list")?
+        .into_iter()
+        .map(|m| m.decode())
+        .collect();
 
     Ok(Json(Studio {
         modified_at: row.modified_at,
@@ -151,7 +191,9 @@ pub async fn patch(
     }
 
     if let Some(messages) = patch.messages {
-        let json = serde_json::to_string(&messages).unwrap();
+        let encoded = messages.into_iter().map(|m| m.encode()).collect::<Vec<_>>();
+
+        let json = serde_json::to_string(&encoded).unwrap();
         sqlx::query!("UPDATE studios SET messages = ? WHERE id = ?", json, id)
             .execute(&mut transaction)
             .await
@@ -244,4 +286,125 @@ async fn token_counts(app: Application, context: &[ContextFile]) -> webserver::R
         total: per_file.iter().sum(),
         per_file,
     })
+}
+
+pub async fn generate(
+    app: Extension<Application>,
+    Path(id): Path<String>,
+) -> webserver::Result<Sse<Pin<Box<dyn tokio_stream::Stream<Item = Result<sse::Event>> + Send>>>> {
+    let answer_api_token = app
+        .answer_api_token()
+        .map_err(|e| Error::user(e).with_status(StatusCode::UNAUTHORIZED))?
+        .map(|s| s.expose_secret().clone());
+
+    let llm_gateway = llm_gateway::Client::new(&app.config.answer_api_url)
+        .temperature(0.0)
+        .bearer(answer_api_token);
+
+    let (messages_json, context_json) =
+        sqlx::query!("SELECT messages, context FROM studios WHERE id = ?", id)
+            .fetch_optional(&*app.sql)
+            .await
+            .map_err(Error::internal)?
+            .map(|row| (row.messages, row.context))
+            .ok_or_else(|| Error::new(ErrorKind::NotFound, "unknown code studio ID"))?;
+
+    let mut messages =
+        serde_json::from_str::<Vec<Message>>(&messages_json).map_err(Error::internal)?;
+
+    let context =
+        serde_json::from_str::<Vec<ContextFile>>(&context_json).map_err(Error::internal)?;
+
+    let llm_context = generate_llm_context((*app).clone(), context).await?;
+    let system_prompt = prompts::answer_article_prompt(true, &llm_context);
+    let llm_messages = iter::once(llm_gateway::api::Message::system(&system_prompt))
+        .chain(messages.iter().map(llm_gateway::api::Message::from))
+        .collect::<Vec<_>>();
+
+    let tokens = llm_gateway
+        .chat(&llm_messages, None)
+        .await
+        .map_err(Error::internal)?;
+
+    let stream = async_stream::try_stream! {
+        pin_mut!(tokens);
+
+        let mut response = String::new();
+
+        while let Some(fragment) = tokens.next().await {
+            let fragment = fragment?;
+            response += &fragment;
+            let (body, _) = transcoder::decode(&response);
+            yield body;
+        }
+
+        messages.push(Message::Assistant(response));
+        let messages_json = serde_json::to_string(&messages).unwrap();
+        sqlx::query!("UPDATE studios SET messages = ? WHERE id = ?", messages_json, id)
+            .execute(&*app.sql)
+            .await?;
+    };
+
+    let mut errored = false;
+    let stream = stream.take_while(move |e| {
+        let ok = !errored;
+        if let Err(e) = &e {
+            error!(?e, "stream error");
+            errored = true;
+        }
+        async move { ok }
+    });
+
+    let event_stream = stream.map(|result| {
+        sse::Event::default()
+            .json_data(result.map_err(|e: anyhow::Error| e.to_string()))
+            .map_err(anyhow::Error::new)
+    });
+    let done_stream = stream::once(async { Ok(sse::Event::default().data("[DONE]")) });
+
+    let stream = event_stream.chain(done_stream);
+
+    Ok(Sse::new(Box::pin(stream)))
+}
+
+async fn generate_llm_context(app: Application, context: Vec<ContextFile>) -> Result<String> {
+    let mut s = String::new();
+
+    s += "##### PATHS #####\n";
+
+    for file in context.iter().filter(|f| !f.hidden) {
+        s += &format!("{}\n", file.path);
+    }
+
+    s += "\n##### CODE CHUNKS #####\n\n";
+
+    for file in context.iter().filter(|f| !f.hidden) {
+        let doc = app
+            .indexes
+            .file
+            .by_path(&file.repo, &file.path, Some(&file.branch))
+            .await?
+            .with_context(|| {
+                format!(
+                    "file `{}` did not exist in repo `{}`, branch `{}`",
+                    file.path, file.repo, file.branch
+                )
+            })?;
+
+        let lines = doc.content.lines().collect::<Vec<_>>();
+
+        for range in &file.ranges {
+            let snippet = lines
+                .iter()
+                .enumerate()
+                .skip(range.start)
+                .take(range.end - range.start)
+                .map(|(i, s)| format!("{i} {s}\n"))
+                .collect::<String>();
+
+            s += &format!("### {} ###\n{snippet}\n", file.path);
+        }
+    }
+
+    Ok(s)
 }


### PR DESCRIPTION
This route returns an SSE stream of `Result<String, String>`, which are JSON objects that look like:

```
{"Ok":"Some generated answer..."}
```

Or in the event of an error, with an error string:

```
{"Err":"some error string..."}
```

Streams are terminated with a `[DONE]` message.