### PR TITLE
Store `user_id` on all templates

### DIFF
--- a/server/bleep/migrations/20230911161509_template_user_id.sql
+++ b/server/bleep/migrations/20230911161509_template_user_id.sql
@@ -1,2 +1,32 @@
+-- This migration codifies the idea of "default" templates into the schema. These are simply
+-- templates which have a `NULL` `user_id` value. We also re-create default templates here, in case
+-- they have been edited. Now, we want to *maintain* "default" templates, copying them when modified
+-- instead of overwriting them.
+
+ALTER TABLE templates ADD COLUMN user_id TEXT;
 DELETE FROM templates;
-ALTER TABLE templates ADD COLUMN user_id TEXT NOT NULL;
+INSERT INTO templates (
+  name,
+  content
+) VALUES (
+  'Write a test',
+  'Perform the following steps:
+
+Step 1: Describe the purpose of the code
+Step 2: Identify which functions would benefit from unit testing
+Step 3: Write a unit test for each of those functions'
+), (
+  'Code review',
+  'You''re a senior software engineer responsible for making sure no code makes it into production that doesn''t pass these rules:
+- All identifiers in the code have been named semantically so that their purpose is understood
+- All logic has been written in the most efficient way possible, optimising for the lowest compute consumption
+- Comments have been written where necessary to help future developers understand this code
+
+Your job is to 1) produce a list of issues related to the provided code and 2) provide example fixes for each issue'
+), (
+  'Explanation',
+  'I''m a new software engineer looking to learn about this codebase. As you''re a senior software engineer, could you please explain:
+1. The business purpose of this code
+2. The user journey
+3. How the code works, in the order of the user journey'
+);

--- a/server/bleep/migrations/20230911161509_template_user_id.sql
+++ b/server/bleep/migrations/20230911161509_template_user_id.sql
@@ -1,0 +1,2 @@
+DELETE FROM templates;
+ALTER TABLE templates ADD COLUMN user_id TEXT NOT NULL;

--- a/server/bleep/sqlx-data.json
+++ b/server/bleep/sqlx-data.json
@@ -36,6 +36,24 @@
     },
     "query": "SELECT\n            s.id,\n            s.name,\n            ss.modified_at as \"modified_at!\",\n            ss.context\n        FROM studios s\n        INNER JOIN studio_snapshots ss ON s.id = ss.studio_id\n        WHERE s.user_id = ? AND (ss.studio_id, ss.modified_at) IN (\n            SELECT studio_id, MAX(modified_at)\n            FROM studio_snapshots\n            GROUP BY studio_id\n        )"
   },
+  "069c6404909c217e0b27e974480cce3f592a0d43ece6dec17fbcee37ce7a6ffa": {
+    "describe": {
+      "columns": [
+        {
+          "name": "user_id",
+          "ordinal": 0,
+          "type_info": "Text"
+        }
+      ],
+      "nullable": [
+        true
+      ],
+      "parameters": {
+        "Right": 2
+      }
+    },
+    "query": "SELECT user_id FROM templates WHERE id = ? AND (user_id = ? OR user_id IS NULL)"
+  },
   "0c72c51f4a5b726f6f524fcb269f074550b1a3a25ed050fb2701f8bec02678d7": {
     "describe": {
       "columns": [],
@@ -84,6 +102,48 @@
     },
     "query": "INSERT INTO studio_snapshots(studio_id, context, messages) VALUES (?, ?, ?)"
   },
+  "379eebe0708c4eaacf217368200c618e55e25f405b81e999dafb77a7579e2af4": {
+    "describe": {
+      "columns": [
+        {
+          "name": "id",
+          "ordinal": 0,
+          "type_info": "Int64"
+        },
+        {
+          "name": "name",
+          "ordinal": 1,
+          "type_info": "Text"
+        },
+        {
+          "name": "modified_at",
+          "ordinal": 2,
+          "type_info": "Datetime"
+        },
+        {
+          "name": "content",
+          "ordinal": 3,
+          "type_info": "Text"
+        },
+        {
+          "name": "is_default: bool",
+          "ordinal": 4,
+          "type_info": "Int"
+        }
+      ],
+      "nullable": [
+        false,
+        false,
+        false,
+        false,
+        false
+      ],
+      "parameters": {
+        "Right": 1
+      }
+    },
+    "query": "SELECT id, name, modified_at, content, user_id IS NULL as \"is_default: bool\"\n        FROM templates\n        WHERE user_id = ? OR user_id IS NULL"
+  },
   "392b563bb3af6711817fe99335d053691750426762dcde7b0381dc9f69cd804e": {
     "describe": {
       "columns": [],
@@ -111,42 +171,6 @@
       }
     },
     "query": "SELECT ss.id\n        FROM studio_snapshots ss\n        JOIN studios s ON s.id = ss.studio_id AND s.user_id = ?\n        WHERE ss.studio_id = ?\n        ORDER BY ss.modified_at DESC\n        LIMIT 1"
