### PR TITLE
Implement snapshot-based studio history

### DIFF
--- a/server/bleep/migrations/20230831184906_code_studio_history.sql
+++ b/server/bleep/migrations/20230831184906_code_studio_history.sql
@@ -1,0 +1,31 @@
+ALTER TABLE studios RENAME TO studios_old;
+
+CREATE TABLE studios (
+    id BLOB NOT NULL,
+    name TEXT NOT NULL,
+
+    PRIMARY KEY (id)
+);
+
+CREATE TABLE studio_snapshots (
+    id INTEGER PRIMARY KEY,
+    studio_id BLOB NOT NULL,
+
+    modified_at DATETIME NOT NULL DEFAULT (datetime('now')),
+
+    -- JSON serialized fields
+    context TEXT NOT NULL,
+    messages TEXT NOT NULL,
+
+    FOREIGN KEY(studio_id) REFERENCES studios(id) ON DELETE CASCADE
+);
+
+INSERT INTO studios(id, name)
+SELECT id, name
+FROM studios_old;
+
+INSERT INTO studio_snapshots(studio_id, modified_at, context, messages)
+SELECT id, modified_at, context, messages
+FROM studios_old; 
+
+DROP TABLE studios_old;

--- a/server/bleep/sqlx-data.json
+++ b/server/bleep/sqlx-data.json
@@ -268,6 +268,16 @@
     },
     "query": "UPDATE templates SET modified_at = datetime('now') WHERE id = ?"
   },
