### PR TITLE
Store incomplete conversations

### DIFF
--- a/server/bleep/src/agent.rs
+++ b/server/bleep/src/agent.rs
@@ -1,9 +1,9 @@
-use std::time::Duration;
+use std::{sync::Arc, time::Duration};
 
 use anyhow::{anyhow, Context, Result};
-use futures::TryStreamExt;
+use futures::{Future, TryStreamExt};
 use tokio::sync::mpsc::Sender;
-use tracing::{debug, info, instrument};
+use tracing::{debug, error, info, instrument};
 
 use crate::{
     analytics::{EventData, QueryEvent},
@@ -12,7 +12,10 @@ use crate::{
     query::parser,
     repo::RepoRef,
     semantic,
-    webserver::middleware::User,
+    webserver::{
+        answer::conversations::{self, ConversationId},
+        middleware::User,
+    },
     Application,
 };
 
@@ -55,7 +58,13 @@ pub struct Agent {
     /// Indicate whether the request was answered.
     ///
     /// This is used in the `Drop` handler, in order to track cancelled answer queries.
-    pub complete: bool,
+    pub exchange_state: ExchangeState,
+}
+
+pub enum ExchangeState {
+    Pending,
+    Complete,
+    Failed,
 }
 
 /// We use a `Drop` implementation to track agent query cancellation.
@@ -68,20 +77,33 @@ pub struct Agent {
 /// `.complete()` will "diffuse" tracking, and disable the cancellation message from sending on drop.
 impl Drop for Agent {
     fn drop(&mut self) {
-        if !self.complete {
-            self.track_query(
-                EventData::output_stage("cancelled")
-                    .with_payload("message", "request was cancelled"),
-            );
+        match self.exchange_state {
+            ExchangeState::Failed => {},
+            ExchangeState::Pending => {
+                self.track_query(
+                    EventData::output_stage("cancelled")
+                        .with_payload("message", "request was cancelled"),
+                );
+
+                tokio::spawn(self.store());
+            }
+
+            ExchangeState::Complete => {
+                tokio::spawn(self.store());
+            }
         }
     }
 }
 
 impl Agent {
     /// Complete this agent, preventing an analytics message from sending on drop.
-    pub fn complete(mut self) {
+    pub fn complete(&mut self, success: bool) {
         // Checked in `Drop::drop`
-        self.complete = true;
+        self.exchange_state = if success {
+            ExchangeState::Complete
+        } else {
+            ExchangeState::Failed
+        };
     }
 
     /// Update the last exchange
@@ -353,6 +375,36 @@ impl Agent {
             .file
             .fuzzy_path_match(&self.repo_ref, query, branch.as_deref(), 50)
             .await
+    }
+
+    /// Store the conversation in the DB.
+    ///
+    /// This allows us to make subsequent requests.
+    // NB: This isn't an `async fn` so as to not capture a lifetime.
+    fn store(&mut self) -> impl Future<Output = ()> {
+        let sql = Arc::clone(&self.app.sql);
+        let conversation = (self.repo_ref.clone(), self.exchanges.clone());
+        let conversation_id = self
+            .user
+            .login()
+            .context("didn't have user ID")
+            .map(|user_id| ConversationId {
+                thread_id: self.thread_id,
+                user_id: user_id.to_owned(),
+            });
+
+        async move {
+            let result = match conversation_id {
+                Ok(conversation_id) => {
+                    conversations::store(&sql, conversation_id, conversation).await
+                }
+                Err(e) => Err(e),
+            };
+
+            if let Err(e) = result {
+                error!("failed to store conversation: {e}");
+            }
+        }
     }
 }
 

--- a/server/bleep/src/agent.rs
+++ b/server/bleep/src/agent.rs
@@ -80,6 +80,8 @@ impl Drop for Agent {
         match self.exchange_state {
             ExchangeState::Failed => {}
             ExchangeState::Pending => {
+                self.last_exchange_mut().apply_update(Update::Cancel);
+
                 self.track_query(
                     EventData::output_stage("cancelled")
                         .with_payload("message", "request was cancelled"),

--- a/server/bleep/src/agent.rs
+++ b/server/bleep/src/agent.rs
@@ -78,7 +78,7 @@ pub enum ExchangeState {
 impl Drop for Agent {
     fn drop(&mut self) {
         match self.exchange_state {
-            ExchangeState::Failed => {},
+            ExchangeState::Failed => {}
             ExchangeState::Pending => {
                 self.track_query(
                     EventData::output_stage("cancelled")

--- a/server/bleep/src/agent/exchange.rs
+++ b/server/bleep/src/agent/exchange.rs
@@ -2,6 +2,7 @@ use crate::query::parser::SemanticQuery;
 use std::{fmt, mem};
 
 use chrono::prelude::{DateTime, Utc};
+use rand::seq::SliceRandom;
 
 /// A continually updated conversation exchange.
 ///
@@ -64,6 +65,20 @@ impl Exchange {
             }
             Update::Focus(chunk) => {
                 self.focused_chunk = Some(chunk);
+            }
+            Update::Cancel => {
+                let conclusion = [
+                    "The article wasn't completed. See what's available",
+                    "Your article stopped before completion. Check out the available content",
+                    "The content stopped generating early. Review the initial response",
+                ]
+                .choose(&mut rand::thread_rng())
+                .copied()
+                .unwrap()
+                .to_owned();
+
+                self.conclusion = Some(conclusion);
+                self.response_timestamp = Some(Utc::now());
             }
         }
     }
@@ -191,4 +206,5 @@ pub enum Update {
     Article(String),
     Conclude(String),
     Focus(FocusedChunk),
+    Cancel,
 }


### PR DESCRIPTION
Now, conversations will persist in the database even if they do not properly complete. Failed conversations are still not persisted with this change, intentionally.

Closes BLO-1364