-  },
-  "449c90c85dc8afd68e50448549d0a4f3a5cf591c8330e0b9c69c7a2dde8cd97d": {
-    "describe": {
-      "columns": [
-        {
-          "name": "id",
-          "ordinal": 0,
-          "type_info": "Int64"
-        },
-        {
-          "name": "name",
-          "ordinal": 1,
-          "type_info": "Text"
-        },
-        {
-          "name": "modified_at",
-          "ordinal": 2,
-          "type_info": "Datetime"
-        },
-        {
-          "name": "content",
-          "ordinal": 3,
-          "type_info": "Text"
-        }
-      ],
-      "nullable": [
-        false,
-        false,
-        false,
-        false
-      ],
-      "parameters": {
-        "Right": 1
-      }
-    },
-    "query": "SELECT id, name, modified_at, content FROM templates WHERE user_id = ?"
   },
   "476c0b82963b9a2333edec797133770f32c8269a21a17d3165e7785f69e886ab": {
     "describe": {
@@ -278,24 +302,6 @@
     },
     "query": "UPDATE templates SET modified_at = datetime('now') WHERE id = ?"
   },
-  "623d5ba93bde27df707f2b7807cca5d853e2a9f5cd8c9b8ddc681776af50fdcc": {
-    "describe": {
-      "columns": [
-        {
-          "name": "id",
-          "ordinal": 0,
-          "type_info": "Int64"
-        }
-      ],
-      "nullable": [
-        false
-      ],
-      "parameters": {
-        "Right": 2
-      }
-    },
-    "query": "SELECT id FROM templates WHERE id = ? AND user_id = ?"
-  },
   "63938812eb2374512bb6dd750e14f363f67471ca85c2ed27f7c4b9404f5a875f": {
     "describe": {
       "columns": [],
@@ -395,6 +401,48 @@
       }
     },
     "query": "SELECT title, repo_ref, exchanges\n        FROM conversations\n        WHERE user_id = ? AND thread_id = ?"
+  },
+  "6e842ac5eb4b5be53dff501a24b6b91c0557d6a7119480441a60c8e99de7daf1": {
+    "describe": {
+      "columns": [
+        {
+          "name": "id",
+          "ordinal": 0,
+          "type_info": "Int64"
+        },
+        {
+          "name": "name",
+          "ordinal": 1,
+          "type_info": "Text"
+        },
+        {
+          "name": "modified_at",
+          "ordinal": 2,
+          "type_info": "Datetime"
+        },
+        {
+          "name": "content",
+          "ordinal": 3,
+          "type_info": "Text"
+        },
+        {
+          "name": "is_default: bool",
+          "ordinal": 4,
+          "type_info": "Int"
+        }
+      ],
+      "nullable": [
+        false,
+        false,
+        false,
+        false,
+        false
+      ],
+      "parameters": {
+        "Right": 2
+      }
+    },
+    "query": "SELECT id, name, modified_at, content, user_id IS NULL as \"is_default: bool\"\n        FROM templates\n        WHERE id = ? AND (user_id = ? OR user_id IS NULL)"
   },
   "76464f75732fee5c742a23d7a0b95de1def360bae7943a2389944b0177106033": {
     "describe": {
@@ -728,42 +776,6 @@
     },
     "query": "SELECT repo_ref, exchanges FROM conversations WHERE user_id = ? AND thread_id = ?"
   },
