### PR TITLE
Allow indexing of large files

### DIFF
--- a/server/bleep/src/indexes/file.rs
+++ b/server/bleep/src/indexes/file.rs
@@ -691,7 +691,7 @@ impl RepoFile {
 
         let indexed = file_filter
             .is_allowed(relative_path)
-            .unwrap_or_else(|| should_index(relative_path));
+            .unwrap_or_else(|| self.should_index());
 
         if !indexed {
             return Some(doc!(

--- a/server/bleep/src/indexes/file.rs
+++ b/server/bleep/src/indexes/file.rs
@@ -16,7 +16,7 @@ use tantivy::{
 };
 use tokenizers as _;
 use tokio::runtime::Handle;
-use tracing::{info, trace, warn};
+use tracing::{error, info, trace, warn};
 
 pub use super::schema::File;
 
@@ -658,7 +658,7 @@ impl RepoDir {
 impl RepoFile {
     #[allow(clippy::too_many_arguments)]
     fn build_document(
-        mut self,
+        self,
         schema: &File,
         workload: &Workload<'_>,
         cache_keys: &CacheKeys,
@@ -681,19 +681,19 @@ impl RepoFile {
         let relative_path_str = relative_path_str.replace('\\', "/");
 
         let branches = self.branches.join("\n");
-        let lang_str = repo_metadata
-            .langs
-            .get(normalized_path, self.buffer.as_ref())
-            .unwrap_or_else(|| {
-                warn!(?normalized_path, "Path not found in language map");
-                ""
-            });
-
         let indexed = file_filter
             .is_allowed(relative_path)
             .unwrap_or_else(|| self.should_index());
 
         if !indexed {
+            let lang_str = repo_metadata
+                .langs
+                .get(normalized_path, b"")
+                .unwrap_or_else(|| {
+                    warn!(?normalized_path, "Path not found in language map");
+                    ""
+                });
+
             return Some(doc!(
                 schema.raw_content => vec![],
                 schema.content => "",
@@ -716,9 +716,24 @@ impl RepoFile {
             ));
         }
 
+        let mut buffer = match self.buffer() {
+            Ok(b) => b,
+            Err(err) => {
+                error!(?err, "failed to open file buffer; skipping file");
+                return None;
+            }
+        };
+        let lang_str = repo_metadata
+            .langs
+            .get(normalized_path, buffer.as_ref())
+            .unwrap_or_else(|| {
+                warn!(?normalized_path, "Path not found in language map");
+                ""
+            });
+
         let symbol_locations = {
             // build a syntax aware representation of the file
-            let scope_graph = TreeSitterFile::try_build(self.buffer.as_bytes(), lang_str)
+            let scope_graph = TreeSitterFile::try_build(buffer.as_bytes(), lang_str)
                 .and_then(TreeSitterFile::scope_graph);
 
             match scope_graph {
@@ -733,19 +748,18 @@ impl RepoFile {
         let symbols = symbol_locations
             .list()
             .iter()
-            .map(|sym| self.buffer[sym.range.start.byte..sym.range.end.byte].to_owned())
+            .map(|sym| buffer[sym.range.start.byte..sym.range.end.byte].to_owned())
             .collect::<HashSet<_>>()
             .into_iter()
             .collect::<Vec<_>>()
             .join("\n");
 
         // add an NL if this file is not NL-terminated
-        if !self.buffer.ends_with('\n') {
-            self.buffer += "\n";
+        if !buffer.ends_with('\n') {
+            buffer += "\n";
         }
 
-        let line_end_indices = self
-            .buffer
+        let line_end_indices = buffer
             .match_indices('\n')
             .flat_map(|(i, _)| u32::to_le_bytes(i as u32))
             .collect::<Vec<_>>();
@@ -756,7 +770,7 @@ impl RepoFile {
             return None;
         }
 
-        let lines_avg = self.buffer.len() as f64 / self.buffer.lines().count() as f64;
+        let lines_avg = buffer.len() as f64 / buffer.lines().count() as f64;
 
         tokio::task::block_in_place(|| {
             Handle::current().block_on(async {
@@ -766,7 +780,7 @@ impl RepoFile {
                         repo_name,
                         repo_ref,
                         &relative_path_str,
-                        &self.buffer,
+                        &buffer,
                         lang_str,
                         &self.branches,
                     )
@@ -775,7 +789,7 @@ impl RepoFile {
         });
 
         Some(doc!(
-            schema.raw_content => self.buffer.as_bytes(),
+            schema.raw_content => buffer.as_bytes(),
             schema.raw_repo_name => repo_name.as_bytes(),
             schema.raw_relative_path => relative_path_str.as_bytes(),
             schema.unique_hash => cache_keys.tantivy(),
@@ -783,7 +797,7 @@ impl RepoFile {
             schema.relative_path => relative_path_str,
             schema.repo_ref => repo_ref.to_string(),
             schema.repo_name => *repo_name,
-            schema.content => self.buffer,
+            schema.content => buffer,
             schema.line_end_indices => line_end_indices,
             schema.lang => lang_str.to_ascii_lowercase().as_bytes(),
             schema.avg_line_length => lines_avg,

--- a/server/bleep/src/repo/iterator.rs
+++ b/server/bleep/src/repo/iterator.rs
@@ -63,9 +63,9 @@ impl RepoDirEntry {
         }
     }
 
-    pub fn buffer(&self) -> Option<&str> {
+    pub fn buffer(&self) -> Option<String> {
         match self {
-            Self::File(file) => Some(file.buffer.as_str()),
+            Self::File(file) => (file.buffer)().ok(),
             _ => None,
         }
     }
@@ -85,9 +85,22 @@ pub struct RepoDir {
 }
 
 pub struct RepoFile {
+    /// Path to file
     pub path: String,
-    pub buffer: String,
+    /// Branches which include the file
     pub branches: Vec<String>,
+    /// Lazily loaded buffer that contains the file contents
+    buffer: Box<dyn Fn() -> std::io::Result<String> + Send + Sync>,
+}
+
+impl RepoFile {
+    pub fn should_index(&self) -> bool {
+        should_index_path(&self.path)
+            && std::fs::metadata(&self.path)
+                .map(|m| m.len())
+                .unwrap_or_default()
+                < MAX_FILE_LEN
+    }
 }
 
 #[derive(Hash, Eq, PartialEq)]
@@ -97,7 +110,7 @@ pub enum FileType {
     Other,
 }
 
-pub(crate) fn should_index<P: AsRef<Path> + ?Sized>(p: &P) -> bool {
+fn should_index_path<P: AsRef<Path> + ?Sized>(p: &P) -> bool {
     let path = p.as_ref();
 
     // TODO: Make this more robust
@@ -191,7 +204,7 @@ mod test {
         ];
 
         for (path, index) in tests {
-            assert_eq!(should_index(&Path::new(path)), index);
+            assert_eq!(should_index_path(&Path::new(path)), index);
         }
     }
 }

--- a/server/bleep/src/repo/iterator.rs
+++ b/server/bleep/src/repo/iterator.rs
@@ -89,17 +89,19 @@ pub struct RepoFile {
     pub path: String,
     /// Branches which include the file
     pub branches: Vec<String>,
+    /// Length of the buffer
+    pub len: u64,
     /// Lazily loaded buffer that contains the file contents
     buffer: Box<dyn Fn() -> std::io::Result<String> + Send + Sync>,
 }
 
 impl RepoFile {
     pub fn should_index(&self) -> bool {
-        should_index_path(&self.path)
-            && std::fs::metadata(&self.path)
-                .map(|m| m.len())
-                .unwrap_or_default()
-                < MAX_FILE_LEN
+        should_index_path(&self.path) && self.len < MAX_FILE_LEN
+    }
+
+    pub fn buffer(&self) -> std::io::Result<String> {
+        (self.buffer)()
     }
 }
 

--- a/server/bleep/src/repo/iterator/fs.rs
+++ b/server/bleep/src/repo/iterator/fs.rs
@@ -29,8 +29,6 @@ impl FileWalker {
                     None
                 }
             })
-            // Preliminarily ignore files that are very large, without reading the contents.
-            .filter(|de| matches!(de.metadata(), Ok(meta) if meta.len() < MAX_FILE_LEN))
             .filter(|de| !de.path().strip_prefix(&dir).unwrap().starts_with(".git"))
             .filter_map(|de| crate::canonicalize(de.into_path()).ok())
             .collect();
@@ -51,13 +49,14 @@ impl FileSource for FileWalker {
                 .into_par_iter()
                 .filter_map(|entry_disk_path| {
                     if entry_disk_path.is_file() {
-                        let buffer = match std::fs::read_to_string(&entry_disk_path) {
-                            Err(err) => {
-                                warn!(%err, ?entry_disk_path, "read failed; skipping");
-                                return None;
-                            }
-                            Ok(buffer) => buffer,
-                        };
+                        let buffer =
+                            Box::new(move || match std::fs::read_to_string(&entry_disk_path) {
+                                Err(err) => {
+                                    warn!(%err, ?entry_disk_path, "read failed; skipping");
+                                    return Err(err);
+                                }
+                                Ok(buffer) => Ok(buffer),
+                            });
                         Some(RepoDirEntry::File(RepoFile {
                             buffer,
                             path: entry_disk_path.to_string_lossy().to_string(),

--- a/server/bleep/src/repo/iterator/git.rs
+++ b/server/bleep/src/repo/iterator/git.rs
@@ -167,17 +167,14 @@ impl FileSource for GitWalker {
                         return None;
                     };
 
-                    if object.data.len() as u64 > MAX_FILE_LEN {
-                        return None;
-                    }
-
                     let entry = match kind {
                         FileType::File => {
                             let buffer = String::from_utf8_lossy(&object.data).to_string();
                             RepoDirEntry::File(RepoFile {
                                 path,
+                                len: buffer.len() as u64,
                                 branches: branches.into_iter().collect(),
-                                buffer,
+                                buffer: Box::new(move || Ok(buffer.clone())),
                             })
                         }
                         FileType::Dir => RepoDirEntry::Dir(RepoDir {


### PR DESCRIPTION
Allow indexing of large files, and also make a best effort at lazy loading these.

The hypothesis is that files in Git are going to be generally not too large. Due to the iteration logic we have always read large files from Git in their entirety, but discarded them early in the process. There's no change here, we just discard them later.

For files from the file system, the process will never read these until it knows that it needs the contents. This may impact the accuracy of language detection for unindexed files, but otherwise it should be safe change.