### PR TITLE
Rework index initialisation logic

### DIFF
--- a/apps/desktop/src-tauri/src/backend.rs
+++ b/apps/desktop/src-tauri/src/backend.rs
@@ -163,7 +163,7 @@ fn setup_configuration<R: Runtime>(app: &tauri::AppHandle<R>) -> Configuration {
         .expect("failed to resolve resource");
 
     let mut bundled = Configuration::read(path).unwrap();
-    bundled.qdrant_url = Some("http://127.0.0.1:6334".into());
+    bundled.qdrant_url = "http://127.0.0.1:6334".into();
     bundled.max_threads = bleep::default_parallelism() / 2;
     bundled.model_dir = app
         .path_resolver()

--- a/server/bleep/src/agent.rs
+++ b/server/bleep/src/agent.rs
@@ -322,8 +322,6 @@ impl Agent {
         debug!(?query, %self.thread_id, "executing semantic query");
         self.app
             .semantic
-            .as_ref()
-            .unwrap()
             .search(&query, limit, offset, threshold, retrieve_more)
             .await
     }
@@ -351,8 +349,6 @@ impl Agent {
         debug!(?queries, %self.thread_id, "executing semantic query");
         self.app
             .semantic
-            .as_ref()
-            .unwrap()
             .batch_search(queries.as_slice(), limit, offset, threshold, retrieve_more)
             .await
     }

--- a/server/bleep/src/background/sync.rs
+++ b/server/bleep/src/background/sync.rs
@@ -392,13 +392,11 @@ impl SyncHandle {
             ..
         } = self.app;
 
-        if let Some(semantic) = semantic {
-            semantic
-                .delete_points_for_hash(&self.reporef.to_string(), std::iter::empty())
-                .await;
-        }
+        semantic
+            .delete_points_for_hash(&self.reporef.to_string(), std::iter::empty())
+            .await;
 
-        FileCache::for_repo(sql, semantic.as_ref(), &self.reporef)
+        FileCache::for_repo(sql, semantic, &self.reporef)
             .delete()
             .await
             .map_err(SyncError::Sql)?;

--- a/server/bleep/src/cache.rs
+++ b/server/bleep/src/cache.rs
@@ -386,8 +386,6 @@ impl<'a> FileCache {
     }
 
     /// Chunks and inserts the buffer content into the semantic db.
