### PR TITLE
Add proxy billing routes

### DIFF
--- a/server/bleep/src/llm_gateway.rs
+++ b/server/bleep/src/llm_gateway.rs
@@ -88,6 +88,7 @@ pub mod api {
         #[serde(default)]
         pub extra_stop_sequences: Vec<String>,
         pub session_reference_id: Option<String>,
+        pub quota_gated: bool,
     }
 
     #[derive(Debug, Copy, Clone, serde::Serialize, serde::Deserialize)]
@@ -205,6 +206,7 @@ pub struct Client {
     pub provider: api::Provider,
     pub model: Option<String>,
     pub session_reference_id: Option<String>,
+    pub quota_gated: bool,
 }
 
 impl Client {
@@ -222,6 +224,7 @@ impl Client {
             frequency_penalty: None,
             model: None,
             session_reference_id: None,
+            quota_gated: false,
         }
     }
 
@@ -264,6 +267,11 @@ impl Client {
 
     pub fn session_reference_id(mut self, session_reference_id: String) -> Self {
         self.session_reference_id = Some(session_reference_id);
+        self
+    }
+
+    pub fn quota_gated(mut self, quota_gated: bool) -> Self {
+        self.quota_gated = quota_gated;
         self
     }
 
@@ -344,6 +352,7 @@ impl Client {
                     model: self.model.clone(),
                     extra_stop_sequences: vec![],
                     session_reference_id: self.session_reference_id.clone(),
+                    quota_gated: self.quota_gated,
                 })
             })
             // We don't have a `Stream` body so this can't fail.

--- a/server/bleep/src/webserver.rs
+++ b/server/bleep/src/webserver.rs
@@ -23,6 +23,7 @@ mod index;
 mod intelligence;
 pub mod middleware;
 mod query;
+mod quota;
 pub mod repos;
 mod search;
 mod studio;
@@ -96,6 +97,11 @@ pub async fn start(app: Application) -> anyhow::Result<()> {
             get(template::get)
                 .patch(template::patch)
                 .delete(template::delete),
+        )
+        .route("/quota", get(quota::get))
+        .route(
+            "/quota/create-checkout-session",
+            get(quota::create_checkout_session),
         );
 
     if app.env.allow(Feature::AnyPathScan) {
@@ -219,6 +225,16 @@ impl Error {
             status: StatusCode::NOT_FOUND,
             body: EndpointError {
                 kind: ErrorKind::NotFound,
+                message: message.to_string().into(),
+            },
+        }
+    }
+
+    fn unauthorized<S: std::fmt::Display>(message: S) -> Self {
+        Error {
+            status: StatusCode::UNAUTHORIZED,
+            body: EndpointError {
+                kind: ErrorKind::User,
                 message: message.to_string().into(),
             },
         }

--- a/server/bleep/src/webserver/quota.rs
+++ b/server/bleep/src/webserver/quota.rs
@@ -8,8 +8,9 @@ use super::Error;
 
 #[derive(serde::Deserialize, serde::Serialize)]
 pub struct QuotaResponse {
-    paid: bool,
-    used: String,
+    upgraded: bool,
+    used: u32,
+    allowed: u32,
 }
 
 pub async fn get(app: Extension<Application>) -> super::Result<Json<QuotaResponse>> {

--- a/server/bleep/src/webserver/quota.rs
+++ b/server/bleep/src/webserver/quota.rs
@@ -1,0 +1,61 @@
+use axum::{Extension, Json};
+use reqwest::StatusCode;
+use secrecy::ExposeSecret;
+
+use crate::Application;
+
+use super::Error;
+
+#[derive(serde::Deserialize, serde::Serialize)]
+pub struct QuotaResponse {
+    paid: bool,
+    used: u32,
+}
+
+pub async fn get(app: Extension<Application>) -> super::Result<Json<QuotaResponse>> {
+    let answer_api_token = app
+        .answer_api_token()
+        .map_err(|e| Error::user(e).with_status(StatusCode::UNAUTHORIZED))?
+        .ok_or_else(|| Error::unauthorized("answer API token was not present"))
+        .map(|s| s.expose_secret().to_owned())?;
+
+    reqwest::Client::new()
+        .get(format!("{}/v2/get-usage-quota", app.config.answer_api_url))
+        .bearer_auth(answer_api_token)
+        .send()
+        .await
+        .map_err(Error::internal)?
+        .json()
+        .await
+        .map_err(Error::internal)
+        .map(Json)
+}
+
+#[derive(serde::Deserialize, serde::Serialize)]
+struct SubscriptionResponse {
+    url: String,
+}
+
+pub async fn create_checkout_session(
+    app: Extension<Application>,
+) -> super::Result<Json<QuotaResponse>> {
+    let answer_api_token = app
+        .answer_api_token()
+        .map_err(|e| Error::user(e).with_status(StatusCode::UNAUTHORIZED))?
+        .ok_or_else(|| Error::unauthorized("answer API token was not present"))
+        .map(|s| s.expose_secret().to_owned())?;
+
+    reqwest::Client::new()
+        .get(format!(
+            "{}/v2/create-checkout-session",
+            app.config.answer_api_url
+        ))
+        .bearer_auth(answer_api_token)
+        .send()
+        .await
+        .map_err(Error::internal)?
+        .json()
+        .await
+        .map_err(Error::internal)
+        .map(Json)
+}

--- a/server/bleep/src/webserver/quota.rs
+++ b/server/bleep/src/webserver/quota.rs
@@ -9,7 +9,7 @@ use super::Error;
 #[derive(serde::Deserialize, serde::Serialize)]
 pub struct QuotaResponse {
     paid: bool,
-    used: u32,
+    used: String,
 }
 
 pub async fn get(app: Extension<Application>) -> super::Result<Json<QuotaResponse>> {
@@ -32,13 +32,13 @@ pub async fn get(app: Extension<Application>) -> super::Result<Json<QuotaRespons
 }
 
 #[derive(serde::Deserialize, serde::Serialize)]
-struct SubscriptionResponse {
+pub struct SubscriptionResponse {
     url: String,
 }
 
 pub async fn create_checkout_session(
     app: Extension<Application>,
-) -> super::Result<Json<QuotaResponse>> {
+) -> super::Result<Json<SubscriptionResponse>> {
     let answer_api_token = app
         .answer_api_token()
         .map_err(|e| Error::user(e).with_status(StatusCode::UNAUTHORIZED))?

--- a/server/bleep/src/webserver/studio.rs
+++ b/server/bleep/src/webserver/studio.rs
@@ -519,6 +519,7 @@ pub async fn generate(
         .map(|s| s.expose_secret().clone());
 
     let llm_gateway = llm_gateway::Client::new(&app.config.answer_api_url)
+        .quota_gated(true)
         .model(LLM_GATEWAY_MODEL)
         .temperature(0.0)
         .bearer(answer_api_token);


### PR DESCRIPTION
Depends on answer-api#54

Here, we add 2 new routes:

- `GET /api/quota`: This will return an object like `{ paid: boolean, used: string (a stringified number) }`
- `GET /api/quota/create-checkout-session`: This will create a checkout session if the user is new, or if they have already purchased a plan, return a link to adjust the plan. The returned object looks like `{ url: string }`, with a Stripe URL.

Additionally, each call to `/studio/:id/generate` will be quota-limited, such that after hitting 10 requests in one day (as configured currently), future calls will fail. The front-end can ensure we don't hit an error here by disabling the `Generate` button when the `used` value is below 10.

Note that the Answer API must be quota-enabled for this to work. Instructions are listed in the relevant PR.