### PR TITLE
Adding frequency penalty only for the finetuned answer model

### DIFF
--- a/server/bleep/src/agent/tools/answer.rs
+++ b/server/bleep/src/agent/tools/answer.rs
@@ -61,6 +61,7 @@ impl Agent {
             self.llm_gateway
                 .clone()
                 .model(self.model.model_name)
+                .frequency_penalty(if self.model.model_name == "gpt-3-finetuned" {Some(0.2)} else {Some(0.0)})
                 .chat_stream(&messages, None)
                 .await?
         );


### PR DESCRIPTION
- Finetuned GPT3 model (used in fast mode) sometimes repeats itself
- Adding frequency penalty of 0.2 prevents that at the cost of generating shorter answers 
- Shorter answers have worse performance in exact_match metric, but looking each example the answers are still semantically correct, but shorter with less citations