-    ///
-    /// Assumes that the semantic db is initialized and usable, otherwise panics.
     #[allow(clippy::too_many_arguments)]
     pub(crate) async fn process_semantic(
         &self,

--- a/server/bleep/src/config.rs
+++ b/server/bleep/src/config.rs
@@ -111,7 +111,8 @@ pub struct Configuration {
     //
     // Semantic values
     //
-    #[clap(long)]
+    #[clap(long, default_value_t = default_qdrant_url())]
+    #[serde(default = "default_qdrant_url")]
     /// URL for the qdrant server
     pub qdrant_url: String,
 
@@ -410,6 +411,10 @@ const fn default_port() -> u16 {
 
 fn default_host() -> String {
     String::from("127.0.0.1")
+}
+
+fn default_qdrant_url() -> String {
+    String::from("http://127.0.0.1:6334")
 }
 
 fn default_answer_api_url() -> String {

--- a/server/bleep/src/config.rs
+++ b/server/bleep/src/config.rs
@@ -113,7 +113,7 @@ pub struct Configuration {
     //
     #[clap(long)]
     /// URL for the qdrant server
-    pub qdrant_url: Option<String>,
+    pub qdrant_url: String,
 
     #[clap(long, default_value_os_t = default_model_dir())]
     #[serde(default = "default_model_dir")]
@@ -301,7 +301,7 @@ impl Configuration {
 
             frontend_dist: b.frontend_dist.or(a.frontend_dist),
 
-            qdrant_url: b.qdrant_url.or(a.qdrant_url),
+            qdrant_url: right_if_default!(b.qdrant_url, a.qdrant_url, String::new()),
 
             answer_api_url: right_if_default!(
                 b.answer_api_url,

--- a/server/bleep/src/indexes.rs
+++ b/server/bleep/src/indexes.rs
@@ -92,7 +92,7 @@ impl Indexes {
         repo_pool: RepositoryPool,
         config: Arc<Configuration>,
         sql: SqlDb,
-        semantic: Option<Semantic>,
+        semantic: Semantic,
     ) -> Result<Self> {
         if config.source.index_version_mismatch() {
             // we don't support old schemas, and tantivy will hard
@@ -108,14 +108,12 @@ impl Indexes {
             });
 
             for reporef in refs {
-                FileCache::for_repo(&sql, semantic.as_ref(), &reporef)
+                FileCache::for_repo(&sql, &semantic, &reporef)
                     .delete()
                     .await?;
             }
 
-            if let Some(ref semantic) = semantic {
-                semantic.reset_collection_blocking().await?;
-            }
+            semantic.reset_collection_blocking().await?;
         }
         config.source.save_index_version()?;
 

--- a/server/bleep/src/indexes.rs
+++ b/server/bleep/src/indexes.rs
@@ -21,13 +21,9 @@ pub use repo::Repo;
 use tracing::debug;
 
 use crate::{
-    background::{SyncHandle, SyncPipes},
-    cache::FileCache,
-    db::SqlDb,
+    background::SyncHandle,
     query::parser::Query,
-    repo::{RepoError, RepoMetadata, RepoRef, Repository},
-    semantic::Semantic,
-    state::RepositoryPool,
+    repo::{RepoError, RepoMetadata, Repository},
     Configuration,
 };
 
@@ -70,9 +66,11 @@ impl<'a> GlobalWriteHandle<'a> {
     ) -> Result<Arc<RepoMetadata>, RepoError> {
         let metadata = repo.get_repo_metadata().await;
 
-        futures::future::join_all(self.handles.iter().map(|handle| {
-            handle.index(&sync_handle.reporef, repo, &metadata, sync_handle.pipes())
-        }))
+        futures::future::join_all(
+            self.handles
+                .iter()
+                .map(|handle| handle.index(sync_handle, repo, &metadata)),
+        )
         .await
         .into_iter()
         .collect::<Result<Vec<_>, _>>()?;
@@ -88,35 +86,7 @@ pub struct Indexes {
 }
 
 impl Indexes {
-    pub async fn new(
-        repo_pool: RepositoryPool,
-        config: Arc<Configuration>,
-        sql: SqlDb,
-        semantic: Semantic,
-    ) -> Result<Self> {
-        if config.source.index_version_mismatch() {
-            // we don't support old schemas, and tantivy will hard
-            // error if we try to open a db with a different schema.
-            std::fs::remove_dir_all(config.index_path("repo"))?;
-            std::fs::remove_dir_all(config.index_path("content"))?;
-
-            let mut refs = vec![];
-            // knocking out our current file caches will force re-indexing qdrant
-            repo_pool.for_each(|reporef, repo| {
-                refs.push(reporef.to_owned());
-                repo.last_index_unix_secs = 0;
-            });
-
-            for reporef in refs {
-                FileCache::for_repo(&sql, &semantic, &reporef)
-                    .delete()
-                    .await?;
-            }
-
-            semantic.reset_collection_blocking().await?;
-        }
-        config.source.save_index_version()?;
-
+    pub async fn new(config: &Configuration) -> Result<Self> {
         Ok(Self {
             repo: Indexer::create(
                 Repo::new(),
@@ -125,13 +95,21 @@ impl Indexes {
                 config.max_threads,
             )?,
             file: Indexer::create(
-                File::new(sql, semantic),
+                File::new(),
                 config.index_path("content").as_ref(),
                 config.buffer_size,
                 config.max_threads,
             )?,
             write_mutex: Default::default(),
         })
+    }
+
+    pub async fn reset_databases(config: &Configuration) -> Result<()> {
+        // we don't support old schemas, and tantivy will hard
+        // error if we try to open a db with a different schema.
+        tokio::fs::remove_dir_all(config.index_path("repo")).await?;
+        tokio::fs::remove_dir_all(config.index_path("content")).await?;
+        Ok(())
     }
 
     pub async fn writers(&self) -> Result<GlobalWriteHandle<'_>> {
@@ -152,11 +130,10 @@ pub trait Indexable: Send + Sync {
     /// This is where files are scanned and indexed.
     async fn index_repository(
         &self,
-        reporef: &RepoRef,
+        handle: &SyncHandle,
         repo: &Repository,
         metadata: &RepoMetadata,
         writer: &IndexWriter,
-        pipes: &SyncPipes,
     ) -> Result<()>;
 
     fn delete_by_repo(&self, writer: &IndexWriter, repo: &Repository);
@@ -206,13 +183,12 @@ impl<'a> IndexWriteHandle<'a> {
 
     pub async fn index(
         &self,
-        reporef: &RepoRef,
+        handle: &SyncHandle,
         repo: &Repository,
         metadata: &RepoMetadata,
-        progress: &SyncPipes,
     ) -> Result<()> {
         self.source
-            .index_repository(reporef, repo, metadata, &self.writer, progress)
+            .index_repository(handle, repo, metadata, &self.writer)
             .await
     }
 

--- a/server/bleep/src/indexes/repo.rs
+++ b/server/bleep/src/indexes/repo.rs
@@ -6,8 +6,8 @@ use tracing::info;
 pub use super::schema::Repo;
 use super::Indexable;
 use crate::{
-    background::SyncPipes,
-    repo::{RepoMetadata, RepoRef, Repository},
+    background::SyncHandle,
+    repo::{RepoMetadata, Repository},
 };
 
 impl Default for Repo {
@@ -20,11 +20,10 @@ impl Default for Repo {
 impl Indexable for Repo {
     async fn index_repository(
         &self,
-        repo_ref: &RepoRef,
+        SyncHandle { ref reporef, .. }: &SyncHandle,
         repo: &Repository,
         _metadata: &RepoMetadata,
         writer: &IndexWriter,
-        _pipes: &SyncPipes,
     ) -> Result<()> {
         // Make sure we delete any stale references to this repository when indexing.
         self.delete_by_repo(writer, repo);
@@ -33,9 +32,9 @@ impl Indexable for Repo {
             // We don't have organization support for now.
             self.org => "",
             self.disk_path => repo.disk_path.to_string_lossy().into_owned(),
-            self.name => repo_ref.indexed_name(),
-            self.raw_name => repo_ref.indexed_name().as_bytes(),
-            self.repo_ref => repo_ref.to_string(),
+            self.name => reporef.indexed_name(),
+            self.raw_name => reporef.indexed_name().as_bytes(),
+            self.repo_ref => reporef.to_string(),
         ))?;
 
         info!(

--- a/server/bleep/src/indexes/schema.rs
+++ b/server/bleep/src/indexes/schema.rs
@@ -6,8 +6,6 @@ use tantivy::schema::{
     FAST, STORED, STRING,
 };
 
-use crate::{db::SqlDb, semantic::Semantic};
-
 #[cfg(feature = "debug")]
 use {
     histogram::Histogram,
@@ -19,8 +17,6 @@ use {
 #[derive(Clone)]
 pub struct File {
     pub(super) schema: Schema,
-    pub(super) semantic: Semantic,
-    pub(super) sql: SqlDb,
 
     #[cfg(feature = "debug")]
     pub histogram: Arc<RwLock<Histogram>>,
@@ -72,7 +68,7 @@ pub struct File {
 }
 
 impl File {
-    pub fn new(sql: SqlDb, semantic: Semantic) -> Self {
+    pub fn new() -> Self {
         let mut builder = tantivy::schema::SchemaBuilder::new();
         let trigram = TextOptions::default().set_stored().set_indexing_options(
             TextFieldIndexing::default()
@@ -112,6 +108,7 @@ impl File {
         let indexed = builder.add_bool_field("indexed", STORED);
 
         Self {
+            schema: builder.build(),
             repo_disk_path,
             relative_path,
             unique_hash,
@@ -124,19 +121,22 @@ impl File {
             lang,
             avg_line_length,
             last_commit_unix_seconds,
-            schema: builder.build(),
-            semantic,
             raw_content,
             raw_repo_name,
             raw_relative_path,
             branches,
             is_directory,
-            sql,
             indexed,
 
             #[cfg(feature = "debug")]
             histogram: Arc::new(Histogram::builder().build().unwrap().into()),
         }
+    }
+}
+
+impl Default for File {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/server/bleep/src/indexes/schema.rs
+++ b/server/bleep/src/indexes/schema.rs
@@ -19,7 +19,7 @@ use {
 #[derive(Clone)]
 pub struct File {
     pub(super) schema: Schema,
-    pub(super) semantic: Option<Semantic>,
+    pub(super) semantic: Semantic,
     pub(super) sql: SqlDb,
 
     #[cfg(feature = "debug")]
@@ -72,7 +72,7 @@ pub struct File {
 }
 
 impl File {
-    pub fn new(sql: SqlDb, semantic: Option<Semantic>) -> Self {
+    pub fn new(sql: SqlDb, semantic: Semantic) -> Self {
         let mut builder = tantivy::schema::SchemaBuilder::new();
         let trigram = TextOptions::default().set_stored().set_indexing_options(
             TextFieldIndexing::default()

--- a/server/bleep/src/lib.rs
+++ b/server/bleep/src/lib.rs
@@ -29,7 +29,7 @@ use crate::{
     background::SyncQueue, indexes::Indexes, remotes::CognitoGithubTokenBundle, semantic::Semantic,
     state::RepositoryPool,
 };
-use anyhow::{bail, Result};
+use anyhow::{bail, Context, Result};
 use axum::extract::FromRef;
 
 use once_cell::sync::OnceCell;
@@ -132,22 +132,43 @@ impl Application {
         config.repo_buffer_size = config.repo_buffer_size.max(threads * 3_000_000);
         config.source.set_default_dir(&config.index_dir);
 
+        // Finalize config
         let config = Arc::new(config);
         debug!(?config, "effective configuration");
 
-        let sqlite = Arc::new(db::init(&config).await?);
+        // Load repositories
+        let repo_pool = config.source.initialize_pool()?;
 
-        // Initialise Semantic index if `qdrant_url` set in config
+        // Databases & indexes
+        let sql = Arc::new(db::init(&config).await?);
         let semantic =
-            match Semantic::initialize(&config.model_dir, &config.qdrant_url, Arc::clone(&config))
+            Semantic::initialize(&config.model_dir, &config.qdrant_url, Arc::clone(&config))
                 .await
-            {
-                Ok(semantic) => semantic,
-                Err(e) => {
-                    bail!("Qdrant initialization failed: {}", e);
-                }
-            };
+                .context("qdrant initialization failed")?;
 
+        // Wipe existing dbs & caches if the schema has changed
+        if config.source.index_version_mismatch() {
+            Indexes::reset_databases(&config).await?;
+            let cache = cache::FileCache::new(sql.clone(), semantic.clone());
+
+            let mut refs = vec![];
+            // knocking out our current file caches will force re-indexing qdrant
+            repo_pool.for_each(|reporef, repo| {
+                refs.push(reporef.to_owned());
+                repo.last_index_unix_secs = 0;
+            });
+
+            for reporef in refs {
+                cache.delete(&reporef).await?;
+            }
+
+            semantic.reset_collection_blocking().await?;
+        }
+        config.source.save_index_version()?;
+
+        let indexes = Indexes::new(&config).await?.into();
+
+        // Enforce capabilies and features depending on environment
         let env = if config.github_app_id.is_some() {
             info!("Starting bleep in private server mode");
             Environment::private_server()
@@ -155,6 +176,7 @@ impl Application {
             env
         };
 
+        // Analytics backend
         let analytics = match initialize_analytics(&config, tracking_seed, analytics_options) {
             Ok(analytics) => Some(analytics),
             Err(err) => {
@@ -163,24 +185,15 @@ impl Application {
             }
         };
 
-        let repo_pool = config.source.initialize_pool()?;
-
         Ok(Self {
-            indexes: Indexes::new(
-                repo_pool.clone(),
-                config.clone(),
-                sqlite.clone(),
-                semantic.clone(),
-            )
-            .await?
-            .into(),
             sync_queue: SyncQueue::start(config.clone()),
             cookie_key: config.source.initialize_cookie_key()?,
             credentials: config
                 .source
                 .load_state_or("credentials", remotes::Backends::default())?,
             user_profiles: config.source.load_or_default("user_profiles")?,
-            sql: sqlite,
+            sql,
+            indexes,
             repo_pool,
             analytics,
             semantic,

--- a/server/bleep/src/webserver.rs
+++ b/server/bleep/src/webserver.rs
@@ -1,6 +1,7 @@
 use crate::{env::Feature, Application};
 
 use axum::{
+    extract::State,
     http::StatusCode,
     response::IntoResponse,
     routing::{delete, get, post},
@@ -325,10 +326,8 @@ impl<'a> From<EndpointError<'a>> for Response<'a> {
     }
 }
 
-async fn health(Extension(app): Extension<Application>) {
-    if let Some(ref semantic) = app.semantic {
-        // panic is fine here, we don't need exact reporting of
-        // subsystem checks at this stage
-        semantic.health_check().await.unwrap()
-    }
+async fn health(State(app): State<Application>) {
+    // panic is fine here, we don't need exact reporting of
+    // subsystem checks at this stage
+    app.semantic.health_check().await.unwrap()
 }


### PR DESCRIPTION
This PR's aim is to make the qdrant dependency mandatory. In practice, we always want semantic indexing, paying attention to this every time we use this subsystem is not super productive.

In addition, steps are taken to reduce some of the dependency mess between tantivy & semantic indexes. `FileCache` is now hierarchically adjacent to the `File` indexer, which opened the door to removing a bunch of database dependnencies for that layer. The `FileCache` is now managed by `SyncHandle`, and passed on as a reference.

The initialization flow is also somewhat clearer, and at a high level is contained fully in `lib.rs` for easier reading.