### PR TITLE
fix env.API_URL example

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -2,7 +2,7 @@
 
 ## Searching in the browser
 
-You can use bloop in the browser, without running the Tauri app. First follow [the steps](./../server/README.md) to install and run the search server. Make sure that `API_URL` is set in `.env` (e.g. `API_URL=http://localhost:7878`). Then, in the root directory run:
+You can use bloop in the browser, without running the Tauri app. First follow [the steps](./../server/README.md) to install and run the search server. Make sure that `API_URL` is set in `.env` (e.g. `API_URL=http://localhost:7878/api`). Then, in the root directory run:
 
 ```
 npm install


### PR DESCRIPTION
We need to include '/api' in the environment variable API_URL.

for `npm run start-web`
https://github.com/BloopAI/bloop/blob/e32c351563cffff85eb0230a82598ed4704e7369/client/src/CloudApp.tsx#L40

for `npm run start-app`
https://github.com/BloopAI/bloop/blob/9c03a8450882468ecc4e094ddc7694f5f8b32f96/apps/desktop/src/App.tsx#L164
https://github.com/BloopAI/bloop/blob/9c03a8450882468ecc4e094ddc7694f5f8b32f96/apps/desktop/src/App.tsx#L201