### PR TITLE
Output file name in studio code blocks

### DIFF
--- a/client/src/components/MarkdownWithCode/CodeRenderer.tsx
+++ b/client/src/components/MarkdownWithCode/CodeRenderer.tsx
@@ -61,7 +61,7 @@ const CodeRenderer = ({
     [className],
   );
   const matchPath = useMemo(
-    () => /path:(.+),/.exec(className || ''),
+    () => /path:(.+?)(,|$)/.exec(className || ''),
     [className],
   );
   const matchLines = useMemo(
@@ -138,6 +138,7 @@ const CodeRenderer = ({
           <NewCode
             code={code}
             language={matchLang?.[1] || ''}
+            filePath={matchPath?.[1] || ''}
             isCodeStudio={isCodeStudio}
           />
         )

--- a/client/src/components/MarkdownWithCode/CodeRenderer.tsx
+++ b/client/src/components/MarkdownWithCode/CodeRenderer.tsx
@@ -53,6 +53,7 @@ const CodeRenderer = ({
   const matchLang = useMemo(
     () =>
       /lang:(\w+)/.exec(className || '') ||
+      /language:(\w+)/.exec(className || '') ||
       /language-(\w+)/.exec(className || ''),
     [className],
   );

--- a/client/src/components/MarkdownWithCode/NewCode.tsx
+++ b/client/src/components/MarkdownWithCode/NewCode.tsx
@@ -1,16 +1,24 @@
 import Code from '../CodeBlock/Code';
 import { getFileExtensionForLang, getPrettyLangName } from '../../utils';
 import FileIcon from '../FileIcon';
+import BreadcrumbsPath from '../BreadcrumbsPath';
 import CopyButton from './CopyButton';
 
 type Props = {
   code: string;
   language: string;
+  filePath: string;
   isSummary?: boolean;
   isCodeStudio?: boolean;
 };
 
-const NewCode = ({ code, language, isSummary, isCodeStudio }: Props) => {
+const NewCode = ({
+  code,
+  language,
+  isSummary,
+  isCodeStudio,
+  filePath,
+}: Props) => {
   return (
     <div
       className={`${
@@ -22,13 +30,17 @@ const NewCode = ({ code, language, isSummary, isCodeStudio }: Props) => {
       } border border-bg-border rounded-md relative group-code`}
     >
       {isCodeStudio && (
-        <div className="bg-bg-shade border-b border-bg-border p-2 flex items-center justify-between gap-2">
-          <div className="flex items-center gap-2">
+        <div className="bg-bg-shade border-b border-bg-border p-2 flex items-center justify-between gap-2 overflow-hidden">
+          <div className="flex items-center gap-2 overflow-hidden">
             <FileIcon
-              filename={getFileExtensionForLang(language, true)}
+              filename={filePath || getFileExtensionForLang(language, true)}
               noMargin
             />
-            {getPrettyLangName(language)}
+            {filePath ? (
+              <BreadcrumbsPath path={filePath} repo={''} nonInteractive />
+            ) : (
+              getPrettyLangName(language)
+            )}
           </div>
           <CopyButton isCodeStudio={isCodeStudio} code={code} />
         </div>

--- a/client/src/components/MarkdownWithCode/NewCode.tsx
+++ b/client/src/components/MarkdownWithCode/NewCode.tsx
@@ -31,7 +31,7 @@ const NewCode = ({
     >
       {isCodeStudio && (
         <div className="bg-bg-shade border-b border-bg-border p-2 flex items-center justify-between gap-2 overflow-hidden">
-          <div className="flex items-center gap-2 overflow-hidden">
+          <div className="flex items-center gap-2 overflow-hidden flex-1">
             <FileIcon
               filename={filePath || getFileExtensionForLang(language, true)}
               noMargin

--- a/server/bleep/src/agent/prompts.rs
+++ b/server/bleep/src/agent/prompts.rs
@@ -246,7 +246,18 @@ You must use the following formatting rules at all times:
 - If you do not have enough information needed to answer the query, do not make up an answer
 - When referring to code, you must provide an example in a code block
 - Keep number of quoted lines of code to a minimum when possible
-- Basic markdown is allowed"#
+- When quoting code in a code block, use the following info string format: language:LANG,path:PATH
+  - For example, to quote `src/main.c`:
+    ```language:c,path:src/main.c
+    int main() {{
+      printf("hello world!");
+    }}
+    ```
+  - For example, to quote `index.js`:
+  ```language:javascript,path:index.js
+  console.log("hello world!")
+  ```
+- Basic markdown is otherwise allowed"#
     )
 }
 


### PR DESCRIPTION
Now, code studio markdown blocks are emitted with an info string that includes both the language and file path. For example, to quote `src/main.rs`, the model will output a block in this format:

````
```language:rust,path:src/main.rs
fn main() {
    println!("hello world!");
}
```
````

This needs front-end support to work properly.