### PR TITLE
Add `/studio/import`

### DIFF
--- a/server/bleep/sqlx-data.json
+++ b/server/bleep/sqlx-data.json
@@ -350,6 +350,36 @@
     },
     "query": "INSERT INTO file_cache (repo_ref, cache_hash) VALUES (?, ?)"
   },
+  "db11e62332a30ef95bf437eabcee804c17820c2c7bb760eb143e3ff587524e43": {
+    "describe": {
+      "columns": [
+        {
+          "name": "title",
+          "ordinal": 0,
+          "type_info": "Text"
+        },
+        {
+          "name": "repo_ref",
+          "ordinal": 1,
+          "type_info": "Text"
+        },
+        {
+          "name": "exchanges",
+          "ordinal": 2,
+          "type_info": "Text"
+        }
+      ],
+      "nullable": [
+        false,
+        false,
+        false
+      ],
+      "parameters": {
+        "Right": 2
+      }
+    },
+    "query": "SELECT title, repo_ref, exchanges\n         FROM conversations\n         WHERE user_id = ? AND thread_id = ?"
+  },
   "db80c758eb137530e6aad6e83778efcea787dfdf42f95b896ac482d3ffac2cfe": {
     "describe": {
       "columns": [

--- a/server/bleep/src/repo.rs
+++ b/server/bleep/src/repo.rs
@@ -198,13 +198,13 @@ impl BranchFilter {
     pub(crate) fn patch(&self, old: Option<&BranchFilter>) -> Option<BranchFilter> {
         let Some(BranchFilter::Select(ref old_list)) = old
         else {
-	    return Some(self.clone());
-	};
+            return Some(self.clone());
+        };
 
         let BranchFilter::Select(new_list) = self
         else {
-	    return Some(self.clone());
-	};
+            return Some(self.clone());
+        };
 
         let mut updated = old_list.iter().collect::<BTreeSet<_>>();
         updated.extend(new_list);

--- a/server/bleep/src/webserver.rs
+++ b/server/bleep/src/webserver.rs
@@ -75,7 +75,8 @@ pub async fn start(app: Application) -> anyhow::Result<()> {
         .route("/studio", get(studio::list))
         .route("/studio/:id", get(studio::get))
         .route("/studio/:id", patch(studio::patch))
-        .route("/studio/:id/generate", get(studio::generate));
+        .route("/studio/:id/generate", get(studio::generate))
+        .route("/studio/import", post(studio::import));
 
     if app.env.allow(Feature::AnyPathScan) {
         api = api.route("/repos/scan", get(repos::scan_local));

--- a/server/bleep/src/webserver/studio.rs
+++ b/server/bleep/src/webserver/studio.rs
@@ -453,23 +453,7 @@ pub async fn import(
         })
         .collect::<Vec<_>>();
 
-    let messages = exchanges
-        .iter()
-        .filter_map(|e| {
-            let query = e.query()?;
-            let (answer, _) = e.answer()?;
-            Some((query, answer))
-        })
-        .flat_map(|(query, answer)| {
-            [
-                Message::User(query),
-                Message::Assistant(answer.to_owned()),
-            ]
-        })
-        .collect::<Vec<_>>();
-
     let context_json = serde_json::to_string(&context).unwrap();
-    let messages_json = serde_json::to_string(&messages).unwrap();
 
     let studio_id = Uuid::new_v4();
     let studio_id_str = studio_id.to_string();
@@ -479,7 +463,7 @@ pub async fn import(
         studio_id_str,
         conversation.title,
         context_json,
-        messages_json,
+        "[]",
     }
     .execute(&*app.sql)
     .await

--- a/server/bleep/src/webserver/studio.rs
+++ b/server/bleep/src/webserver/studio.rs
@@ -456,13 +456,13 @@ pub async fn import(
     let messages = exchanges
         .iter()
         .filter_map(|e| {
-            let query = e.query.target()?;
+            let query = e.query()?;
             let (answer, _) = e.answer()?;
             Some((query, answer))
         })
         .flat_map(|(query, answer)| {
             [
-                Message::User(query.into_owned()),
+                Message::User(query),
                 Message::Assistant(answer.to_owned()),
             ]
         })


### PR DESCRIPTION
This route accepts a query parameter in the form `?thread_id=...`. It must be called from a logged-in state. When successful, it will return a string for the new studio ID.

A new studio is created with a name equal to the the conversation title, and its messages and context are imported, collapsing exchange code chunks and extracting query/answer pairs.

Additionally, `studio.context` JSON objects have been modified such that `branch` is now optional.

Closes BLO-1454