-  "e807398025b2b80405d3653e9ffc339d29d69d40dc2a57c4f1824822ab9da298": {
-    "describe": {
-      "columns": [
-        {
-          "name": "id",
-          "ordinal": 0,
-          "type_info": "Int64"
-        },
-        {
-          "name": "name",
-          "ordinal": 1,
-          "type_info": "Text"
-        },
-        {
-          "name": "modified_at",
-          "ordinal": 2,
-          "type_info": "Datetime"
-        },
-        {
-          "name": "content",
-          "ordinal": 3,
-          "type_info": "Text"
-        }
-      ],
-      "nullable": [
-        false,
-        false,
-        false,
-        false
-      ],
-      "parameters": {
-        "Right": 2
-      }
-    },
-    "query": "SELECT id, name, modified_at, content FROM templates WHERE id = ? AND user_id = ?"
-  },
   "ec193a038eb7fc3aaca3c3adebcc4dbde01b47ae34ac2df2227c5e5459617182": {
     "describe": {
       "columns": [],
@@ -783,5 +795,23 @@
       }
     },
     "query": "DELETE FROM chunk_cache WHERE repo_ref = ?"
+  },
+  "fd74b491f6b06bb58c7d62b461094e5463e397bb649ae338c2b1a0e67e6155c3": {
+    "describe": {
+      "columns": [
+        {
+          "name": "id",
+          "ordinal": 0,
+          "type_info": "Int64"
+        }
+      ],
+      "nullable": [
+        true
+      ],
+      "parameters": {
+        "Right": 2
+      }
+    },
+    "query": "INSERT INTO templates(name, content, user_id)\n            SELECT name, content, ?\n            FROM templates\n            WHERE id = ?\n            RETURNING id"
   }
 }

--- a/server/bleep/sqlx-data.json
+++ b/server/bleep/sqlx-data.json
@@ -46,42 +46,6 @@
     },
     "query": "INSERT INTO studio_snapshots (studio_id, context, messages)\n         VALUES (?, ?, ?)"
   },
-  "109cbc6bd18131c59718a575c5e09b78a4d8f28667d347ced1a13f1b4be7e2eb": {
-    "describe": {
-      "columns": [
-        {
-          "name": "id",
-          "ordinal": 0,
-          "type_info": "Int64"
-        },
-        {
-          "name": "name",
-          "ordinal": 1,
-          "type_info": "Text"
-        },
-        {
-          "name": "modified_at",
-          "ordinal": 2,
-          "type_info": "Datetime"
-        },
-        {
-          "name": "content",
-          "ordinal": 3,
-          "type_info": "Text"
-        }
-      ],
-      "nullable": [
-        false,
-        false,
-        false,
-        false
-      ],
-      "parameters": {
-        "Right": 1
-      }
-    },
-    "query": "SELECT id, name, modified_at, content FROM templates WHERE id = ?"
-  },
   "11f5e7122d047f87c398cf56470c284e2037203bc4d1506efc85e7431e2e2f5f": {
     "describe": {
       "columns": [
@@ -109,24 +73,6 @@
       }
     },
     "query": "INSERT INTO conversations (user_id, thread_id, repo_ref, title, exchanges, created_at) VALUES (?, ?, ?, ?, ?, strftime('%s', 'now'))"
-  },
-  "1650f7ee180dfc3169cd92ec20483663e118831b48274fbea6ca819808bcd9d1": {
-    "describe": {
-      "columns": [
-        {
-          "name": "id",
-          "ordinal": 0,
-          "type_info": "Int64"
-        }
-      ],
-      "nullable": [
-        false
-      ],
-      "parameters": {
-        "Right": 1
-      }
-    },
-    "query": "SELECT id FROM templates WHERE id = ?"
   },
   "359b4d0fa1fcb081767303103b23f0650568cf4e79787c7ddcd21af5bad6761b": {
     "describe": {
@@ -165,6 +111,42 @@
       }
     },
     "query": "SELECT ss.id\n        FROM studio_snapshots ss\n        JOIN studios s ON s.id = ss.studio_id AND s.user_id = ?\n        WHERE ss.studio_id = ?\n        ORDER BY ss.modified_at DESC\n        LIMIT 1"
