### PR TITLE
 Track studio generation and import events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6508,6 +6508,7 @@ dependencies = [
  "thiserror",
  "tokio-stream",
  "url",
+ "uuid",
  "webpki-roots 0.22.6",
 ]
 

--- a/apps/desktop/src-tauri/src/backend.rs
+++ b/apps/desktop/src-tauri/src/backend.rs
@@ -12,7 +12,10 @@ use super::{Manager, Payload, Runtime};
 use super::TELEMETRY;
 
 #[cfg(test)]
-static TELEMETRY: std::sync::RwLock<bool> = std::sync::RwLock::new(false);
+use {once_cell::sync::Lazy, std::sync::RwLock};
+
+#[cfg(test)]
+static TELEMETRY: Lazy<Arc<RwLock<bool>>> = Lazy::new(|| Arc::new(RwLock::new(false)));
 
 #[cfg(test)]
 fn get_device_id() -> String {
@@ -92,10 +95,7 @@ async fn start_backend<R: Runtime>(configuration: Configuration, app: tauri::App
         configuration,
         get_device_id(),
         analytics::HubOptions {
-            event_filter: Some(Arc::new(|event| match *TELEMETRY.read().unwrap() {
-                true => Some(event),
-                false => None,
-            })),
+            enable_telemetry: Arc::clone(&TELEMETRY),
             package_metadata: Some(analytics::PackageMetadata {
                 name: env!("CARGO_CRATE_NAME"),
                 version: env!("CARGO_PKG_VERSION"),

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -6,11 +6,15 @@
 mod backend;
 mod qdrant;
 
+use once_cell::sync::Lazy;
 pub use tauri::{plugin, App, Manager, Runtime};
 
-use std::{path::PathBuf, sync::RwLock};
+use std::{
+    path::PathBuf,
+    sync::{Arc, RwLock},
+};
 
-pub static TELEMETRY: RwLock<bool> = RwLock::new(false);
+pub static TELEMETRY: Lazy<Arc<RwLock<bool>>> = Lazy::new(|| Arc::new(RwLock::new(false)));
 
 // the payload type must implement `Serialize` and `Clone`.
 #[derive(Clone, serde::Serialize)]

--- a/server/bleep/Cargo.toml
+++ b/server/bleep/Cargo.toml
@@ -38,7 +38,7 @@ tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter", "registry"] }
 tracing-appender = "0.2.2"
 color-eyre = "0.6.2"
-sqlx = { version = "0.6.3", features = ["sqlite", "migrate", "offline", "runtime-tokio-rustls", "chrono"] }
+sqlx = { version = "0.6.3", features = ["sqlite", "migrate", "offline", "runtime-tokio-rustls", "chrono", "uuid"] }
 fuzzy-matcher = "0.3.7"
 
 # for debugging

--- a/server/bleep/migrations/20230831170927_code_studio_uuid_blob.sql
+++ b/server/bleep/migrations/20230831170927_code_studio_uuid_blob.sql
@@ -1,0 +1,14 @@
+-- We re-create `studios`, with the `id` type as `BLOB` this time.
+
+DROP TABLE studios;
+CREATE TABLE studios (
+    -- UUID
+    id BLOB NOT NULL,
+
+    name TEXT NOT NULL,
+    modified_at DATETIME NOT NULL DEFAULT (datetime('now')),
+
+    -- JSON serialized fields
+    context TEXT NOT NULL,
+    messages TEXT NOT NULL
+);

--- a/server/bleep/sqlx-data.json
+++ b/server/bleep/sqlx-data.json
@@ -80,7 +80,7 @@
         {
           "name": "id",
           "ordinal": 0,
-          "type_info": "Text"
+          "type_info": "Blob"
         },
         {
           "name": "name",
@@ -122,7 +122,7 @@
         {
           "name": "id",
           "ordinal": 0,
-          "type_info": "Text"
+          "type_info": "Blob"
         }
       ],
       "nullable": [
@@ -133,42 +133,6 @@
       }
     },
     "query": "DELETE FROM studios WHERE id = ? RETURNING id"
-  },
-  "34c0a1743016c76a50f543623940632f1e9daaf4233df7239d972e58ba05f3f3": {
-    "describe": {
-      "columns": [
-        {
-          "name": "id",
-          "ordinal": 0,
-          "type_info": "Text"
-        },
-        {
-          "name": "name",
-          "ordinal": 1,
-          "type_info": "Text"
-        },
-        {
-          "name": "modified_at",
-          "ordinal": 2,
-          "type_info": "Datetime"
-        },
-        {
-          "name": "context",
-          "ordinal": 3,
-          "type_info": "Text"
-        }
-      ],
-      "nullable": [
-        false,
-        false,
-        false,
-        false
-      ],
-      "parameters": {
-        "Right": 0
-      }
-    },
-    "query": "SELECT id, name, modified_at, context FROM studios"
   },
   "392b563bb3af6711817fe99335d053691750426762dcde7b0381dc9f69cd804e": {
     "describe": {
@@ -318,6 +282,42 @@
     },
     "query": "UPDATE templates SET modified_at = datetime('now') WHERE id = ?"
   },
+  "5f891519fb8bdd247e2a3dc45a7966709a7a09bf2709dfd5196b14dd2b13c39c": {
+    "describe": {
+      "columns": [
+        {
+          "name": "id: Uuid",
+          "ordinal": 0,
+          "type_info": "Blob"
+        },
+        {
+          "name": "name",
+          "ordinal": 1,
+          "type_info": "Text"
+        },
+        {
+          "name": "modified_at",
+          "ordinal": 2,
+          "type_info": "Datetime"
+        },
+        {
+          "name": "context",
+          "ordinal": 3,
+          "type_info": "Text"
+        }
+      ],
+      "nullable": [
+        false,
+        false,
+        false,
+        false
+      ],
+      "parameters": {
+        "Right": 0
+      }
+    },
+    "query": "SELECT id as \"id: Uuid\", name, modified_at, context FROM studios"
+  },
   "69e7fcbe274e645ac8dece40ddad39b5f594731e4647a683f4537ede7e20b3d4": {
     "describe": {
       "columns": [],
@@ -430,7 +430,7 @@
         {
           "name": "id",
           "ordinal": 0,
-          "type_info": "Text"
+          "type_info": "Blob"
         }
       ],
       "nullable": [

--- a/server/bleep/src/analytics.rs
+++ b/server/bleep/src/analytics.rs
@@ -1,4 +1,7 @@
-use std::sync::Arc;
+use std::{
+    fmt::Debug,
+    sync::{Arc, RwLock},
+};
 
 use crate::{
     repo::RepoRef,
@@ -12,19 +15,51 @@ use rudderanalytics::{
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use tracing::{info, warn};
+use uuid::Uuid;
 
 #[derive(Debug, Clone)]
 pub struct QueryEvent {
-    pub query_id: uuid::Uuid,
-    pub thread_id: uuid::Uuid,
+    pub query_id: Uuid,
+    pub thread_id: Uuid,
     pub repo_ref: Option<RepoRef>,
     pub data: EventData,
+}
+
+#[derive(Debug, Clone)]
+pub struct StudioEvent {
+    pub studio_id: Uuid,
+
+    // This is not a `Map<K, V>`, to prevent RudderStack from collapsing these fields into columns
+    // in the analytics DB.
+    pub payload: Vec<(String, Value)>,
+    pub type_: String,
+}
+
+impl StudioEvent {
+    pub fn new(studio_id: Uuid, type_: &str) -> Self {
+        Self {
+            studio_id,
+            type_: type_.to_owned(),
+            payload: Vec::new(),
+        }
+    }
+
+    pub fn with_payload<T: Serialize + Clone>(mut self, name: &str, payload: &T) -> Self {
+        self.payload.push((
+            name.to_owned(),
+            serde_json::to_value(payload.clone()).unwrap(),
+        ));
+        self
+    }
 }
 
 #[derive(Debug, Clone, Serialize)]
 pub struct EventData {
     kind: EventKind,
     name: String,
+
+    // This is not a `Map<K, V>`, to prevent RudderStack from collapsing these fields into columns
+    // in the analytics DB.
     payload: Vec<(String, Value)>,
 }
 
@@ -81,8 +116,14 @@ pub struct RudderHub {
 
 #[derive(Default)]
 pub struct HubOptions {
-    pub event_filter: Option<Arc<dyn Fn(QueryEvent) -> Option<QueryEvent> + Send + Sync + 'static>>,
+    pub enable_telemetry: Arc<RwLock<bool>>,
     pub package_metadata: Option<PackageMetadata>,
+}
+
+impl HubOptions {
+    pub fn enable_telemetry(&self) -> bool {
+        *self.enable_telemetry.read().unwrap()
+    }
 }
 
 #[derive(Serialize, Deserialize)]
@@ -147,23 +188,44 @@ impl RudderHub {
 
     pub fn track_query(&self, user: &crate::webserver::middleware::User, event: QueryEvent) {
         if let Some(options) = &self.options {
-            if let Some(filter) = &options.event_filter {
-                if let Some(ev) = (filter)(event) {
-                    self.send(Message::Track(Track {
-                        user_id: Some(self.tracking_id(user.login())),
-                        event: "openai query".to_owned(),
-                        properties: Some(json!({
-                            "device_id": self.device_id(),
-                            "query_id": ev.query_id,
-                            "thread_id": ev.thread_id,
-                            "repo_ref": ev.repo_ref.as_ref().map(ToString::to_string),
-                            "data": ev.data,
-                            "package_metadata": options.package_metadata,
-                        })),
-                        ..Default::default()
-                    }));
-                }
+            if !options.enable_telemetry() {
+                return;
             }
+
+            self.send(Message::Track(Track {
+                user_id: Some(self.tracking_id(user.login())),
+                event: "openai query".to_owned(),
+                properties: Some(json!({
+                    "device_id": self.device_id(),
+                    "query_id": event.query_id,
+                    "thread_id": event.thread_id,
+                    "repo_ref": event.repo_ref.as_ref().map(ToString::to_string),
+                    "data": event.data,
+                    "package_metadata": options.package_metadata,
+                })),
+                ..Default::default()
+            }));
+        }
+    }
+
+    pub fn track_studio(&self, user: &crate::webserver::middleware::User, event: StudioEvent) {
+        if let Some(options) = &self.options {
+            if !options.enable_telemetry() {
+                return;
+            }
+
+            self.send(Message::Track(Track {
+                user_id: Some(self.tracking_id(user.login())),
+                event: "code studio".to_owned(),
+                properties: Some(json!({
+                    "device_id": self.device_id(),
+                    "event_type": event.type_,
+                    "studio_id": event.studio_id,
+                    "payload": event.payload,
+                    "package_metadata": options.package_metadata,
+                })),
+                ..Default::default()
+            }));
         }
     }
 


### PR DESCRIPTION
**WARNING: This will wipe the `studios` table when run. Studios are still an in-dev feature so this should not have consequences for any real users.**

---

Now, we track successful studio import calls, and generation requests alongside associated response strings.

A few things were changed here:

- A new `StudioEvent` type was introduced, following the existing pattern for `QueryEvent`
- Event filtering was only used with a boolean telemetry check, so this was cleaned up in order to support telemetry checks for non-query events
- The `sqlx/uuid` feature was enabled so that we can natively use UUIDs in queries. **This required a migration to move away from `TEXT`-based UUIDs to `BLOB`-based UUIDs. All entries in `studios` are dropped.**

Note that `QueryEvent` and `StudioEvent` are intentionally not merged, as the `QueryEvent` type must remain stable because our analytics database schema relies on the type in order to describe table columns.

Rather, a similar event was added but specialized to Studio-related data. In the long term, we may want to consider a refactor to merge these two types, but this may require an analytics migration.

Closes BLO-1503