### PR TITLE
Fix empty answer context where the single relevant file is too long

### DIFF
--- a/server/bleep/src/agent/prompts.rs
+++ b/server/bleep/src/agent/prompts.rs
@@ -117,9 +117,9 @@ pub fn answer_article_prompt(context: &str) -> String {
     format!(
         r#"{context}####
 
-Your job is to answer a query about a codebase using the information above.
+You are an expert programmer called 'bloop' and you are helping a junior colleagure answer questions about a codebase using the information above. If their query refers to 'this' or 'it' and there is no other context, assume that it refers to the information above.
 
-Provide only as much information and code as is necessary to answer the query, but be concise. Keep number of quoted lines to a minimum when possible. If you do not have enough information needed to answer the query, do not make up an answer.
+Provide only as much information and code as is necessary to answer the query, but be concise. Keep number of quoted lines to a minimum when possible. If you do not have enough information needed to answer the query, do not make up an answer. Infer as much as possible from the information above.
 When referring to code, you must provide an example in a code block.
 
 Respect these rules at all times:

--- a/server/bleep/src/agent/tools/answer.rs
+++ b/server/bleep/src/agent/tools/answer.rs
@@ -372,7 +372,7 @@ impl Agent {
 
         debug!(?spans_by_path, "expanded spans");
 
-        spans_by_path
+        let code_chunks = spans_by_path
             .into_iter()
             .flat_map(|(path, spans)| spans.into_iter().map(move |s| (path.clone(), s)))
             .map(|(path, span)| {
@@ -386,7 +386,24 @@ impl Agent {
                     end_line: span.end,
                 }
             })
-            .collect()
+            .collect::<Vec<CodeChunk>>();
+
+        // Handle case where there is only one code chunk and it exceeds `max_tokens`.
+        // In this instance we trim the chunk to fit within the limit.
+        if code_chunks.len() == 1 {
+            let chunk = code_chunks.first().unwrap();
+            let trimmed_snippet = transcoder::limit_tokens(&chunk.snippet, bpe, max_tokens);
+            let num_trimmed_lines = trimmed_snippet.lines().count();
+            vec![CodeChunk {
+                alias: chunk.alias,
+                path: chunk.path.clone(),
+                snippet: trimmed_snippet.to_string(),
+                start_line: chunk.start_line,
+                end_line: (chunk.start_line + num_trimmed_lines).saturating_sub(1),
+            }]
+        } else {
+            code_chunks
+        }
     }
 }
 


### PR DESCRIPTION
Previously, if the code context contained a single file that contained more than `max_tokens` we'd trim it and the answer would contain no context at all. This often happened for single-file explanation. Now we trim the single-file to `max_tokens`.

Also contains some minor changes to the explanation prompt.