+  },
+  "449c90c85dc8afd68e50448549d0a4f3a5cf591c8330e0b9c69c7a2dde8cd97d": {
+    "describe": {
+      "columns": [
+        {
+          "name": "id",
+          "ordinal": 0,
+          "type_info": "Int64"
+        },
+        {
+          "name": "name",
+          "ordinal": 1,
+          "type_info": "Text"
+        },
+        {
+          "name": "modified_at",
+          "ordinal": 2,
+          "type_info": "Datetime"
+        },
+        {
+          "name": "content",
+          "ordinal": 3,
+          "type_info": "Text"
+        }
+      ],
+      "nullable": [
+        false,
+        false,
+        false,
+        false
+      ],
+      "parameters": {
+        "Right": 1
+      }
+    },
+    "query": "SELECT id, name, modified_at, content FROM templates WHERE user_id = ?"
   },
   "476c0b82963b9a2333edec797133770f32c8269a21a17d3165e7785f69e886ab": {
     "describe": {
@@ -266,6 +248,16 @@
     },
     "query": "DELETE FROM chunk_cache WHERE chunk_hash = ? AND file_hash = ?"
   },
+  "523e2fd0c4f2c3318e894af3537b1c2e503e0865fcaabc4bdda43960ca0ef45c": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Right": 3
+      }
+    },
+    "query": "INSERT INTO templates (name, content, user_id) VALUES (?, ?, ?)"
+  },
   "5776008bf71ba2a90bad43c66a6e622ad71a81e1751c00b62aafa70840997999": {
     "describe": {
       "columns": [],
@@ -276,42 +268,6 @@
     },
     "query": "UPDATE templates SET content = ? WHERE id = ?"
   },
-  "5840a627d06f7e3fe4681954fd6d36c4b33924f97803a988c2b3a9e31dfee402": {
-    "describe": {
-      "columns": [
-        {
-          "name": "id",
-          "ordinal": 0,
-          "type_info": "Int64"
-        },
-        {
-          "name": "name",
-          "ordinal": 1,
-          "type_info": "Text"
-        },
-        {
-          "name": "modified_at",
-          "ordinal": 2,
-          "type_info": "Datetime"
-        },
-        {
-          "name": "content",
-          "ordinal": 3,
-          "type_info": "Text"
-        }
-      ],
-      "nullable": [
-        false,
-        false,
-        false,
-        false
-      ],
-      "parameters": {
-        "Right": 0
-      }
-    },
-    "query": "SELECT id, name, modified_at, content FROM templates"
-  },
   "5bdd10bd3029a70911749c200c1680224e2fb9f4ce1bf463a6ebfcdf3de10ad6": {
     "describe": {
       "columns": [],
@@ -321,6 +277,24 @@
       }
     },
     "query": "UPDATE templates SET modified_at = datetime('now') WHERE id = ?"
+  },
+  "623d5ba93bde27df707f2b7807cca5d853e2a9f5cd8c9b8ddc681776af50fdcc": {
+    "describe": {
+      "columns": [
+        {
+          "name": "id",
+          "ordinal": 0,
+          "type_info": "Int64"
+        }
+      ],
+      "nullable": [
+        false
+      ],
+      "parameters": {
+        "Right": 2
+      }
+    },
+    "query": "SELECT id FROM templates WHERE id = ? AND user_id = ?"
   },
   "63938812eb2374512bb6dd750e14f363f67471ca85c2ed27f7c4b9404f5a875f": {
     "describe": {
@@ -392,16 +366,6 @@
     },
     "query": "INSERT INTO studios(name, user_id) VALUES (?, ?) RETURNING id"
   },
-  "69e7fcbe274e645ac8dece40ddad39b5f594731e4647a683f4537ede7e20b3d4": {
-    "describe": {
-      "columns": [],
-      "nullable": [],
-      "parameters": {
-        "Right": 2
-      }
-    },
-    "query": "INSERT INTO templates (name, content) VALUES (?, ?)"
-  },
   "6e3bfe277ca4506bc389597db418b311c4faabf5af132f81699997e4d766e40d": {
     "describe": {
       "columns": [
@@ -431,6 +395,24 @@
       }
     },
     "query": "SELECT title, repo_ref, exchanges\n        FROM conversations\n        WHERE user_id = ? AND thread_id = ?"
+  },
+  "76464f75732fee5c742a23d7a0b95de1def360bae7943a2389944b0177106033": {
+    "describe": {
+      "columns": [
+        {
+          "name": "id",
+          "ordinal": 0,
+          "type_info": "Int64"
+        }
+      ],
+      "nullable": [
+        true
+      ],
+      "parameters": {
+        "Right": 2
+      }
+    },
+    "query": "DELETE FROM templates WHERE id = ? AND user_id = ? RETURNING id"
   },
   "7ca39c2d8aebd7ebe1dbda00b4fb5fce6f4ea17894ce64c3d9786585c61739f0": {
     "describe": {
@@ -487,24 +469,6 @@
       }
     },
     "query": "UPDATE chunk_cache SET branches = ? WHERE chunk_hash = ?"
