### PR TITLE
Auto-generate studio names

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -240,6 +240,22 @@ function App({ deviceContextValue }: Props) {
     [],
   );
 
+  const updateTabName = useCallback((tabKey: string, name: string) => {
+    setTabs((prev) => {
+      const tabIndex = prev.findIndex((t) => t.key === tabKey);
+      if (tabIndex < 0) {
+        return prev;
+      }
+      const newTab = {
+        ...prev[tabIndex],
+        name,
+      };
+      const newTabs = [...prev];
+      newTabs[tabIndex] = newTab;
+      return newTabs;
+    });
+  }, []);
+
   const handleKeyEvent = useCallback(
     (e: KeyboardEvent) => {
       if (e.metaKey || e.ctrlKey) {
@@ -277,6 +293,7 @@ function App({ deviceContextValue }: Props) {
       setActiveTab: handleChangeActiveTab,
       updateTabNavHistory,
       updateTabBranch,
+      updateTabName,
     }),
     [
       tabs,
@@ -285,6 +302,7 @@ function App({ deviceContextValue }: Props) {
       handleRemoveTab,
       updateTabNavHistory,
       updateTabBranch,
+      updateTabName,
     ],
   );
 

--- a/client/src/components/AddStudioContext/index.tsx
+++ b/client/src/components/AddStudioContext/index.tsx
@@ -84,16 +84,7 @@ const AddStudioContext = ({ filePath, threadId, name }: Props) => {
             console.log(err);
           }
         } else {
-          const exising = studios
-            .filter((s) => s.name.startsWith('New Code Studio'))
-            .sort((a, b) => a.name.localeCompare(b.name));
-          const lastNum = Number(
-            exising[exising.length - 1]?.name.split('#').pop() || 0,
-          );
-          const name = `New Code Studio${
-            exising.length ? ` #${Number.isNaN(lastNum) ? 1 : lastNum + 1}` : ''
-          }`;
-          const id = await postCodeStudio(name);
+          const id = await postCodeStudio();
           await patchCodeStudio(id, {
             context: [
               {
@@ -105,7 +96,7 @@ const AddStudioContext = ({ filePath, threadId, name }: Props) => {
               },
             ],
           });
-          handleAddStudioTab(name, id);
+          handleAddStudioTab('New Studio', id);
           refetchStudios();
         }
       } else if (threadId) {

--- a/client/src/context/tabsContext.ts
+++ b/client/src/context/tabsContext.ts
@@ -20,6 +20,7 @@ type ContextType = {
     history: (prev: NavigationItem[]) => NavigationItem[],
   ) => void;
   updateTabBranch: (t: string, branch: string | null) => void;
+  updateTabName: (t: string, name: string) => void;
 };
 
 export const TabsContext = createContext<ContextType>({
@@ -36,4 +37,5 @@ export const TabsContext = createContext<ContextType>({
   setActiveTab: () => {},
   updateTabNavHistory: () => {},
   updateTabBranch: () => {},
+  updateTabName: () => {},
 });

--- a/client/src/pages/HomeTab/CodeStudiosSection/CodeStudioCard.tsx
+++ b/client/src/pages/HomeTab/CodeStudiosSection/CodeStudioCard.tsx
@@ -18,6 +18,7 @@ import { deleteCodeStudio } from '../../../services/api';
 import FileIcon from '../../../components/FileIcon';
 import LiteLoaderContainer from '../../../components/Loaders/LiteLoader';
 import { PersonalQuotaContext } from '../../../context/personalQuotaContext';
+import Tooltip from '../../../components/Tooltip';
 
 type Props = {
   modified_at: string;
@@ -94,9 +95,15 @@ const CodeStudioCard = ({
             )}
           </span>
           <div className="min-h-[2.75rem] flex items-center">
-            <p className="break-word text-label-title -mt-1">
-              {name.length > 43 ? `${name.slice(0, 41)}...` : name}
-            </p>
+            {name.length > 43 ? (
+              <Tooltip text={name} placement={'top'}>
+                <p className="break-word text-label-title -mt-1">
+                  {name.slice(0, 41)}...
+                </p>
+              </Tooltip>
+            ) : (
+              <p className="break-word text-label-title -mt-1">{name}</p>
+            )}
           </div>
         </div>
         <div className="opacity-0 group-hover:opacity-100 focus-within:opacity-100 transition-all duration-150">

--- a/client/src/pages/HomeTab/Content.tsx
+++ b/client/src/pages/HomeTab/Content.tsx
@@ -105,6 +105,13 @@ const HomePage = ({ randomKey }: { randomKey?: any }) => {
     setAddReposOpen('studio');
   }, []);
 
+  const handleNewStudio = useCallback(() => {
+    postCodeStudio().then((id) => {
+      handleAddStudioTab('New Studio', id);
+      refreshCodeStudios();
+    });
+  }, []);
+
   return (
     <PageTemplate renderPage="home">
       <div className="w-full flex flex-col mx-auto max-w-6.5xl">
@@ -118,7 +125,7 @@ const HomePage = ({ randomKey }: { randomKey?: any }) => {
             {!isSelfServe && (
               <AddRepoCard type="local" onClick={setAddReposOpen} />
             )}
-            <AddRepoCard type="studio" onClick={setAddReposOpen} />
+            <AddRepoCard type="studio" onClick={handleNewStudio} />
           </div>
         </div>
         <div className="overflow-auto">
@@ -170,11 +177,6 @@ const HomePage = ({ randomKey }: { randomKey?: any }) => {
                 patchCodeStudio(studioToEdit.id, { name }).then(
                   refreshCodeStudios,
                 );
-              } else {
-                postCodeStudio(name).then((id) => {
-                  handleAddStudioTab(name, id);
-                  refreshCodeStudios();
-                });
               }
             } else if (isSubmitted) {
               fetchRepos();

--- a/client/src/pages/StudioTab/Content.tsx
+++ b/client/src/pages/StudioTab/Content.tsx
@@ -1,4 +1,11 @@
-import React, { memo, useCallback, useEffect, useMemo, useState } from 'react';
+import React, {
+  memo,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
 import * as Sentry from '@sentry/react';
 import { Trans } from 'react-i18next';
 import ErrorFallback from '../../components/ErrorFallback';
@@ -17,6 +24,7 @@ import { CodeStudioType, HistoryConversationTurn } from '../../types/api';
 import useResizeableSplitPanel from '../../hooks/useResizeableSplitPanel';
 import { TOKEN_LIMIT } from '../../consts/codeStudio';
 import { Info } from '../../icons';
+import { TabsContext } from '../../context/tabsContext';
 import ContextPanel from './ContextPanel';
 import HistoryPanel from './HistoryPanel';
 import TemplatesPanel from './TemplatesPanel';
@@ -57,11 +65,13 @@ const ContentContainer = ({
   const [isHistoryOpen, setIsHistoryOpen] = useState(false);
   const { leftPanelRef, rightPanelRef, dividerRef, containerRef } =
     useResizeableSplitPanel();
+  const { updateTabName } = useContext(TabsContext);
 
   const refetchCodeStudio = useCallback(
     async (keyToUpdate?: keyof CodeStudioType) => {
       if (tab.key) {
         const resp = await getCodeStudio(tab.key);
+        updateTabName(tab.key, resp.name);
         setCurrentState((prev) => {
           if (JSON.stringify(resp) === JSON.stringify(prev)) {
             return prev;

--- a/client/src/services/api.ts
+++ b/client/src/services/api.ts
@@ -290,8 +290,8 @@ export const getCodeStudioHistory = (
   http(`/studio/${id}/snapshots`).then((r) => r.data);
 export const deleteCodeStudio = (id: string): Promise<CodeStudioType> =>
   http.delete(`/studio/${id}`).then((r) => r.data);
-export const postCodeStudio = (name: string) =>
-  http.post('/studio', { name }).then((r) => r.data);
+export const postCodeStudio = () =>
+  http.post('/studio', {}).then((r) => r.data);
 export const importCodeStudio = (thread_id: string, studio_id?: string) =>
   http
     .post('/studio/import', {}, { params: { thread_id, studio_id } })

--- a/server/bleep/migrations/20230912084309_nullable_studio_name.sql
+++ b/server/bleep/migrations/20230912084309_nullable_studio_name.sql
@@ -1,0 +1,31 @@
+ALTER TABLE studios RENAME TO studios_old;
+ALTER TABLE studio_snapshots RENAME TO studio_snapshots_old;
+
+-- Identical to before, except we allow `name` to be null.
+CREATE TABLE studios (
+    id INTEGER PRIMARY KEY,
+    name TEXT,
+    user_id TEXT NOT NULL
+);
+
+CREATE TABLE studio_snapshots (
+    id INTEGER PRIMARY KEY,
+    studio_id INTEGER NOT NULL REFERENCES studios(id) ON DELETE CASCADE,
+
+    modified_at DATETIME NOT NULL DEFAULT (datetime('now')),
+
+    -- JSON serialized fields
+    context TEXT NOT NULL,
+    messages TEXT NOT NULL
+);
+
+INSERT INTO studios(id, name, user_id)
+SELECT id, name, user_id
+FROM studios_old;
+
+INSERT INTO studio_snapshots(id, studio_id, modified_at, context, messages)
+SELECT id, studio_id, modified_at, context, messages
+FROM studio_snapshots_old;
+
+DROP TABLE studio_snapshots_old;
+DROP TABLE studios_old;

--- a/server/bleep/sqlx-data.json
+++ b/server/bleep/sqlx-data.json
@@ -26,7 +26,7 @@
       ],
       "nullable": [
         false,
-        false,
+        true,
         false,
         false
       ],
@@ -53,6 +53,30 @@
       }
     },
     "query": "SELECT user_id FROM templates WHERE id = ? AND (user_id = ? OR user_id IS NULL)"
+  },
+  "081aa337d2c658e09c21c3f7ec2f5164296c66e78fad34d2e65b47a0de508aeb": {
+    "describe": {
+      "columns": [
+        {
+          "name": "context",
+          "ordinal": 0,
+          "type_info": "Text"
+        },
+        {
+          "name": "messages",
+          "ordinal": 1,
+          "type_info": "Text"
+        }
+      ],
+      "nullable": [
+        false,
+        false
+      ],
+      "parameters": {
+        "Right": 1
+      }
+    },
+    "query": "SELECT context, messages FROM studio_snapshots WHERE id = ?"
   },
   "0c72c51f4a5b726f6f524fcb269f074550b1a3a25ed050fb2701f8bec02678d7": {
     "describe": {
@@ -462,6 +486,24 @@
     },
     "query": "DELETE FROM templates WHERE id = ? AND user_id = ? RETURNING id"
   },
+  "77cb1637b38b9a0988d8e07c08d8086c9047b50a7c2a664171a851271b877f9b": {
+    "describe": {
+      "columns": [
+        {
+          "name": "id",
+          "ordinal": 0,
+          "type_info": "Int64"
+        }
+      ],
+      "nullable": [
+        false
+      ],
+      "parameters": {
+        "Right": 1
+      }
+    },
+    "query": "SELECT id FROM studios WHERE id = ? AND name IS NULL"
+  },
   "7ca39c2d8aebd7ebe1dbda00b4fb5fce6f4ea17894ce64c3d9786585c61739f0": {
     "describe": {
       "columns": [
@@ -587,7 +629,7 @@
       ],
       "nullable": [
         false,
-        false,
+        true,
         false,
         false,
         false

--- a/server/bleep/src/agent/prompts.rs
+++ b/server/bleep/src/agent/prompts.rs
@@ -322,3 +322,23 @@ pub fn final_explanation_prompt(context: &str, query: &str, query_history: &str)
         assert_eq!(try_parse_hypothetical_documents(document), expected);
     }
 }
+
+pub fn studio_name_prompt(context_json: &str, messages_json: &str) -> String {
+    format!(
+        "Your job is to generate a name for a conversation about software source code, given \
+        source code context and conversation history. Follow these rules strictly:\n\
+        - You MUST only return the new title, and NO additional text\n\
+        - Be brief, only return a few words, 3-5 is ideal\n\
+        - Do NOT respond with quotation marks, just the title itself\n\
+        \n\
+        Here is the source code context:\n\
+        =====\n\
+        {context_json}\n\
+        =====\n\
+        \n\
+        And here is the serialized conversation:\n\
+        =====\n\
+        {messages_json}\n\
+        ====="
+    )
+}

--- a/server/bleep/src/agent/prompts.rs
+++ b/server/bleep/src/agent/prompts.rs
@@ -250,6 +250,35 @@ You must use the following formatting rules at all times:
     )
 }
 
+pub fn studio_name_prompt(context_json: &str, messages_json: &str) -> String {
+    format!(
+        r#"Your job is to generate a name for a conversation about software source code, given source code context and conversation history.
+        
+Follow these rules strictly:
+    - You MUST only return the new title, and NO additional text
+    - Be brief, only return a few words, 3-5 is ideal
+    - Do NOT include quotation marks in your title
+    - Do NOT use gerunds (e.g. "Searching for...")
+
+Here are some example titles demonstrating the correct style:
+    - Rust PyO3 Function Reference
+    - Update HelmRelease Chart Version
+    - Readable Code and Tests
+
+######
+
+Here is the source code context:
+=====
+{context_json}
+=====
+
+And here is the serialized conversation:
+=====
+{messages_json}
+====="#
+    )
+}
+
 pub fn hypothetical_document_prompt(query: &str) -> String {
     format!(
         r#"Write a code snippet that could hypothetically be returned by a code search engine as the answer to the query: {query}
@@ -321,24 +350,4 @@ pub fn final_explanation_prompt(context: &str, query: &str, query_history: &str)
 
         assert_eq!(try_parse_hypothetical_documents(document), expected);
     }
-}
-
-pub fn studio_name_prompt(context_json: &str, messages_json: &str) -> String {
-    format!(
-        "Your job is to generate a name for a conversation about software source code, given \
-        source code context and conversation history. Follow these rules strictly:\n\
-        - You MUST only return the new title, and NO additional text\n\
-        - Be brief, only return a few words, 3-5 is ideal\n\
-        - Do NOT respond with quotation marks, just the title itself\n\
-        \n\
-        Here is the source code context:\n\
-        =====\n\
-        {context_json}\n\
-        =====\n\
-        \n\
-        And here is the serialized conversation:\n\
-        =====\n\
-        {messages_json}\n\
-        ====="
-    )
 }

--- a/server/bleep/src/lib.rs
+++ b/server/bleep/src/lib.rs
@@ -20,7 +20,7 @@ use git_version as _;
 #[cfg(all(feature = "debug", not(tokio_unstable)))]
 use console_subscriber as _;
 
-use secrecy::SecretString;
+use secrecy::{ExposeSecret, SecretString};
 use state::PersistedState;
 use std::{fs::canonicalize, sync::RwLock};
 use user::UserProfile;
@@ -349,6 +349,12 @@ impl Application {
         } else {
             None
         })
+    }
+
+    fn llm_gateway_client(&self) -> Result<llm_gateway::Client> {
+        let answer_api_token = self.answer_api_token()?.map(|s| s.expose_secret().clone());
+
+        Ok(llm_gateway::Client::new(&self.config.answer_api_url).bearer(answer_api_token))
     }
 }
 

--- a/server/bleep/src/webserver.rs
+++ b/server/bleep/src/webserver.rs
@@ -6,7 +6,7 @@ use axum::{
     routing::{delete, get, post},
     Extension, Json,
 };
-use std::{borrow::Cow, net::SocketAddr};
+use std::{borrow::Cow, fmt, net::SocketAddr};
 use tower::Service;
 use tower_http::services::{ServeDir, ServeFile};
 use tower_http::{catch_panic::CatchPanicLayer, cors::CorsLayer};
@@ -177,6 +177,12 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 pub struct Error {
     status: StatusCode,
     body: EndpointError<'static>,
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.body.message)
+    }
 }
 
 impl Error {

--- a/server/bleep/src/webserver/studio.rs
+++ b/server/bleep/src/webserver/studio.rs
@@ -76,12 +76,10 @@ pub async fn create(
 
     let user_id = user.login().ok_or_else(no_user_id)?.to_string();
 
-    let name = params.name.unwrap_or_else(|| "New Studio".to_owned());
-
     let studio_id: i64 = sqlx::query! {
         "INSERT INTO studios (user_id, name) VALUES (?, ?) RETURNING id",
         user_id,
-        name,
+        params.name,
     }
     .fetch_one(&mut transaction)
     .await?

--- a/server/bleep/src/webserver/studio.rs
+++ b/server/bleep/src/webserver/studio.rs
@@ -715,7 +715,7 @@ async fn populate_studio_name(
     let llm_gateway = app
         .llm_gateway_client()
         .map_err(|e| Error::user(e).with_status(StatusCode::UNAUTHORIZED))?
-        .model(LLM_GATEWAY_MODEL)
+        .model("gpt-3.5-turbo-0613")
         .temperature(0.0);
 
     let messages = &[llm_gateway::api::Message::system(

--- a/server/bleep/src/webserver/studio.rs
+++ b/server/bleep/src/webserver/studio.rs
@@ -728,6 +728,14 @@ async fn populate_studio_name(
         .try_collect::<String>()
         .await?;
 
+    // Normalize studio name by removing:
+    // - surrounding whitespace
+    // - enclosing quotation marks
+    // - the prefix phrase "Understanding "
+    let name = name.trim();
+    let name = name.trim_matches('"');
+    let name = name.trim_start_matches("Understanding ");
+
     debug!("populate studio `{studio_id}` with LLM-generated name: `{name}`");
 
     sqlx::query!("UPDATE studios SET name = ? WHERE id = ?", name, studio_id)

--- a/server/bleep/src/webserver/studio.rs
+++ b/server/bleep/src/webserver/studio.rs
@@ -715,7 +715,7 @@ async fn populate_studio_name(
     let llm_gateway = app
         .llm_gateway_client()
         .map_err(|e| Error::user(e).with_status(StatusCode::UNAUTHORIZED))?
-        .model("gpt-3.5-turbo-0613")
+        .model("gpt-3.5-turbo-16k-0613")
         .temperature(0.0);
 
     let messages = &[llm_gateway::api::Message::system(


### PR DESCRIPTION
Now, studio names are given a default name of `New Studio` if a name is not supplied at creation time. These studios will internally have a name of `NULL`, which will then attempt to be auto-populated in a call to `/studio/:id/generate`.

Note, the front-end currently still requires a studio name to be specified. To test this behaviour, you can set a studio's name to `NULL` with a sqlite database editor, and generate a response which will in turn populate the studio name.

Closes BLO-1505