### PR TITLE
Studio: get file tokens

### DIFF
--- a/server/bleep/src/webserver.rs
+++ b/server/bleep/src/webserver.rs
@@ -89,6 +89,7 @@ pub async fn start(app: Application) -> anyhow::Result<()> {
             "/studio/:studio_id/snapshots/:snapshot_id",
             delete(studio::delete_snapshot),
         )
+        .route("/studio/file-token-count", post(studio::get_file_token_count))
         .route("/template", post(template::create))
         .route("/template", get(template::list))
         .route(


### PR DESCRIPTION
With the latest change on the FE, we no longer save a file to context as soon as it is selected, nor when the line ranges change.  Now we save changes on submit. This leads to an issue that the token counter cannot show the current number of tokens when the user adds a file to context or changes ranges. This PR adds a separate endpoint to only get a number of tokens for a given file (and optionally ranges). Note that this endpoint is a POST, although it would make more sense to make it a GET, but passing an array of arrays in query params turned out to be extremely tricky.