-  },
-  "9abe5ab6b9b3ccbcea0eab3750f3a7cfa00e9fe3eaf77db18c639fec8061800f": {
-    "describe": {
-      "columns": [
-        {
-          "name": "id",
-          "ordinal": 0,
-          "type_info": "Int64"
-        }
-      ],
-      "nullable": [
-        false
-      ],
-      "parameters": {
-        "Right": 1
-      }
-    },
-    "query": "DELETE FROM templates WHERE id = ? RETURNING id"
   },
   "9f862a56e79cc9ae6e9b896064a0057335b40225be0a8c8d29d9227de12ae364": {
     "describe": {
@@ -763,6 +727,42 @@
       }
     },
     "query": "SELECT repo_ref, exchanges FROM conversations WHERE user_id = ? AND thread_id = ?"
+  },
+  "e807398025b2b80405d3653e9ffc339d29d69d40dc2a57c4f1824822ab9da298": {
+    "describe": {
+      "columns": [
+        {
+          "name": "id",
+          "ordinal": 0,
+          "type_info": "Int64"
+        },
+        {
+          "name": "name",
+          "ordinal": 1,
+          "type_info": "Text"
+        },
+        {
+          "name": "modified_at",
+          "ordinal": 2,
+          "type_info": "Datetime"
+        },
+        {
+          "name": "content",
+          "ordinal": 3,
+          "type_info": "Text"
+        }
+      ],
+      "nullable": [
+        false,
+        false,
+        false,
+        false
+      ],
+      "parameters": {
+        "Right": 2
+      }
+    },
+    "query": "SELECT id, name, modified_at, content FROM templates WHERE id = ? AND user_id = ?"
   },
   "ec193a038eb7fc3aaca3c3adebcc4dbde01b47ae34ac2df2227c5e5459617182": {
     "describe": {

--- a/server/bleep/src/webserver/template.rs
+++ b/server/bleep/src/webserver/template.rs
@@ -1,5 +1,6 @@
 use super::{middleware::User, Error, ErrorKind};
 use crate::{webserver, Application};
+use anyhow::Context;
 use axum::extract::{Extension, Json, Path};
 use chrono::NaiveDateTime;
 use serde::Deserialize;
@@ -27,8 +28,7 @@ pub async fn create(
         user_id,
     )
     .execute(&*app.sql)
-    .await
-    .map_err(Error::internal)?
+    .await?
     .last_insert_rowid();
 
     Ok(id.to_string())
@@ -40,6 +40,7 @@ pub struct Template {
     name: String,
     modified_at: NaiveDateTime,
     content: String,
+    is_default: bool,
 }
 
 pub async fn list(
@@ -53,12 +54,13 @@ pub async fn list(
 
     let templates = sqlx::query_as!(
         Template,
-        "SELECT id, name, modified_at, content FROM templates WHERE user_id = ?",
+        "SELECT id, name, modified_at, content, user_id IS NULL as \"is_default: bool\"
+        FROM templates
+        WHERE user_id = ? OR user_id IS NULL",
         user_id,
     )
     .fetch_all(&*app.sql)
-    .await
-    .map_err(Error::internal)?;
+    .await?;
 
     Ok(Json(templates))
 }
@@ -75,13 +77,14 @@ pub async fn get(
 
     let template = sqlx::query_as!(
         Template,
-        "SELECT id, name, modified_at, content FROM templates WHERE id = ? AND user_id = ?",
+        "SELECT id, name, modified_at, content, user_id IS NULL as \"is_default: bool\"
+        FROM templates
+        WHERE id = ? AND (user_id = ? OR user_id IS NULL)",
         id,
         user_id,
     )
     .fetch_optional(&*app.sql)
-    .await
-    .map_err(Error::internal)?
+    .await?
     .ok_or_else(|| Error::new(ErrorKind::NotFound, "Template not found"))?;
 
     Ok(Json(template))
@@ -96,39 +99,53 @@ pub struct Patch {
 pub async fn patch(
     app: Extension<Application>,
     user: Extension<User>,
-    Path(id): Path<String>,
+    Path(mut id): Path<i64>,
     Json(patch): Json<Patch>,
-) -> webserver::Result<()> {
+) -> webserver::Result<String> {
     let user_id = user
         .login()
         .ok_or_else(|| super::Error::user("didn't have user ID"))?
         .to_string();
 
-    let mut transaction = app.sql.begin().await.map_err(Error::internal)?;
+    let mut transaction = app.sql.begin().await?;
 
     // Ensure the ID is valid first.
-    sqlx::query!(
-        "SELECT id FROM templates WHERE id = ? AND user_id = ?",
+    let template_user_id = sqlx::query!(
+        "SELECT user_id FROM templates WHERE id = ? AND (user_id = ? OR user_id IS NULL)",
         id,
-        user_id
+        user_id,
     )
     .fetch_optional(&mut transaction)
-    .await
-    .map_err(Error::internal)?
+    .await?
+    .map(|row| row.user_id)
     .ok_or_else(|| Error::new(ErrorKind::NotFound, "unknown template ID"))?;
+
+    if template_user_id.is_none() {
+        id = sqlx::query! {
+            "INSERT INTO templates(name, content, user_id)
+            SELECT name, content, ?
+            FROM templates
+            WHERE id = ?
+            RETURNING id",
+            user_id,
+            id,
+        }
+        .fetch_one(&mut transaction)
+        .await
+        .map(|row| row.id)?
+        .context("query didn't return new ID")?;
+    }
 
     if let Some(name) = patch.name {
         sqlx::query!("UPDATE templates SET name = ? WHERE id = ?", name, id)
             .execute(&mut transaction)
-            .await
-            .map_err(Error::internal)?;
+            .await?;
     }
 
     if let Some(content) = patch.content {
         sqlx::query!("UPDATE templates SET content = ? WHERE id = ?", content, id)
             .execute(&mut transaction)
-            .await
-            .map_err(Error::internal)?;
+            .await?;
     }
 
     sqlx::query!(
@@ -136,18 +153,17 @@ pub async fn patch(
         id
     )
     .execute(&mut transaction)
-    .await
-    .map_err(Error::internal)?;
+    .await?;
 
-    transaction.commit().await.map_err(Error::internal)?;
+    transaction.commit().await?;
 
-    Ok(())
+    Ok(id.to_string())
 }
 
 pub async fn delete(
     app: Extension<Application>,
     user: Extension<User>,
-    Path(id): Path<String>,
+    Path(id): Path<i64>,
 ) -> webserver::Result<()> {
     let user_id = user
         .login()
@@ -160,8 +176,7 @@ pub async fn delete(
         user_id
     )
     .fetch_optional(&*app.sql)
-    .await
-    .map_err(Error::internal)?
+    .await?
     .ok_or_else(|| Error::new(ErrorKind::NotFound, "unknown template ID"))
     .map(|_| ())
 }

--- a/server/bleep/src/webserver/template.rs
+++ b/server/bleep/src/webserver/template.rs
@@ -1,4 +1,4 @@
-use super::{Error, ErrorKind};
+use super::{middleware::User, Error, ErrorKind};
 use crate::{webserver, Application};
 use axum::extract::{Extension, Json, Path};
 use chrono::NaiveDateTime;
@@ -12,12 +12,19 @@ pub struct Create {
 
 pub async fn create(
     app: Extension<Application>,
+    user: Extension<User>,
     params: Json<Create>,
 ) -> webserver::Result<String> {
+    let user_id = user
+        .login()
+        .ok_or_else(|| super::Error::user("didn't have user ID"))?
+        .to_string();
+
     let id = sqlx::query!(
-        "INSERT INTO templates (name, content) VALUES (?, ?)",
+        "INSERT INTO templates (name, content, user_id) VALUES (?, ?, ?)",
         params.name,
-        params.content
+        params.content,
+        user_id,
     )
     .execute(&*app.sql)
     .await
@@ -35,10 +42,19 @@ pub struct Template {
     content: String,
 }
 
-pub async fn list(app: Extension<Application>) -> webserver::Result<Json<Vec<Template>>> {
+pub async fn list(
+    app: Extension<Application>,
+    user: Extension<User>,
+) -> webserver::Result<Json<Vec<Template>>> {
+    let user_id = user
+        .login()
+        .ok_or_else(|| super::Error::user("didn't have user ID"))?
+        .to_string();
+
     let templates = sqlx::query_as!(
         Template,
-        "SELECT id, name, modified_at, content FROM templates"
+        "SELECT id, name, modified_at, content FROM templates WHERE user_id = ?",
+        user_id,
     )
     .fetch_all(&*app.sql)
     .await
@@ -49,12 +65,19 @@ pub async fn list(app: Extension<Application>) -> webserver::Result<Json<Vec<Tem
 
 pub async fn get(
     app: Extension<Application>,
+    user: Extension<User>,
     Path(id): Path<String>,
 ) -> webserver::Result<Json<Template>> {
+    let user_id = user
+        .login()
+        .ok_or_else(|| super::Error::user("didn't have user ID"))?
+        .to_string();
+
     let template = sqlx::query_as!(
         Template,
-        "SELECT id, name, modified_at, content FROM templates WHERE id = ?",
-        id
+        "SELECT id, name, modified_at, content FROM templates WHERE id = ? AND user_id = ?",
+        id,
+        user_id,
     )
     .fetch_optional(&*app.sql)
     .await
@@ -72,17 +95,27 @@ pub struct Patch {
 
 pub async fn patch(
     app: Extension<Application>,
+    user: Extension<User>,
     Path(id): Path<String>,
     Json(patch): Json<Patch>,
 ) -> webserver::Result<()> {
+    let user_id = user
+        .login()
+        .ok_or_else(|| super::Error::user("didn't have user ID"))?
+        .to_string();
+
     let mut transaction = app.sql.begin().await.map_err(Error::internal)?;
 
     // Ensure the ID is valid first.
-    sqlx::query!("SELECT id FROM templates WHERE id = ?", id)
-        .fetch_optional(&mut transaction)
-        .await
-        .map_err(Error::internal)?
-        .ok_or_else(|| Error::new(ErrorKind::NotFound, "unknown template ID"))?;
+    sqlx::query!(
+        "SELECT id FROM templates WHERE id = ? AND user_id = ?",
+        id,
+        user_id
+    )
+    .fetch_optional(&mut transaction)
+    .await
+    .map_err(Error::internal)?
+    .ok_or_else(|| Error::new(ErrorKind::NotFound, "unknown template ID"))?;
 
     if let Some(name) = patch.name {
         sqlx::query!("UPDATE templates SET name = ? WHERE id = ?", name, id)
@@ -111,11 +144,24 @@ pub async fn patch(
     Ok(())
 }
 
-pub async fn delete(app: Extension<Application>, Path(id): Path<String>) -> webserver::Result<()> {
-    sqlx::query!("DELETE FROM templates WHERE id = ? RETURNING id", id)
-        .fetch_optional(&*app.sql)
-        .await
-        .map_err(Error::internal)?
-        .ok_or_else(|| Error::new(ErrorKind::NotFound, "unknown template ID"))
-        .map(|_| ())
+pub async fn delete(
+    app: Extension<Application>,
+    user: Extension<User>,
+    Path(id): Path<String>,
+) -> webserver::Result<()> {
+    let user_id = user
+        .login()
+        .ok_or_else(|| super::Error::user("didn't have user ID"))?
+        .to_string();
+
+    sqlx::query!(
+        "DELETE FROM templates WHERE id = ? AND user_id = ? RETURNING id",
+        id,
+        user_id
+    )
+    .fetch_optional(&*app.sql)
+    .await
+    .map_err(Error::internal)?
+    .ok_or_else(|| Error::new(ErrorKind::NotFound, "unknown template ID"))
+    .map(|_| ())
 }


### PR DESCRIPTION
***Note: this will delete *all* existing templates***

Now, we filter by `user_id` for template-related operations. "Default" templates now have a `NULL` `user_id` value. Route operation has changed slightly:

- `POST /template` will create a user-local template ID
- `GET /template/:id` will fetch a template if it is considered "default" *or* it belongs to the user
  - Template objects now include `{ ..., is_default: boolean }`
- `GET /template`
  - Template objects now include `{ ..., is_default: boolean }`
- `PATCH /template/:id` will work as before for user-local template, but patching a **default** template will internally create a new user-local template
  - This route now returns the template ID - the same `:id` as in the URL for user-local templates, and a *new* ID for new templates created when patching a **default** template
- `DELETE /template/:id` will *only* work for user-local templates. It is not possible to delete a **default** template, as these are migration-managed.

Closes BLO-1574