### PR TITLE
Fix single alias agent context

### DIFF
--- a/server/bleep/src/agent/tools/answer.rs
+++ b/server/bleep/src/agent/tools/answer.rs
@@ -258,6 +258,16 @@ impl Agent {
                 .push(c.start_line..c.end_line);
         }
 
+        // If there are no relevant code chunks, but there is a focused chunk, we use that.
+        if spans_by_path.is_empty() {
+            if let Some(chunk) = self.last_exchange().focused_chunk.clone() {
+                spans_by_path
+                    .entry(chunk.file_path.clone())
+                    .or_default()
+                    .push(chunk.start_line..chunk.end_line);
+            }
+        }
+
         debug!(?spans_by_path, "expanding spans");
 
         let self_ = &*self;

--- a/server/bleep/src/agent/tools/answer.rs
+++ b/server/bleep/src/agent/tools/answer.rs
@@ -260,7 +260,7 @@ impl Agent {
 
         // If there are no relevant code chunks, but there is a focused chunk, we use that.
         if spans_by_path.is_empty() {
-            if let Some(chunk) = self.last_exchange().focused_chunk.clone() {
+            if let Some(chunk) = &self.last_exchange().focused_chunk {
                 spans_by_path
                     .entry(chunk.file_path.clone())
                     .or_default()


### PR DESCRIPTION
If there are no relevant code chunks, try adding a `FocussedChunk` from the last `Exchange` to the context. 