### PR TITLE
Remove junk `tar.gz` files from release assets

### DIFF
--- a/.github/workflows/tauri-release.yml
+++ b/.github/workflows/tauri-release.yml
@@ -140,7 +140,8 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/v')
         with:
           files: |
-            target/${{ matrix.target }}/release/bundle/**/*.deb
-            target/${{ matrix.target }}/release/bundle/**/*.AppImage
-            target/${{ matrix.target }}/release/bundle/**/*.dmg
-            target/${{ matrix.target }}/release/bundle/**/*.tar.gz
+            target/${{ matrix.target }}/release/bundle/dev/*.deb
+            target/${{ matrix.target }}/release/bundle/appimage/*.AppImage
+            target/${{ matrix.target }}/release/bundle/appimage/*.tar.gz
+            target/${{ matrix.target }}/release/bundle/dmg/*.dmg
+            target/${{ matrix.target }}/release/bundle/macos/*.tar.gz


### PR DESCRIPTION
Solution: specify source folders for release assets to avoid control.tar.gz and data.tar.gz, that come from `target/x86_64-unknown-linux-gnu/release/bundle/deb/bloop_0.5.2_amd64/` folder
What I have tried: select file paths in a previous step using the `find` bash command and provide them using GitHub step output or temp file in the last step. This doesn't work as `softprops/action-gh-release@v1` expect files to be an array of string separated with new lines, expressions don't get evaluated here.