+  "63938812eb2374512bb6dd750e14f363f67471ca85c2ed27f7c4b9404f5a875f": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Right": 2
+      }
+    },
+    "query": "INSERT INTO studio_snapshots(studio_id, context, messages)\n            SELECT studio_id, context, ?\n            FROM studio_snapshots\n            WHERE id = ?"
+  },
   "671df14b7c9077b95e586690f8c6d3f2eeb0a3942d0b800f272b010fcd2ca97b": {
     "describe": {
       "columns": [

--- a/server/bleep/sqlx-data.json
+++ b/server/bleep/sqlx-data.json
@@ -1,14 +1,14 @@
 {
   "db": "SQLite",
-  "0b8661afb0bd1a3806b96d07902fc6ba520b4efd1665f04b53f51c8dcd544343": {
+  "0c72c51f4a5b726f6f524fcb269f074550b1a3a25ed050fb2701f8bec02678d7": {
     "describe": {
       "columns": [],
       "nullable": [],
       "parameters": {
-        "Right": 4
+        "Right": 3
       }
     },
-    "query": "INSERT INTO studios (id, name, context, messages) VALUES (?, ?, ?, ?)"
+    "query": "INSERT INTO studio_snapshots (studio_id, context, messages)\n         VALUES (?, ?, ?)"
   },
   "109cbc6bd18131c59718a575c5e09b78a4d8f28667d347ced1a13f1b4be7e2eb": {
     "describe": {
@@ -46,6 +46,24 @@
     },
     "query": "SELECT id, name, modified_at, content FROM templates WHERE id = ?"
   },
+  "11f5e7122d047f87c398cf56470c284e2037203bc4d1506efc85e7431e2e2f5f": {
+    "describe": {
+      "columns": [
+        {
+          "name": "context",
+          "ordinal": 0,
+          "type_info": "Text"
+        }
+      ],
+      "nullable": [
+        false
+      ],
+      "parameters": {
+        "Right": 1
+      }
+    },
+    "query": "SELECT context FROM studio_snapshots WHERE id = ?"
+  },
   "13d9aec6f721a649ab89c29c770ae5aa9f1bf34a0e30f6e608b697772774568e": {
     "describe": {
       "columns": [],
@@ -74,48 +92,6 @@
     },
     "query": "SELECT id FROM templates WHERE id = ?"
   },
-  "21dfa10d31da4ec906483d92c4e885536b8020630f989306fb00fd5b861378e5": {
-    "describe": {
-      "columns": [
-        {
-          "name": "id",
-          "ordinal": 0,
-          "type_info": "Blob"
-        },
-        {
-          "name": "name",
-          "ordinal": 1,
-          "type_info": "Text"
-        },
-        {
-          "name": "context",
-          "ordinal": 2,
-          "type_info": "Text"
-        },
-        {
-          "name": "messages",
-          "ordinal": 3,
-          "type_info": "Text"
-        },
-        {
-          "name": "modified_at",
-          "ordinal": 4,
-          "type_info": "Datetime"
-        }
-      ],
-      "nullable": [
-        false,
-        false,
-        false,
-        false,
-        false
-      ],
-      "parameters": {
-        "Right": 1
-      }
-    },
-    "query": "SELECT id, name, context, messages, modified_at\n         FROM studios\n         WHERE id = ?"
-  },
   "2463553250cf5cb24170b9f04e51b3defa7b639a7e6ac704781761566d922a69": {
     "describe": {
       "columns": [
@@ -133,6 +109,16 @@
       }
     },
     "query": "DELETE FROM studios WHERE id = ? RETURNING id"
+  },
+  "359b4d0fa1fcb081767303103b23f0650568cf4e79787c7ddcd21af5bad6761b": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Right": 3
+      }
+    },
+    "query": "INSERT INTO studio_snapshots(studio_id, context, messages) VALUES (?, ?, ?)"
   },
   "392b563bb3af6711817fe99335d053691750426762dcde7b0381dc9f69cd804e": {
     "describe": {
@@ -226,6 +212,24 @@
     },
     "query": "DELETE FROM chunk_cache WHERE chunk_hash = ? AND file_hash = ?"
   },
+  "52b4b9dfaac3203b892b8c46a7659db3cebc2f98387005709e2e4480227be725": {
+    "describe": {
+      "columns": [
+        {
+          "name": "id",
+          "ordinal": 0,
+          "type_info": "Int64"
+        }
+      ],
+      "nullable": [
+        true
+      ],
+      "parameters": {
+        "Right": 1
+      }
+    },
+    "query": "SELECT id\n         FROM studio_snapshots\n         WHERE studio_id = ?\n         ORDER BY modified_at\n         LIMIT 1"
+  },
   "5776008bf71ba2a90bad43c66a6e622ad71a81e1751c00b62aafa70840997999": {
     "describe": {
       "columns": [],
@@ -282,41 +286,29 @@
     },
     "query": "UPDATE templates SET modified_at = datetime('now') WHERE id = ?"
   },
-  "5f891519fb8bdd247e2a3dc45a7966709a7a09bf2709dfd5196b14dd2b13c39c": {
+  "671df14b7c9077b95e586690f8c6d3f2eeb0a3942d0b800f272b010fcd2ca97b": {
     "describe": {
       "columns": [
         {
-          "name": "id: Uuid",
+          "name": "messages",
           "ordinal": 0,
-          "type_info": "Blob"
-        },
-        {
-          "name": "name",
-          "ordinal": 1,
           "type_info": "Text"
         },
         {
-          "name": "modified_at",
-          "ordinal": 2,
-          "type_info": "Datetime"
-        },
-        {
           "name": "context",
-          "ordinal": 3,
+          "ordinal": 1,
           "type_info": "Text"
         }
       ],
       "nullable": [
         false,
-        false,
-        false,
         false
       ],
       "parameters": {
-        "Right": 0
+        "Right": 1
       }
     },
-    "query": "SELECT id as \"id: Uuid\", name, modified_at, context FROM studios"
+    "query": "SELECT messages, context FROM studio_snapshots WHERE id = ?"
   },
   "69e7fcbe274e645ac8dece40ddad39b5f594731e4647a683f4537ede7e20b3d4": {
     "describe": {
@@ -328,7 +320,7 @@
     },
     "query": "INSERT INTO templates (name, content) VALUES (?, ?)"
   },
-  "757d0afca2629937d717f9d6fc02df5dada4412e7b09bfed57423aa9b5f07b40": {
+  "8850cdae165c79f72e929c14de8b6ca67fd17dd745ca7fd62a0cd044f87f3e85": {
     "describe": {
       "columns": [],
       "nullable": [],
@@ -336,7 +328,17 @@
         "Right": 2
       }
     },
-    "query": "UPDATE studios SET modified_at = ? WHERE id = ?"
+    "query": "INSERT INTO studios(id, name) VALUES (?, ?)"
+  },
+  "8f99eede8e6c1fb27acc2524c00cebbc2d4e73db8af05599521e3b00c621347f": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Right": 2
+      }
+    },
+    "query": "UPDATE studio_snapshots SET modified_at = ? WHERE id = ?"
   },
   "9146d9c8a7f17cc65c017cb364d1a853a9163b5ece336c0a6ef4e28e8df56a6b": {
     "describe": {
@@ -376,7 +378,7 @@
     },
     "query": "DELETE FROM file_cache WHERE repo_ref = ?"
   },
