### PR TITLE
Kill rogue qdrant on boot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -606,6 +606,7 @@ dependencies = [
  "sentry-anyhow",
  "serde",
  "serde_json",
+ "sysinfo",
  "tauri",
  "tauri-build",
  "tokio",
@@ -4379,6 +4380,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ntapi"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6725,6 +6735,21 @@ dependencies = [
  "wasm-bindgen",
  "web-sys",
  "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.29.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a18d114d420ada3a891e6bc8e96a2023402203296a47cdd65083377dad18ba5"
+dependencies = [
+ "cfg-if",
+ "core-foundation-sys",
+ "libc",
+ "ntapi",
+ "once_cell",
+ "rayon",
+ "winapi",
 ]
 
 [[package]]

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -29,6 +29,7 @@ sentry = "0.27.0"
 qdrant-client = "1.5.0"
 git-version = "0.3.5"
 sentry-anyhow = "0.31.7"
+sysinfo = "0.29.10"
 
 [target.'cfg(unix)'.dependencies]
 nix = { version = "0.26.4", default-features = false, features = [ "resource" ] }


### PR DESCRIPTION
Here, we try to close any rogue `qdrant` processes on boot. We first try via `SIGTERM`, but utilize `SIGKILL` if processes do not close gracefully within 5 seconds (10 checks with a 500ms wait time). Internal use of `rayon` in the `sysinfo` crate necessitates #983 is merged first.

Closes BLO-1648