### PR TITLE
replace levenshtein fuzzy matching with skim fuzzy matcher

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -493,6 +493,7 @@ dependencies = [
  "expect-test",
  "flume",
  "futures",
+ "fuzzy-matcher",
  "git-version",
  "gix",
  "histogram",
@@ -2048,6 +2049,15 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "fuzzy-matcher"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94"
+dependencies = [
+ "thread_local",
 ]
 
 [[package]]

--- a/server/bleep/Cargo.toml
+++ b/server/bleep/Cargo.toml
@@ -39,6 +39,7 @@ tracing-subscriber = { version = "0.3.17", features = ["env-filter", "registry"]
 tracing-appender = "0.2.2"
 color-eyre = "0.6.2"
 sqlx = { version = "0.6.3", features = ["sqlite", "migrate", "offline", "runtime-tokio-rustls", "chrono"] }
+fuzzy-matcher = "0.3.7"
 
 # for debugging
 console-subscriber = { version = "0.1.10", optional = true }

--- a/server/bleep/src/collector/bytes_filter.rs
+++ b/server/bleep/src/collector/bytes_filter.rs
@@ -36,7 +36,7 @@ where
 impl<TCollector, TPredicate> Collector for BytesFilterCollector<TCollector, TPredicate>
 where
     TCollector: Collector + Send + Sync,
-    TPredicate: 'static + Fn(&[u8]) -> bool + Send + Sync + Clone,
+    TPredicate: Fn(&[u8]) -> bool + Send + Sync + Clone,
 {
     // That's the type of our result.
     // Our standard deviation will be a float.

--- a/server/bleep/src/webserver/search.rs
+++ b/server/bleep/src/webserver/search.rs
@@ -55,7 +55,7 @@ pub(super) async fn fuzzy_path(
 
     let data = indexes
         .file
-        .fuzzy_path_match(
+        .skim_fuzzy_path_match(
             repo_ref,
             target,
             q.first_branch().as_deref(),


### PR DESCRIPTION
this should work more like how sublime text's search. generally, the
following changes in behavior are expected:

- better search results for camel and snake-case identifiers: a corpus
  containing `scope_resolution` is matched by `scores`
- ranks prefix matches higher: `res` matches both `resolution` and
  `progress`, but `resolution` will be ranked higher
- ranks file hits higher than directory hits
- ranks documents with hits near the file-stem higher than those with
  hits around the ancestor directories