### PR TITLE
Make use of our tokio-enabled rayon thread pool explicit

### DIFF
--- a/server/bleep/src/repo/iterator/fs.rs
+++ b/server/bleep/src/repo/iterator/fs.rs
@@ -1,3 +1,5 @@
+use crate::background;
+
 use super::*;
 
 use tracing::warn;
@@ -42,32 +44,35 @@ impl FileSource for FileWalker {
     }
 
     fn for_each(self, pipes: &SyncPipes, iterator: impl Fn(RepoDirEntry) + Sync + Send) {
-        self.file_list
-            .into_iter()
-            .filter_map(|entry_disk_path| {
-                if entry_disk_path.is_file() {
-                    let buffer = match std::fs::read_to_string(&entry_disk_path) {
-                        Err(err) => {
-                            warn!(%err, ?entry_disk_path, "read failed; skipping");
-                            return None;
-                        }
-                        Ok(buffer) => buffer,
-                    };
-                    Some(RepoDirEntry::File(RepoFile {
-                        buffer,
-                        path: entry_disk_path.to_string_lossy().to_string(),
-                        branches: vec![HEAD.into()],
-                    }))
-                } else if entry_disk_path.is_dir() {
-                    Some(RepoDirEntry::Dir(RepoDir {
-                        path: entry_disk_path.to_string_lossy().to_string(),
-                        branches: vec![HEAD.into()],
-                    }))
-                } else {
-                    Some(RepoDirEntry::Other)
-                }
-            })
-            .take_while(|_| !pipes.is_cancelled())
-            .for_each(iterator);
+        use rayon::prelude::*;
+        background::rayon_pool().install(|| {
+            self.file_list
+                .into_par_iter()
+                .filter_map(|entry_disk_path| {
+                    if entry_disk_path.is_file() {
+                        let buffer = match std::fs::read_to_string(&entry_disk_path) {
+                            Err(err) => {
+                                warn!(%err, ?entry_disk_path, "read failed; skipping");
+                                return None;
+                            }
+                            Ok(buffer) => buffer,
+                        };
+                        Some(RepoDirEntry::File(RepoFile {
+                            buffer,
+                            path: entry_disk_path.to_string_lossy().to_string(),
+                            branches: vec![HEAD.into()],
+                        }))
+                    } else if entry_disk_path.is_dir() {
+                        Some(RepoDirEntry::Dir(RepoDir {
+                            path: entry_disk_path.to_string_lossy().to_string(),
+                            branches: vec![HEAD.into()],
+                        }))
+                    } else {
+                        Some(RepoDirEntry::Other)
+                    }
+                })
+                .take_any_while(|_| !pipes.is_cancelled())
+                .for_each(iterator);
+        })
     }
 }

--- a/server/bleep/src/repo/iterator/fs.rs
+++ b/server/bleep/src/repo/iterator/fs.rs
@@ -42,9 +42,8 @@ impl FileSource for FileWalker {
     }
 
     fn for_each(self, pipes: &SyncPipes, iterator: impl Fn(RepoDirEntry) + Sync + Send) {
-        use rayon::prelude::*;
         self.file_list
-            .into_par_iter()
+            .into_iter()
             .filter_map(|entry_disk_path| {
                 if entry_disk_path.is_file() {
                     let buffer = match std::fs::read_to_string(&entry_disk_path) {
@@ -68,7 +67,7 @@ impl FileSource for FileWalker {
                     Some(RepoDirEntry::Other)
                 }
             })
-            .take_any_while(|_| !pipes.is_cancelled())
+            .take_while(|_| !pipes.is_cancelled())
             .for_each(iterator);
     }
 }

--- a/server/bleep/src/repo/iterator/git.rs
+++ b/server/bleep/src/repo/iterator/git.rs
@@ -179,9 +179,8 @@ impl FileSource for GitWalker {
     }
 
     fn for_each(self, pipes: &SyncPipes, iterator: impl Fn(RepoDirEntry) + Sync + Send) {
-        use rayon::prelude::*;
         self.entries
-            .into_par_iter()
+            .into_iter()
             .filter_map(|((path, kind, oid), branches)| {
                 trace!(?path, "walking over path");
                 let git = self.git.to_thread_local();
@@ -212,7 +211,7 @@ impl FileSource for GitWalker {
 
                 Some(entry)
             })
-            .take_any_while(|_| !pipes.is_cancelled())
+            .take_while(|_| !pipes.is_cancelled())
             .for_each(iterator)
     }
 }


### PR DESCRIPTION
Here, we use an explicit `rayon` pool when queuing files. It was previously possible to break our `rayon` usage if a global pool was initialized before our background executor setup. In this case, `process_embedding_queue` would call `tokio::runtime::Handle::current` in a rayon thread that does not have re-entrant behaviour with `tokio`, which results in immediate failure.

This was observed with related work that utilized `rayon` in unrelated parts of the application, which broke worker queuing.