-  "a65012ef1100880ed0a93569a397b4c0632e0f4f8d9be9577fbb5bcc8c31b8cf": {
+  "a4278b11c21e533d662043810e7cc8a3fca86cf03989766fffb84302d84394e5": {
     "describe": {
       "columns": [],
       "nullable": [],
@@ -384,7 +386,43 @@
         "Right": 2
       }
     },
-    "query": "UPDATE studios SET context = ? WHERE id = ?"
+    "query": "UPDATE studio_snapshots SET context = ? WHERE id = ?"
+  },
+  "ab030e967884bb8946d4b7a7497a59a2dc6e172fe9a2461b6d1c9b122e180898": {
+    "describe": {
+      "columns": [
+        {
+          "name": "id: Uuid",
+          "ordinal": 0,
+          "type_info": "Blob"
+        },
+        {
+          "name": "name",
+          "ordinal": 1,
+          "type_info": "Text"
+        },
+        {
+          "name": "modified_at!",
+          "ordinal": 2,
+          "type_info": "Datetime"
+        },
+        {
+          "name": "context",
+          "ordinal": 3,
+          "type_info": "Text"
+        }
+      ],
+      "nullable": [
+        false,
+        false,
+        false,
+        false
+      ],
+      "parameters": {
+        "Right": 0
+      }
+    },
+    "query": "SELECT\n                s.id as \"id: Uuid\",\n                s.name,\n                ss.modified_at as \"modified_at!\",\n                ss.context\n            FROM studios s\n            INNER JOIN studio_snapshots ss ON s.id = ss.studio_id\n            WHERE (ss.studio_id, ss.modified_at) IN (\n                SELECT studio_id, MAX(modified_at)\n                FROM studio_snapshots\n                GROUP BY studio_id\n            )"
   },
   "ac1299cb16ae8ff77ded6a11241b84414352c12e55ce40b89e5b85109c7dc523": {
     "describe": {
@@ -404,6 +442,16 @@
     },
     "query": "SELECT raw_query FROM query_log WHERE created_at > ?"
   },
+  "aca77850668a0991ee92c3a41efb82fa085a716032f2668f8b78d9406cf8b441": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Right": 2
+      }
+    },
+    "query": "INSERT INTO studios (id, name) VALUES (?, ?)"
+  },
   "adcf8cfb776a4a3954bf2fe4bbb9e562ae4a0a388cd26de91e8b51753357030e": {
     "describe": {
       "columns": [],
@@ -413,6 +461,48 @@
       }
     },
     "query": "UPDATE templates SET name = ? WHERE id = ?"
+  },
+  "b2946315fd120bc1b59801bdc59ea1e3763e2ff7f1dd305b5398e19edc032651": {
+    "describe": {
+      "columns": [
+        {
+          "name": "id",
+          "ordinal": 0,
+          "type_info": "Blob"
+        },
+        {
+          "name": "name",
+          "ordinal": 1,
+          "type_info": "Text"
+        },
+        {
+          "name": "context",
+          "ordinal": 2,
+          "type_info": "Text"
+        },
+        {
+          "name": "messages",
+          "ordinal": 3,
+          "type_info": "Text"
+        },
+        {
+          "name": "modified_at",
+          "ordinal": 4,
+          "type_info": "Datetime"
+        }
+      ],
+      "nullable": [
+        false,
+        false,
+        false,
+        false,
+        false
+      ],
+      "parameters": {
+        "Right": 2
+      }
+    },
+    "query": "SELECT s.id, s.name, ss.context, ss.messages, ss.modified_at\n         FROM studios s\n         INNER JOIN studio_snapshots ss ON ss.id = ?\n         WHERE s.id = ?"
   },
   "b3ebaeec21c90aa9ebc59a808e03c661839d0a0eaa86ad2bf4251e895f8e0a03": {
     "describe": {
@@ -472,15 +562,23 @@
     },
     "query": "SELECT thread_id, created_at, title FROM conversations WHERE user_id = ? AND repo_ref = ? ORDER BY created_at DESC"
   },
