### PR TITLE
Default to `HEAD` in indexer when not on a branch

### DIFF
--- a/server/bleep/src/indexes/file.rs
+++ b/server/bleep/src/indexes/file.rs
@@ -157,7 +157,8 @@ impl Indexable for File {
                             use gix::bstr::ByteSlice;
                             r.name().shorten().to_str_lossy().into_owned()
                         })
-                });
+                })
+                .unwrap_or_else(|| "HEAD".to_owned());
 
             let walker = FileWalker::index_directory(&repo.disk_path, branch);
             let count = walker.len();

--- a/server/bleep/src/repo/iterator/fs.rs
+++ b/server/bleep/src/repo/iterator/fs.rs
@@ -10,11 +10,11 @@ pub struct FileWalker {
     file_list: Vec<PathBuf>,
 
     /// Branch to index files as part of.
-    branch: Option<String>,
+    branch: String,
 }
 
 impl FileWalker {
-    pub fn index_directory(dir: impl AsRef<Path>, branch: Option<String>) -> impl FileSource {
+    pub fn index_directory(dir: impl AsRef<Path>, branch: String) -> impl FileSource {
         // note: this WILL observe .gitignore files for the respective repos.
         let walker = ignore::WalkBuilder::new(&dir)
             .standard_filters(true)
@@ -61,12 +61,12 @@ impl FileSource for FileWalker {
                         Some(RepoDirEntry::File(RepoFile {
                             buffer,
                             path: entry_disk_path.to_string_lossy().to_string(),
-                            branches: self.branch.clone().into_iter().collect(),
+                            branches: vec![self.branch.clone()],
                         }))
                     } else if entry_disk_path.is_dir() {
                         Some(RepoDirEntry::Dir(RepoDir {
                             path: entry_disk_path.to_string_lossy().to_string(),
-                            branches: self.branch.clone().into_iter().collect(),
+                            branches: vec![self.branch.clone()],
                         }))
                     } else {
                         Some(RepoDirEntry::Other)


### PR DESCRIPTION
This appears to resolve failure to retrieve indexed results in some scenarios.