### PR TITLE
List studio repos and top file extension

### DIFF
--- a/server/bleep/sqlx-data.json
+++ b/server/bleep/sqlx-data.json
@@ -164,6 +164,42 @@
     },
     "query": "DELETE FROM studios WHERE id = ? RETURNING id"
   },
+  "34c0a1743016c76a50f543623940632f1e9daaf4233df7239d972e58ba05f3f3": {
+    "describe": {
+      "columns": [
+        {
+          "name": "id",
+          "ordinal": 0,
+          "type_info": "Text"
+        },
+        {
+          "name": "name",
+          "ordinal": 1,
+          "type_info": "Text"
+        },
+        {
+          "name": "modified_at",
+          "ordinal": 2,
+          "type_info": "Datetime"
+        },
+        {
+          "name": "context",
+          "ordinal": 3,
+          "type_info": "Text"
+        }
+      ],
+      "nullable": [
+        false,
+        false,
+        false,
+        false
+      ],
+      "parameters": {
+        "Right": 0
+      }
+    },
+    "query": "SELECT id, name, modified_at, context FROM studios"
+  },
   "392b563bb3af6711817fe99335d053691750426762dcde7b0381dc9f69cd804e": {
     "describe": {
       "columns": [],

--- a/server/bleep/sqlx-data.json
+++ b/server/bleep/sqlx-data.json
@@ -74,36 +74,6 @@
     },
     "query": "SELECT id FROM templates WHERE id = ?"
   },
-  "18d1bdc46f4448448cb7121db7b2952076e6b17ba00ce370c919419d20d0fe07": {
-    "describe": {
-      "columns": [
-        {
-          "name": "id",
-          "ordinal": 0,
-          "type_info": "Text"
-        },
-        {
-          "name": "name",
-          "ordinal": 1,
-          "type_info": "Text"
-        },
-        {
-          "name": "modified_at",
-          "ordinal": 2,
-          "type_info": "Datetime"
-        }
-      ],
-      "nullable": [
-        false,
-        false,
-        false
-      ],
-      "parameters": {
-        "Right": 0
-      }
-    },
-    "query": "SELECT id, name, modified_at FROM studios"
-  },
   "21dfa10d31da4ec906483d92c4e885536b8020630f989306fb00fd5b861378e5": {
     "describe": {
       "columns": [
@@ -581,6 +551,24 @@
       }
     },
     "query": "SELECT title, repo_ref, exchanges\n         FROM conversations\n         WHERE user_id = ? AND thread_id = ?"
+  },
+  "db80c758eb137530e6aad6e83778efcea787dfdf42f95b896ac482d3ffac2cfe": {
+    "describe": {
+      "columns": [
+        {
+          "name": "context",
+          "ordinal": 0,
+          "type_info": "Text"
+        }
+      ],
+      "nullable": [
+        false
+      ],
+      "parameters": {
+        "Right": 1
+      }
+    },
+    "query": "SELECT context FROM studios WHERE id = ?"
   },
   "e444f39d4fc9219873c7a8565a13e65e4646658631b785431cb64ca0cc5d6ab9": {
     "describe": {

--- a/server/bleep/src/webserver/studio.rs
+++ b/server/bleep/src/webserver/studio.rs
@@ -65,13 +65,15 @@ pub async fn list(app: Extension<Application>) -> webserver::Result<Json<Vec<Lis
     let mut list_items = Vec::new();
 
     for studio in studios {
-        let context_json: String = sqlx::query!("SELECT context FROM studios WHERE id = ?", studio.id)
-            .fetch_one(&*app.sql)
-            .await
-            .map_err(Error::internal)?
-            .context;
+        let context_json: String =
+            sqlx::query!("SELECT context FROM studios WHERE id = ?", studio.id)
+                .fetch_one(&*app.sql)
+                .await
+                .map_err(Error::internal)?
+                .context;
 
-        let context: Vec<ContextFile> = serde_json::from_str(&context_json).map_err(Error::internal)?;
+        let context: Vec<ContextFile> =
+            serde_json::from_str(&context_json).map_err(Error::internal)?;
 
         let mut repos: Vec<String> = context.iter().map(|file| file.repo.name.clone()).collect();
         repos.sort();
@@ -83,7 +85,11 @@ pub async fn list(app: Extension<Application>) -> webserver::Result<Json<Vec<Lis
             let tokens = token_counts((*app).clone(), &[], &[file.clone()]).await?;
             *ext_tokens.entry(ext.to_string()).or_insert(0) += tokens.total;
         }
-        let most_common_ext = ext_tokens.into_iter().max_by_key(|(_, tokens)| *tokens).map(|(ext, _)| ext).unwrap_or_default();
+        let most_common_ext = ext_tokens
+            .into_iter()
+            .max_by_key(|(_, tokens)| *tokens)
+            .map(|(ext, _)| ext)
+            .unwrap_or_default();
 
         let list_item = ListItem {
             id: studio.id,


### PR DESCRIPTION
In the list of code studios 'GET /studio' endpoint added 2 new fields:
- `repos` containing repo refs used in this code studio, and
- `most_common_ext` containing the most used file extension based on a number of tokens in files. So if there are 3 files: foo.yml (10 tokens), bar.yml (100 tokens), and baz.rs (200 tokens) the response will contain `.rs`.