-  "d5d1d85ebd2740431593367145770ec13ab3b3f0eb23cfefacabb7a5711dbd99": {
+  "d2b52987aaa4bdc39c04254834c941cad2165eefd02eef46fda413822be91fd0": {
     "describe": {
-      "columns": [],
-      "nullable": [],
+      "columns": [
+        {
+          "name": "messages",
+          "ordinal": 0,
+          "type_info": "Text"
+        }
+      ],
+      "nullable": [
+        false
+      ],
       "parameters": {
         "Right": 1
       }
     },
-    "query": "UPDATE studios SET modified_at = datetime('now') WHERE id = ?"
+    "query": "SELECT messages FROM studio_snapshots WHERE id = ?"
   },
   "d5ee5becde7005920d7094fca5b7974bbf19713b3625fbf6d1a3e198e7cf4de4": {
     "describe": {
@@ -552,23 +650,15 @@
     },
     "query": "SELECT title, repo_ref, exchanges\n         FROM conversations\n         WHERE user_id = ? AND thread_id = ?"
   },
-  "db80c758eb137530e6aad6e83778efcea787dfdf42f95b896ac482d3ffac2cfe": {
+  "db4077fd7603079ffc8c237ec49a640a6061a06d12499bdb7b39ed3c23c1b38e": {
     "describe": {
-      "columns": [
-        {
-          "name": "context",
-          "ordinal": 0,
-          "type_info": "Text"
-        }
-      ],
-      "nullable": [
-        false
-      ],
+      "columns": [],
+      "nullable": [],
       "parameters": {
-        "Right": 1
+        "Right": 2
       }
     },
-    "query": "SELECT context FROM studios WHERE id = ?"
+    "query": "UPDATE studio_snapshots SET messages = ? WHERE id = ?"
   },
   "e444f39d4fc9219873c7a8565a13e65e4646658631b785431cb64ca0cc5d6ab9": {
     "describe": {
@@ -594,29 +684,15 @@
     },
     "query": "SELECT repo_ref, exchanges FROM conversations WHERE user_id = ? AND thread_id = ?"
   },
-  "e5aef852b8c69dd4fade0bf5deee0406aa883d5cf399740223e71659139188e2": {
+  "ec193a038eb7fc3aaca3c3adebcc4dbde01b47ae34ac2df2227c5e5459617182": {
     "describe": {
-      "columns": [
-        {
-          "name": "messages",
-          "ordinal": 0,
-          "type_info": "Text"
-        },
-        {
-          "name": "context",
-          "ordinal": 1,
-          "type_info": "Text"
-        }
-      ],
-      "nullable": [
-        false,
-        false
-      ],
+      "columns": [],
+      "nullable": [],
       "parameters": {
         "Right": 1
       }
     },
-    "query": "SELECT messages, context FROM studios WHERE id = ?"
+    "query": "UPDATE studio_snapshots SET modified_at = datetime('now') WHERE id = ?"
   },
   "ed6379e37c16064198f48dbfb91899d74eb346533e3c9ab3814ba67b68d71f51": {
     "describe": {
@@ -627,15 +703,5 @@
       }
     },
     "query": "DELETE FROM chunk_cache WHERE repo_ref = ?"
-  },
-  "fcd51dfbd5e468d2517a9b21a444998cdf8fc9564a2b60961bddc4f5f9f49e2c": {
-    "describe": {
-      "columns": [],
-      "nullable": [],
-      "parameters": {
-        "Right": 2
-      }
-    },
-    "query": "UPDATE studios SET messages = ? WHERE id = ?"
   }
 }

--- a/server/bleep/sqlx-data.json
+++ b/server/bleep/sqlx-data.json
@@ -562,6 +562,24 @@
     },
     "query": "SELECT thread_id, created_at, title FROM conversations WHERE user_id = ? AND repo_ref = ? ORDER BY created_at DESC"
   },
+  "cdee6789dd26e6a7dcc7f9218d9b7307674408c1cae10c951324712af9e9858a": {
+    "describe": {
+      "columns": [
+        {
+          "name": "id",
+          "ordinal": 0,
+          "type_info": "Int64"
+        }
+      ],
+      "nullable": [
+        true
+      ],
+      "parameters": {
+        "Right": 2
+      }
+    },
+    "query": "DELETE FROM studio_snapshots WHERE studio_id = ? AND id = ? RETURNING id"
+  },
   "d2b52987aaa4bdc39c04254834c941cad2165eefd02eef46fda413822be91fd0": {
     "describe": {
       "columns": [
@@ -579,6 +597,42 @@
       }
     },
     "query": "SELECT messages FROM studio_snapshots WHERE id = ?"
+  },
+  "d3389a360f2b71adc8ca962d843738d724b48e84b22803692202631c78c066e5": {
+    "describe": {
+      "columns": [
+        {
+          "name": "id!",
+          "ordinal": 0,
+          "type_info": "Int64"
+        },
+        {
+          "name": "modified_at",
+          "ordinal": 1,
+          "type_info": "Datetime"
+        },
+        {
+          "name": "context",
+          "ordinal": 2,
+          "type_info": "Text"
+        },
+        {
+          "name": "messages",
+          "ordinal": 3,
+          "type_info": "Text"
+        }
+      ],
+      "nullable": [
+        true,
+        false,
+        false,
+        false
+      ],
+      "parameters": {
+        "Right": 1
+      }
+    },
+    "query": "SELECT id as 'id!', modified_at, context, messages\n        FROM studio_snapshots\n        WHERE studio_id = ?\n        ORDER BY modified_at DESC"
   },
   "d5ee5becde7005920d7094fca5b7974bbf19713b3625fbf6d1a3e198e7cf4de4": {
     "describe": {

--- a/server/bleep/sqlx-data.json
+++ b/server/bleep/sqlx-data.json
@@ -212,24 +212,6 @@
     },
     "query": "DELETE FROM chunk_cache WHERE chunk_hash = ? AND file_hash = ?"
   },
