### PR TITLE
Ensure consistency of semantic & tantivy & caches

### DIFF
--- a/server/bleep/src/indexes/file.rs
+++ b/server/bleep/src/indexes/file.rs
@@ -122,11 +122,7 @@ impl Indexable for File {
                     warn!(%err, entry_disk_path, "indexing failed; skipping");
                 }
 
-                let commit_embeddings = tokio::task::block_in_place(|| {
-                    Handle::current()
-                        .block_on(async { cache.parent().batched_process_embed_queue(false).await })
-                });
-                if let Err(err) = commit_embeddings {
+                if let Err(err) = cache.parent().process_embedding_queue() {
                     warn!(?err, "failed to commit embeddings");
                 }
             }

--- a/server/bleep/src/indexes/file.rs
+++ b/server/bleep/src/indexes/file.rs
@@ -440,10 +440,7 @@ impl File {
         let last_commit = workload.repo_metadata.last_commit_unix_secs.unwrap_or(0);
 
         match dir_entry {
-            _ if workload
-                .cache
-                .is_fresh(&cache_keys, &workload.normalized_path) =>
-            {
+            _ if workload.cache.is_fresh(&cache_keys) => {
                 info!("fresh; skipping");
                 return Ok(());
             }

--- a/server/bleep/src/semantic.rs
+++ b/server/bleep/src/semantic.rs
@@ -452,17 +452,17 @@ impl Semantic {
     }
 
     #[allow(clippy::too_many_arguments)]
-    #[tracing::instrument(skip(self, repo_name, buffer, chunk_cache))]
-    pub async fn insert_points_for_buffer(
-        &self,
-        repo_name: &str,
-        repo_ref: &str,
-        relative_path: &str,
-        buffer: &str,
-        lang_str: &str,
-        branches: &[String],
-        chunk_cache: crate::cache::ChunkCache<'_>,
-    ) {
+    #[tracing::instrument(skip(self, repo_name, buffer))]
+    pub fn chunks_for_buffer<'a>(
+        &'a self,
+        file_cache_key: String,
+        repo_name: &'a str,
+        repo_ref: &'a str,
+        relative_path: &'a str,
+        buffer: &'a str,
+        lang_str: &'a str,
+        branches: &'a [String],
+    ) -> impl ParallelIterator<Item = (String, Payload)> + 'a {
         const MIN_CHUNK_TOKENS: usize = 50;
 
         let chunks = chunk::by_tokens(
@@ -475,13 +475,13 @@ impl Semantic {
         );
         debug!(chunk_count = chunks.len(), "found chunks");
 
-        chunks.par_iter().for_each(|chunk| {
-            let data = format!("{repo_name}\t{relative_path}\n{}", chunk.data,);
+        chunks.into_par_iter().map(move |chunk| {
+            let data = format!("{repo_name}\t{relative_path}\n{}", chunk.data);
             let payload = Payload {
                 repo_name: repo_name.to_owned(),
                 repo_ref: repo_ref.to_owned(),
                 relative_path: relative_path.to_owned(),
-                content_hash: chunk_cache.file_hash(),
+                content_hash: file_cache_key.to_string(),
                 text: chunk.data.to_owned(),
                 lang: lang_str.to_ascii_lowercase(),
                 branches: branches.to_owned(),
@@ -492,23 +492,8 @@ impl Semantic {
                 ..Default::default()
             };
 
-            let cached = chunk_cache.update_or_embed(&data, payload);
-            if let Err(err) = cached {
-                warn!(?err, %repo_name, %relative_path, "embedding failed");
-            }
-        });
-
-        match chunk_cache.commit().await {
-            Ok((new, updated, deleted)) => {
-                info!(
-                    repo_name,
-                    relative_path, new, updated, deleted, "Successful commit"
-                )
-            }
-            Err(err) => {
-                warn!(repo_name, relative_path, ?err, "Failed to upsert vectors")
-            }
-        }
+            (data, payload)
+        })
     }
 
     pub async fn delete_points_for_hash(


### PR DESCRIPTION
Since the tracking of semantic & tantivy is done with different uniqueness constraints, the wrong key was used to delete stale chunks from qdrant, therefore nothing was deleted.

This PR unifies the handling of the 2 keys (`CacheKeys`), the tracking of changes, and defines one explicit synchronization point where everything needs to line up. All semantic db work now goes through the `ChunkCache`.

Overall this is an improvement to the mess we have in our file indexing logic, and creates better separation & dependency structure between the involved components. Some code moved around as a result. Maybe as next steps we should break out more files with the involved components to make navigation better.

Builds on #882.