-  "52b4b9dfaac3203b892b8c46a7659db3cebc2f98387005709e2e4480227be725": {
-    "describe": {
-      "columns": [
-        {
-          "name": "id",
-          "ordinal": 0,
-          "type_info": "Int64"
-        }
-      ],
-      "nullable": [
-        true
-      ],
-      "parameters": {
-        "Right": 1
-      }
-    },
-    "query": "SELECT id\n         FROM studio_snapshots\n         WHERE studio_id = ?\n         ORDER BY modified_at\n         LIMIT 1"
-  },
   "5776008bf71ba2a90bad43c66a6e622ad71a81e1751c00b62aafa70840997999": {
     "describe": {
       "columns": [],
@@ -319,6 +301,24 @@
       }
     },
     "query": "INSERT INTO templates (name, content) VALUES (?, ?)"
+  },
+  "877a7db4b5610a6e4bb45918d10870e8f345e6d194504d6a6f12857a1b5bd73e": {
+    "describe": {
+      "columns": [
+        {
+          "name": "id",
+          "ordinal": 0,
+          "type_info": "Int64"
+        }
+      ],
+      "nullable": [
+        true
+      ],
+      "parameters": {
+        "Right": 1
+      }
+    },
+    "query": "SELECT id\n         FROM studio_snapshots\n         WHERE studio_id = ?\n         ORDER BY modified_at DESC\n         LIMIT 1"
   },
   "8850cdae165c79f72e929c14de8b6ca67fd17dd745ca7fd62a0cd044f87f3e85": {
     "describe": {

--- a/server/bleep/src/webserver.rs
+++ b/server/bleep/src/webserver.rs
@@ -3,7 +3,7 @@ use crate::{env::Feature, Application};
 use axum::{
     http::StatusCode,
     response::IntoResponse,
-    routing::{get, post},
+    routing::{delete, get, post},
     Extension, Json,
 };
 use std::{borrow::Cow, net::SocketAddr};
@@ -79,11 +79,16 @@ pub async fn start(app: Application) -> anyhow::Result<()> {
         .route("/studio", post(studio::create))
         .route("/studio", get(studio::list))
         .route(
-            "/studio/:id",
+            "/studio/:studio_id",
             get(studio::get).patch(studio::patch).delete(studio::delete),
         )
-        .route("/studio/:id/generate", get(studio::generate))
         .route("/studio/import", post(studio::import))
+        .route("/studio/:studio_id/generate", get(studio::generate))
+        .route("/studio/:studio_id/snapshots", get(studio::list_snapshots))
+        .route(
+            "/studio/:studio_id/snapshots/:snapshot_id",
+            delete(studio::delete_snapshot),
+        )
         .route("/template", post(template::create))
         .route("/template", get(template::list))
         .route(

--- a/server/bleep/src/webserver/studio.rs
+++ b/server/bleep/src/webserver/studio.rs
@@ -193,7 +193,7 @@ where
         "SELECT id
          FROM studio_snapshots
          WHERE studio_id = ?
-         ORDER BY modified_at
+         ORDER BY modified_at DESC
          LIMIT 1",
         studio_id,
     }

--- a/server/bleep/src/webserver/studio.rs
+++ b/server/bleep/src/webserver/studio.rs
@@ -522,7 +522,10 @@ pub async fn generate(
         let messages_json = serde_json::to_string(&messages).unwrap();
 
         sqlx::query! {
-            "UPDATE studio_snapshots SET messages = ? WHERE id = ?",
+            "INSERT INTO studio_snapshots(studio_id, context, messages)
+            SELECT studio_id, context, ?
+            FROM studio_snapshots
+            WHERE id = ?",
             messages_json,
             snapshot_id,
         }

--- a/server/bleep/src/webserver/studio.rs
+++ b/server/bleep/src/webserver/studio.rs
@@ -40,19 +40,31 @@ pub async fn create(
     app: Extension<Application>,
     params: Json<Create>,
 ) -> webserver::Result<String> {
-    let id = Uuid::new_v4();
+    let studio_id = Uuid::new_v4();
+
+    let mut transaction = app.sql.begin().await?;
 
     sqlx::query! {
-        "INSERT INTO studios (id, name, context, messages) VALUES (?, ?, ?, ?)",
-        id,
+        "INSERT INTO studios (id, name) VALUES (?, ?)",
+        studio_id,
         params.name,
-        "[]",
-        "[]"
     }
-    .execute(&*app.sql)
+    .execute(&mut transaction)
     .await?;
 
-    Ok(id.to_string())
+    sqlx::query! {
+        "INSERT INTO studio_snapshots (studio_id, context, messages)
+         VALUES (?, ?, ?)",
+        studio_id,
+        "[]",
+        "[]",
+    }
+    .execute(&mut transaction)
+    .await?;
+
+    transaction.commit().await?;
+
+    Ok(studio_id.to_string())
 }
 
 #[derive(serde::Serialize)]
@@ -63,12 +75,25 @@ pub struct ListItem {
     repos: Vec<String>,
     most_common_ext: String,
 }
+
 pub async fn list(app: Extension<Application>) -> webserver::Result<Json<Vec<ListItem>>> {
     let studios =
-        sqlx::query!("SELECT id as \"id: Uuid\", name, modified_at, context FROM studios")
-            .fetch_all(&*app.sql)
-            .await
-            .map_err(Error::internal)?;
+        sqlx::query!(
+            "SELECT
+                s.id as \"id: Uuid\",
+                s.name,
+                ss.modified_at as \"modified_at!\",
+                ss.context
+            FROM studios s
+            INNER JOIN studio_snapshots ss ON s.id = ss.studio_id
+            WHERE (ss.studio_id, ss.modified_at) IN (
+                SELECT studio_id, MAX(modified_at)
+                FROM studio_snapshots
+                GROUP BY studio_id
+            )"
+        )
+        .fetch_all(&*app.sql)
+        .await?;
 
     let mut list_items = Vec::new();
 
@@ -160,15 +185,46 @@ impl From<&Message> for llm_gateway::api::Message {
     }
 }
 
+async fn latest_snapshot_id<'a, E>(studio_id: Uuid, exec: E) -> webserver::Result<i64>
+where
+    E: sqlx::Executor<'a, Database = sqlx::Sqlite>,
+{
+    sqlx::query! {
+        "SELECT id
+         FROM studio_snapshots
+         WHERE studio_id = ?
+         ORDER BY modified_at
+         LIMIT 1",
+        studio_id,
+    }
+    .fetch_optional(exec)
+    .await?
+    .and_then(|r| r.id)
+    .ok_or_else(|| Error::not_found("no snapshots with given studio ID"))
+}
+
+#[derive(serde::Deserialize)]
+pub struct Get {
+    pub snapshot_id: Option<i64>,
+}
+
 pub async fn get(
     app: Extension<Application>,
     Path(id): Path<Uuid>,
+    Query(params): Query<Get>,
 ) -> webserver::Result<Json<Studio>> {
+    let snapshot_id = match params.snapshot_id {
+        Some(id) => id,
+        None => latest_snapshot_id(id, &*app.sql).await?,
+    };
+
     let row = sqlx::query! {
-        "SELECT id, name, context, messages, modified_at
-         FROM studios
-         WHERE id = ?",
-         id
+        "SELECT s.id, s.name, ss.context, ss.messages, ss.modified_at
+         FROM studios s
+         INNER JOIN studio_snapshots ss ON ss.id = ?
+         WHERE s.id = ?",
+        snapshot_id,
+        id
     }
     .fetch_optional(&*app.sql)
     .await?
@@ -194,32 +250,38 @@ pub struct Patch {
     modified_at: Option<NaiveDateTime>,
     context: Option<Vec<ContextFile>>,
     messages: Option<Vec<Message>>,
+    snapshot_id: Option<i64>,
 }
 
 pub async fn patch(
     app: Extension<Application>,
-    Path(id): Path<Uuid>,
+    Path(studio_id): Path<Uuid>,
     Json(patch): Json<Patch>,
 ) -> webserver::Result<Json<TokenCounts>> {
     let mut transaction = app.sql.begin().await?;
 
+    let snapshot_id = match patch.snapshot_id {
+        Some(id) => id,
+        None => latest_snapshot_id(studio_id, &mut transaction).await?,
+    };
+
     // Ensure the ID is valid first.
-    sqlx::query!("SELECT id FROM studios WHERE id = ?", id)
+    sqlx::query!("SELECT id FROM studios WHERE id = ?", studio_id)
         .fetch_optional(&mut transaction)
         .await?
         .ok_or_else(|| Error::not_found("unknown code studio ID"))?;
 
     if let Some(name) = patch.name {
-        sqlx::query!("UPDATE studios SET name = ? WHERE id = ?", name, id)
+        sqlx::query!("UPDATE studios SET name = ? WHERE id = ?", name, studio_id)
             .execute(&mut transaction)
             .await?;
     }
 
     if let Some(modified_at) = patch.modified_at {
         sqlx::query!(
-            "UPDATE studios SET modified_at = ? WHERE id = ?",
+            "UPDATE studio_snapshots SET modified_at = ? WHERE id = ?",
             modified_at,
-            id
+            snapshot_id
         )
         .execute(&mut transaction)
         .await?;
@@ -227,33 +289,43 @@ pub async fn patch(
 
     if let Some(context) = patch.context {
         let json = serde_json::to_string(&context).unwrap();
-        sqlx::query!("UPDATE studios SET context = ? WHERE id = ?", json, id)
-            .execute(&mut transaction)
-            .await?;
+        sqlx::query!(
+            "UPDATE studio_snapshots SET context = ? WHERE id = ?",
+            json,
+            snapshot_id
+        )
+        .execute(&mut transaction)
+        .await?;
     }
 
     if let Some(messages) = patch.messages {
         let json = serde_json::to_string(&messages).unwrap();
-        sqlx::query!("UPDATE studios SET messages = ? WHERE id = ?", json, id)
-            .execute(&mut transaction)
-            .await?;
+        sqlx::query!(
+            "UPDATE studio_snapshots SET messages = ? WHERE id = ?",
+            json,
+            snapshot_id
+        )
+        .execute(&mut transaction)
+        .await?;
     }
 
-    sqlx::query!(
-        "UPDATE studios SET modified_at = datetime('now') WHERE id = ?",
-        id
-    )
+    sqlx::query! {
+        "UPDATE studio_snapshots SET modified_at = datetime('now') WHERE id = ?",
+        snapshot_id,
+    }
     .execute(&mut transaction)
     .await?;
 
     // Re-fetch the context and messages in case we didn't change them. If we did, this will now
     // contain the updated values.
-    let (messages_json, context_json) =
-        sqlx::query!("SELECT messages, context FROM studios WHERE id = ?", id)
-            .fetch_optional(&mut transaction)
-            .await?
-            .map(|r| (r.messages, r.context))
-            .unwrap_or_default();
+    let (messages_json, context_json) = sqlx::query!(
+        "SELECT messages, context FROM studio_snapshots WHERE id = ?",
+        snapshot_id
+    )
+    .fetch_optional(&mut transaction)
+    .await?
+    .map(|r| (r.messages, r.context))
+    .unwrap_or_default();
 
     let context: Vec<ContextFile> =
         serde_json::from_str(&context_json).context("invalid context JSON")?;
@@ -387,6 +459,8 @@ pub async fn generate(
     Extension(user): Extension<User>,
     Path(id): Path<Uuid>,
 ) -> webserver::Result<Sse<Pin<Box<dyn tokio_stream::Stream<Item = Result<sse::Event>> + Send>>>> {
+    let snapshot_id = latest_snapshot_id(id, &*app.sql).await?;
+
     let answer_api_token = app
         .answer_api_token()
         .map_err(|e| Error::user(e).with_status(StatusCode::UNAUTHORIZED))?
@@ -397,12 +471,14 @@ pub async fn generate(
         .temperature(0.0)
         .bearer(answer_api_token);
 
-    let (messages_json, context_json) =
-        sqlx::query!("SELECT messages, context FROM studios WHERE id = ?", id)
-            .fetch_optional(&*app.sql)
-            .await?
-            .map(|row| (row.messages, row.context))
-            .ok_or_else(|| Error::not_found("unknown code studio ID"))?;
+    let (messages_json, context_json) = sqlx::query!(
+        "SELECT messages, context FROM studio_snapshots WHERE id = ?",
+        snapshot_id
+    )
+    .fetch_optional(&*app.sql)
+    .await?
+    .map(|row| (row.messages, row.context))
+    .ok_or_else(|| Error::not_found("unknown code studio ID"))?;
 
     let mut messages =
         serde_json::from_str::<Vec<Message>>(&messages_json).map_err(Error::internal)?;
@@ -444,9 +520,14 @@ pub async fn generate(
 
         messages.push(Message::Assistant(response));
         let messages_json = serde_json::to_string(&messages).unwrap();
-        sqlx::query!("UPDATE studios SET messages = ? WHERE id = ?", messages_json, id)
-            .execute(&*app.sql)
-            .await?;
+
+        sqlx::query! {
+            "UPDATE studio_snapshots SET messages = ? WHERE id = ?",
+            messages_json,
+            snapshot_id,
+        }
+        .execute(&*app.sql)
+        .await?;
     };
 
     let mut errored = false;
@@ -602,6 +683,8 @@ pub async fn import(
     user: Extension<User>,
     Query(params): Query<Import>,
 ) -> webserver::Result<String> {
+    let mut transaction = app.sql.begin().await?;
+
     let user_id = user
         .login()
         .ok_or_else(|| super::Error::user("didn't have user ID"))?
@@ -616,7 +699,7 @@ pub async fn import(
         user_id,
         thread_id,
     }
-    .fetch_optional(&*app.sql)
+    .fetch_optional(&mut transaction)
     .await?
     .ok_or_else(|| Error::not_found("conversation not found"))?;
 
@@ -624,12 +707,17 @@ pub async fn import(
     let exchanges = serde_json::from_str::<Vec<Exchange>>(&conversation.exchanges)
         .context("couldn't deserialize exchange list")?;
 
-    let old_context: Vec<ContextFile> = if let Some(studio_id) = params.studio_id {
+    let snapshot_id = match params.studio_id {
+        None => None,
+        Some(studio_id) => Some(latest_snapshot_id(studio_id, &mut transaction).await?),
+    };
+
+    let old_context: Vec<ContextFile> = if let Some(snapshot_id) = snapshot_id {
         sqlx::query! {
-            "SELECT context FROM studios WHERE id = ?",
-            studio_id,
+            "SELECT context FROM studio_snapshots WHERE id = ?",
+            snapshot_id,
         }
-        .fetch_optional(&*app.sql)
+        .fetch_optional(&mut transaction)
         .await?
         .ok_or_else(|| Error::not_found("unknown studio ID"))
         .and_then(|r| serde_json::from_str(&r.context).map_err(Error::internal))?
@@ -648,52 +736,56 @@ pub async fn import(
     }))
     .collect::<Vec<_>>();
 
-    let filtered_context =
+    let new_context =
         extract_relevant_chunks((*app).clone(), &exchanges, &imported_context).await?;
 
-    let context = canonicalize_context(
-        filtered_context
-            .clone()
-            .into_iter()
-            .chain(old_context.clone()),
-    )
-    .collect::<Vec<_>>();
+    let context = canonicalize_context(new_context.clone().into_iter().chain(old_context.clone()))
+        .collect::<Vec<_>>();
 
     let context_json = serde_json::to_string(&context).unwrap();
 
-    let studio_id = if let Some(studio_id) = params.studio_id {
-        sqlx::query! {
-            "UPDATE studios SET context = ? WHERE id = ?",
-            context_json,
-            studio_id,
+    let studio_id = match params.studio_id {
+        Some(id) => id,
+        None => {
+            let id = Uuid::new_v4();
+            sqlx::query!(
+                "INSERT INTO studios(id, name) VALUES (?, ?)",
+                id,
+                conversation.title
+            )
+            .execute(&mut transaction)
+            .await?;
+            id
         }
-        .execute(&*app.sql)
-        .await?;
-
-        studio_id
-    } else {
-        let studio_id = Uuid::new_v4();
-
-        sqlx::query! {
-            "INSERT INTO studios (id, name, context, messages) VALUES (?, ?, ?, ?)",
-            studio_id,
-            conversation.title,
-            context_json,
-            "[]",
-        }
-        .execute(&*app.sql)
-        .await?;
-
-        studio_id
     };
+
+    let messages_json = sqlx::query! {
+        "SELECT messages FROM studio_snapshots WHERE id = ?",
+        snapshot_id
+    }
+    .fetch_optional(&mut transaction)
+    .await?
+    .map(|r| r.messages)
+    .unwrap_or_else(|| "[]".to_owned());
+
+    sqlx::query! {
+        "INSERT INTO studio_snapshots(studio_id, context, messages) VALUES (?, ?, ?)",
+        studio_id,
+        context_json,
+        messages_json,
+    }
+    .execute(&mut transaction)
+    .await?;
 
     app.track_studio(
         &user,
         StudioEvent::new(studio_id, "import")
             .with_payload("thread_id", &params.thread_id)
             .with_payload("old_context", &old_context)
-            .with_payload("new_filtered_context", &filtered_context),
+            .with_payload("new_context", &new_context),
     );
+
+    transaction.commit().await?;
 
     Ok(studio_id.to_string())
 }


### PR DESCRIPTION
This PR adds "snapshots" to studios. By default, using the routes as before changes nothing, but new "snapshots" are created during `/import` and `/generate` calls. When a snapshot is taken, the current state is saved and duplicated. Most routes are by-default unaware of this, here are the complete changes:

- `GET /studio` retrieves the full list of studios, each titled and dated by their latest snapshot
- `GET /studio/:id` returns the "latest" snapshot, but optionally takes `?snapshot_id=...`
- `PATCH /studio/:id` operates on the "latest" snapshot, but optionally takes `?snapshot_id=...`
- `DELETE /studio/:id` works as before, but also deletes **all** associated snapshots
- `POST /studio/:id/import` works as before, but now implicitly creates a new snapshot on successful import
- `GET /studio/:id/generate` works as before, but now implicitly creates a new snapshot on successful generation

To manage these snapshots, we add 2 new routes:

- `GET /studio/:studio_id/snapshots`
  - This will return a list of snapshots, which look like:
    ```ts
    {
      id: number,
      modified_at: date string,
      context: [...],
      messages: [...]
    }
    ```
- `DELETE /studio/:studio_id/snapshots/:snapshot_id`
  - This deletes the snapshot

Closes BLO-1535