### PR TITLE
Studio Diffs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -496,6 +496,7 @@ dependencies = [
  "comrak",
  "console-subscriber",
  "criterion",
+ "diffy",
  "directories",
  "either",
  "erased-serde",
@@ -1510,6 +1511,15 @@ name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
+name = "diffy"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e616e59155c92257e84970156f506287853355f58cd4a6eb167385722c32b790"
+dependencies = [
+ "nu-ansi-term",
+]
 
 [[package]]
 name = "digest"

--- a/server/bleep/Cargo.toml
+++ b/server/bleep/Cargo.toml
@@ -157,6 +157,7 @@ relative-path = "1.9.0"
 semver = { version = "1", features = ["serde"] }
 scc = { version= "1.9.1", features = ["serde"] }
 thread-priority = "0.13.1"
+diffy = "0.3.0"
 
 [dev-dependencies]
 criterion = { version = "0.5.1", features = ["async_tokio"] }

--- a/server/bleep/sqlx-data.json
+++ b/server/bleep/sqlx-data.json
@@ -572,6 +572,30 @@
     },
     "query": "DELETE FROM studio_snapshots\n        WHERE id IN (\n            SELECT ss.id\n            FROM studio_snapshots ss\n            JOIN studios s ON s.id = ss.studio_id AND s.user_id = ?\n            WHERE ss.id = ? AND ss.studio_id = ?\n        )\n        RETURNING id"
   },
+  "671df14b7c9077b95e586690f8c6d3f2eeb0a3942d0b800f272b010fcd2ca97b": {
+    "describe": {
+      "columns": [
+        {
+          "name": "messages",
+          "ordinal": 0,
+          "type_info": "Text"
+        },
+        {
+          "name": "context",
+          "ordinal": 1,
+          "type_info": "Text"
+        }
+      ],
+      "nullable": [
+        false,
+        false
+      ],
+      "parameters": {
+        "Right": 1
+      }
+    },
+    "query": "SELECT messages, context FROM studio_snapshots WHERE id = ?"
+  },
   "69c8b59ce4be3fc6edb58563bf69f55ea5dca4646b0ba05820e5d1b2b07c3c82": {
     "describe": {
       "columns": [

--- a/server/bleep/src/agent/prompts.rs
+++ b/server/bleep/src/agent/prompts.rs
@@ -298,6 +298,94 @@ And here is the serialized conversation:
     )
 }
 
+pub fn studio_diff_prompt(context_formatted: &str) -> String {
+    format!(
+        r#"Below are files from a codebase. Your job is to write a Unified Format patch to complete a provided task. To write a unified format patch, surround it in a code block: ```diff
+
+Follow these rules strictly:
+- You MUST only return a single diff block, no additional commentary.
+- Keep hunks concise only include a short context for each hunk. 
+- ALWAYS respect input whitespace, to ensure diffs can be applied cleanly!
+- Only generate diffs that can be applied by `patch`! NO extra information like `git` commands
+- To add a new file, set the input file as /dev/null
+- To remove an existing file, set the output file to /dev/null
+
+# Example outputs
+
+```diff
+--- src/index.js
++++ src/index.js
+@@ -10,5 +10,5 @@
+ const maybeHello = () => {{
+     if (Math.random() > 0.5) {{
+-        console.log("hello world!")
++        console.log("hello?")
+     }}
+ }}
+```
+
+```diff
+--- README.md
++++ README.md
+@@ -1,3 +1,3 @@
+ # Bloop AI
+ 
+-bloop is ChatGPT for your code. Ask questions in natural language, search for code and generate patches using your existing codebase as context.
++bloop is ChatGPT for your code. Ask questions in natural language, search for code and generate patches using your existing code base as context.
+```
+
+```diff
+--- client/src/locales/en.json
++++ client/src/locales/en.json
+@@ -21,5 +21,5 @@
+ 	"Report a bug": "Report a bug",
+ 	"Sign In": "Sign In",
+-	"Sign in with GitHub": "Sign in with GitHub",
++	"Sign in via GitHub": "Sign in via GitHub",
+ 	"Status": "Status",
+ 	"Submit bug report": "Submit bug report",
+```
+
+Adding a new file:
+
+```diff
+--- /dev/null
++++ src/sum.rs
+@@ -0,0 +1,3 @@
++fn sum(a: f32, b: f32) -> f32 {{
++    a + b
++}}
+```
+
+Removing an existing file:
+
+```diff
+--- src/div.rs
++++ /dev/null
+@@ -1,3 +0,0 @@
+-fn div(a: f32, b: f32) -> f32 {{
+-    a / b
+-}}
+```
+
+#####
+
+{context_formatted}"#
+    )
+}
+
+pub fn studio_diff_regen_hunk_prompt(context_formatted: &str) -> String {
+    format!(
+        r#"The provided diff contains no context lines. Output a new hunk with the correct 3 context lines.
+
+Here is the full context for reference:
+
+#####
+
+{context_formatted}"#
+    )
+}
+
 pub fn hypothetical_document_prompt(query: &str) -> String {
     format!(
         r#"Write a code snippet that could hypothetically be returned by a code search engine as the answer to the query: {query}

--- a/server/bleep/src/webserver.rs
+++ b/server/bleep/src/webserver.rs
@@ -104,6 +104,8 @@ pub async fn start(app: Application) -> anyhow::Result<()> {
         )
         .route("/studio/import", post(studio::import))
         .route("/studio/:studio_id/generate", get(studio::generate))
+        .route("/studio/:studio_id/diff", get(studio::diff))
+        .route("/studio/:studio_id/diff/apply", post(studio::diff_apply))
         .route("/studio/:studio_id/snapshots", get(studio::list_snapshots))
         .route(
             "/studio/:studio_id/snapshots/:snapshot_id",

--- a/server/bleep/src/webserver/repos.rs
+++ b/server/bleep/src/webserver/repos.rs
@@ -320,7 +320,7 @@ pub(super) async fn delete_by_id(
 /// Synchronize a repo by its id
 pub(super) async fn sync(
     Query(RepoParams { repo }): Query<RepoParams>,
-    State(app): State<Application>,
+    Extension(app): Extension<Application>,
     Extension(user): Extension<User>,
 ) -> Result<impl IntoResponse> {
     // TODO: We can refactor `repo_pool` to also hold queued repos, instead of doing a calculation

--- a/server/bleep/src/webserver/studio.rs
+++ b/server/bleep/src/webserver/studio.rs
@@ -16,8 +16,10 @@ use chrono::NaiveDateTime;
 use futures::{pin_mut, stream, StreamExt, TryStreamExt};
 use rayon::prelude::*;
 use reqwest::StatusCode;
-use tracing::{debug, error};
+use tracing::{debug, error, warn};
 use uuid::Uuid;
+
+use self::diff::{DiffChunk, DiffHunk};
 
 use super::{middleware::User, Error};
 use crate::{
@@ -27,6 +29,8 @@ use crate::{
     repo::RepoRef,
     webserver, Application,
 };
+
+mod diff;
 
 const LLM_GATEWAY_MODEL: &str = "gpt-4-0613";
 
@@ -866,6 +870,487 @@ async fn generate_llm_context(
     Ok(s)
 }
 
+/// A set of structured diff definitions consumed by the front-end.
+mod structured_diff {
+    use std::fmt;
+
+    use crate::repo::RepoRef;
+
+    #[derive(serde::Serialize, serde::Deserialize)]
+    pub struct Diff {
+        pub chunks: Vec<Chunk>,
+    }
+
+    impl fmt::Display for Diff {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            use std::fmt::Write;
+
+            let mut s = String::new();
+
+            for c in &self.chunks {
+                writeln!(s, "--- {}\n+++ {}", c.file, c.file)?;
+
+                for h in &c.hunks {
+                    writeln!(s, "@@ -{},0 +{},0 @@", h.line_start, h.line_start)?;
+                    write!(s, "{}", h.patch)?;
+                }
+            }
+
+            for c in super::diff::relaxed_parse(&s) {
+                write!(f, "{}", c)?;
+            }
+
+            Ok(())
+        }
+    }
+
+    #[derive(serde::Serialize, serde::Deserialize)]
+    pub struct Chunk {
+        pub file: String,
+        pub repo: RepoRef,
+        pub branch: Option<String>,
+        pub lang: Option<String>,
+        pub hunks: Vec<Hunk>,
+
+        /// This field is additionally included for simplicity on the front-end.
+        pub raw_patch: String,
+    }
+
+    #[derive(serde::Serialize, serde::Deserialize)]
+    pub struct Hunk {
+        pub line_start: usize,
+        pub patch: String,
+    }
+}
+
+pub async fn diff(
+    app: Extension<Application>,
+    user: Extension<User>,
+    Path(studio_id): Path<i64>,
+) -> webserver::Result<Json<structured_diff::Diff>> {
+    let user_id = user.username().ok_or_else(no_user_id)?.to_string();
+
+    let snapshot_id = latest_snapshot_id(studio_id, &*app.sql, &user_id).await?;
+
+    let llm_gateway = user
+        .llm_gateway(&app)
+        .await
+        .map_err(|e| Error::user(e).with_status(StatusCode::UNAUTHORIZED))?
+        .quota_gated(!app.env.is_cloud_instance())
+        .model(LLM_GATEWAY_MODEL)
+        .temperature(0.0);
+
+    let (messages_json, context_json) = sqlx::query!(
+        "SELECT messages, context FROM studio_snapshots WHERE id = ?",
+        snapshot_id,
+    )
+    .fetch_optional(&*app.sql)
+    .await?
+    .map(|row| (row.messages, row.context))
+    .ok_or_else(studio_not_found)?;
+
+    let messages = serde_json::from_str::<Vec<Message>>(&messages_json).map_err(Error::internal)?;
+
+    let context =
+        serde_json::from_str::<Vec<ContextFile>>(&context_json).map_err(Error::internal)?;
+
+    let user_message = messages
+        .iter()
+        .rev()
+        .find_map(|msg| match msg {
+            Message::User(m) => Some(m),
+            Message::Assistant(..) => None,
+        })
+        .context("studio did not contain a user message")?;
+
+    let assistant_message = messages
+        .iter()
+        .rev()
+        .find_map(|msg| match msg {
+            Message::User(..) => None,
+            Message::Assistant(m) => Some(m),
+        })
+        .context("studio did not contain an assistant message")?;
+
+    app.track_studio(
+        &user,
+        StudioEvent::new(studio_id, "diff")
+            .with_payload("context", &context)
+            .with_payload("user_message", &user_message)
+            .with_payload("assistant_message", &assistant_message),
+    );
+
+    let llm_context = generate_llm_context((*app).clone(), &context, &[]).await?;
+
+    let system_prompt = prompts::studio_diff_prompt(&llm_context);
+    let user_message = format!("Create a patch for the task \"{user_message}\".\n\n\nHere is the solution:\n\n{assistant_message}");
+
+    let messages = vec![
+        llm_gateway::api::Message::system(&system_prompt),
+        llm_gateway::api::Message::user(&user_message),
+    ];
+
+    let response = llm_gateway.chat(&messages, None).await?;
+    let diff_chunks = diff::extract(&response)?.collect::<Vec<_>>();
+
+    let (repo, branch) = context
+        .first()
+        .map(|cf| (cf.repo.clone(), cf.branch.clone()))
+        // We make a hard assumption in the design of diffs that a studio can only contain files
+        // from one repository. This allows us to determine which repository to create new files
+        // or delete files in, without having to prefix file paths with repository names.
+        //
+        // If we can't find *any* files in the context to detect the current repository,
+        // creating/deleting a file like `index.js` is ambiguous, so we just return an error.
+        .context("could not determine studio repository, studio didn't contain any files")?;
+
+    let valid_chunks = futures::stream::iter(diff_chunks)
+        .map(|mut chunk| {
+            let (repo, branch) = (repo.clone(), branch.clone());
+            let app = (*app).clone();
+            let llm_context = llm_context.clone();
+            let llm_gateway = llm_gateway.clone();
+
+            async move {
+                match (&chunk.src, &chunk.dst) {
+                    (Some(src), Some(dst)) => {
+                        if src != dst {
+                            error!(
+                                "patch source and destination file were different: \
+                                got `{src}` and `{dst}`"
+                            );
+
+                            return Ok(None);
+                        }
+
+                        chunk.hunks = rectify_hunks(
+                            &app,
+                            &llm_context,
+                            &llm_gateway,
+                            chunk.hunks.iter(),
+                            src,
+                            &repo,
+                            branch.as_deref(),
+                        )
+                        .await?;
+
+                        Ok(Some(chunk))
+                    }
+
+                    (Some(src), None) => {
+                        if validate_delete_file(&app, &chunk, src, &repo, branch.as_deref()).await?
+                        {
+                            Ok(Some(chunk))
+                        } else {
+                            Ok(None)
+                        }
+                    }
+
+                    (None, Some(dst)) => {
+                        if validate_add_file(&app, &chunk, dst, &repo, branch.as_deref()).await? {
+                            Ok(Some(chunk))
+                        } else {
+                            Ok(None)
+                        }
+                    }
+
+                    (None, None) => {
+                        error!("patch chunk had no file source or destination");
+                        Ok(None)
+                    }
+                }
+            }
+        })
+        .buffered(10)
+        .try_filter_map(|c: Option<_>| async move { Ok::<_, anyhow::Error>(c) })
+        .try_collect::<Vec<_>>()
+        .await
+        .context("failed to interpret diff chunks")?;
+
+    let mut file_langs = HashMap::<String, String>::new();
+    let mut out = structured_diff::Diff { chunks: vec![] };
+
+    for chunk in valid_chunks {
+        let path = chunk.src.as_deref().or(chunk.dst.as_deref()).unwrap();
+        let lang = if let Some(l) = file_langs.get(path) {
+            Some(l.clone())
+        } else {
+            let detected_lang = if let Some(src) = &chunk.src {
+                let doc = app
+                    .indexes
+                    .file
+                    .by_path(&repo, src, branch.as_deref())
+                    .await?
+                    .context("path did not exist in the index")?;
+
+                doc.lang
+            } else {
+                hyperpolyglot::detect(std::path::Path::new(&chunk.dst.as_deref().unwrap()))
+                    .ok()
+                    .flatten()
+                    .map(|detection| detection.language().to_owned())
+            };
+
+            if let Some(l) = detected_lang.clone() {
+                file_langs.insert(path.to_owned(), l);
+            }
+
+            detected_lang
+        };
+
+        out.chunks.push(structured_diff::Chunk {
+            raw_patch: chunk.to_string(),
+
+            lang: lang.clone(),
+            repo: repo.clone(),
+            branch: branch.clone(),
+            file: path.to_owned(),
+            hunks: chunk
+                .hunks
+                .into_iter()
+                .map(|hunk| structured_diff::Hunk {
+                    line_start: hunk.src_line,
+                    patch: hunk
+                        .lines
+                        .into_iter()
+                        .map(|line| line.to_string())
+                        .collect::<String>(),
+                })
+                .collect(),
+        });
+    }
+
+    Ok(Json(out))
+}
+
+fn context_repo_branch(context: &[ContextFile]) -> Result<(RepoRef, Option<String>)> {
+    let (repo, branch) = context
+        .first()
+        .map(|cf| (cf.repo.clone(), cf.branch.clone()))
+        // We make a hard assumption in the design of diffs that a studio can only contain files
+        // from one repository. This allows us to determine which repository to create new files
+        // or delete files in, without having to prefix file paths with repository names.
+        //
+        // If we can't find *any* files in the context to detect the current repository,
+        // creating/deleting a file like `index.js` is ambiguous, so we just return an error.
+        .context("could not determine studio repository, studio didn't contain any files")?;
+
+    Ok((repo, branch))
+}
+
+async fn rectify_hunks(
+    app: &Application,
+    llm_context: &str,
+    llm_gateway: &llm_gateway::Client,
+    hunks: impl Iterator<Item = &DiffHunk>,
+    path: &str,
+    repo: &RepoRef,
+    branch: Option<&str>,
+) -> Result<Vec<DiffHunk>> {
+    let file = app
+        .indexes
+        .file
+        .by_path(repo, path, branch)
+        .await?
+        .context("path did not exist in the index")?;
+
+    let mut file_content = file.content;
+
+    let mut out = Vec::new();
+
+    for (i, hunk) in hunks.enumerate() {
+        let mut singular_chunk = DiffChunk {
+            src: Some(path.to_owned()),
+            dst: Some(path.to_owned()),
+            hunks: vec![hunk.clone()],
+        };
+
+        let diff = singular_chunk.to_string();
+        let patch = diffy::Patch::from_str(&diff).context("invalid patch")?;
+
+        if let Ok(t) = diffy::apply(&file_content, &patch) {
+            file_content = t;
+            out.extend(singular_chunk.hunks);
+        } else {
+            debug!("fixing up patch:\n\n{hunk:?}\n\n{diff}");
+
+            singular_chunk.hunks[0].lines.retain(|line| match line {
+                diff::Line::AddLine(..) | diff::Line::DelLine(..) => true,
+                diff::Line::Context(..) => false,
+            });
+            singular_chunk.fixup_hunks();
+
+            let diff = if singular_chunk.hunks[0]
+                .lines
+                .iter()
+                .all(|l| matches!(l, diff::Line::AddLine(..)))
+            {
+                let system_prompt = prompts::studio_diff_regen_hunk_prompt(llm_context);
+                let messages = vec![
+                    llm_gateway::api::Message::system(&system_prompt),
+                    llm_gateway::api::Message::user(&singular_chunk.to_string()),
+                ];
+                llm_gateway.chat(&messages, None).await?
+            } else {
+                singular_chunk.to_string()
+            };
+
+            let patch = diffy::Patch::from_str(&diff).context("redacted patch was invalid")?;
+
+            if let Ok(t) = diffy::apply(&file_content, &patch) {
+                file_content = t;
+                out.extend(singular_chunk.hunks);
+            } else {
+                warn!("hunk {path}#{i} failed: {diff}");
+            }
+        }
+    }
+
+    Ok(out)
+}
+
+async fn validate_delete_file(
+    app: &Application,
+    chunk: &DiffChunk,
+    path: &str,
+    repo: &RepoRef,
+    branch: Option<&str>,
+) -> Result<bool> {
+    let Some(file) = app.indexes.file.by_path(repo, path, branch).await? else {
+        error!("diff tried to delete a file that doesn't exist: {path}");
+        return Ok(false);
+    };
+
+    // We know our formatted diffs are valid syntax.
+    let diff = chunk.to_string();
+    let patch = diffy::Patch::from_str(&diff).unwrap();
+
+    let Ok(final_content) = diffy::apply(&file.content, &patch) else {
+        error!("deletion diff did not cleanly apply to file: {path}");
+        return Ok(false);
+    };
+
+    if !final_content.trim().is_empty() {
+        error!("deletion diff did not fully delete file contents");
+        return Ok(false);
+    }
+
+    Ok(true)
+}
+
+async fn validate_add_file(
+    app: &Application,
+    chunk: &DiffChunk,
+    path: &str,
+    repo: &RepoRef,
+    branch: Option<&str>,
+) -> Result<bool> {
+    if app
+        .indexes
+        .file
+        .by_path(repo, path, branch)
+        .await?
+        .is_some()
+    {
+        error!("diff tried to create a file that already exists: {path}");
+        return Ok(false);
+    };
+
+    if chunk.hunks.iter().any(|h| {
+        h.lines
+            .iter()
+            .any(|l| !matches!(l, diff::Line::AddLine(..)))
+    }) {
+        error!("diff to create a new file had non-addition lines");
+        Ok(false)
+    } else {
+        Ok(true)
+    }
+}
+
+pub async fn diff_apply(
+    app: Extension<Application>,
+    user: Extension<User>,
+    Path(studio_id): Path<i64>,
+    diff: String,
+) -> webserver::Result<()> {
+    let user_id = user.username().ok_or_else(no_user_id)?.to_string();
+
+    let snapshot_id = latest_snapshot_id(studio_id, &*app.sql, &user_id).await?;
+
+    let context_json = sqlx::query!(
+        "SELECT context FROM studio_snapshots WHERE id = ?",
+        snapshot_id,
+    )
+    .fetch_optional(&*app.sql)
+    .await?
+    .map(|row| row.context)
+    .ok_or_else(studio_not_found)?;
+
+    let context =
+        serde_json::from_str::<Vec<ContextFile>>(&context_json).map_err(Error::internal)?;
+
+    let diff_chunks = diff::relaxed_parse(&diff);
+
+    let (repo, branch) = context_repo_branch(&context)?;
+
+    for (i, chunk) in diff_chunks.enumerate() {
+        let mut file_content = if let Some(src) = &chunk.src {
+            app.indexes
+                .file
+                .by_path(&repo, src, branch.as_deref())
+                .await?
+                .context("path did not exist in the index")?
+                .content
+        } else {
+            String::new()
+        };
+
+        for (j, hunk) in chunk.hunks.iter().enumerate() {
+            let mut singular_chunk = chunk.clone();
+            singular_chunk.hunks = vec![hunk.clone()];
+
+            let diff = singular_chunk.to_string();
+            let patch = diffy::Patch::from_str(&diff).context("invalid patch")?;
+
+            match diffy::apply(&file_content, &patch) {
+                Ok(t) => file_content = t,
+                Err(e) => {
+                    return Err(
+                        Error::user(format!("chunk {i}, hunk {j} failed to apply: {e}"))
+                            .with_status(StatusCode::BAD_REQUEST),
+                    )
+                }
+            }
+        }
+
+        let Some(repo_path) = repo.local_path() else {
+            error!("cannot apply patch to remote repo");
+            continue;
+        };
+
+        if let Some(dst) = &chunk.dst {
+            let file_path = repo_path.join(dst);
+            std::fs::write(file_path, file_content).context("failed to patch file on disk")?;
+        } else {
+            if !file_content.trim().is_empty() {
+                return Err(Error::user(
+                    "diff deletes a file but not all contents were removed",
+                ));
+            }
+
+            let file_path = repo_path.join(chunk.src.clone().unwrap());
+            std::fs::remove_file(file_path).context("failed to delete file on disk")?;
+        }
+    }
+
+    // Force a re-sync.
+    let _ = crate::webserver::repos::sync(Query(webserver::repos::RepoParams { repo }), app, user)
+        .await?;
+
+    Ok(())
+}
+
 /// If a given studio's name is `NULL`, try to auto-generate a name.
 ///
 /// If the requested studio already has a name, this is a no-op.
@@ -1107,9 +1592,9 @@ fn canonicalize_context(
     context: impl Iterator<Item = ContextFile>,
 ) -> impl Iterator<Item = ContextFile> {
     context
-        .fold(HashMap::new(), |mut map, file| {
+        .fold(HashMap::<_, Vec<_>>::new(), |mut map, file| {
             let key = (file.path.clone(), file.branch.clone());
-            map.entry(key).or_insert_with(Vec::new).push(file);
+            map.entry(key).or_default().push(file);
             map
         })
         .into_values()

--- a/server/bleep/src/webserver/studio/diff.rs
+++ b/server/bleep/src/webserver/studio/diff.rs
@@ -1,0 +1,734 @@
+use std::fmt;
+
+use anyhow::{bail, Result};
+use lazy_regex::regex;
+
+pub fn extract(chat_response: &str) -> Result<impl Iterator<Item = DiffChunk>> {
+    Ok(relaxed_parse(&extract_diff(chat_response)?)
+        // We eagerly collect the iterator, and re-create it, as our input string is created in and
+        // can't escape this function. This also allows us to catch parse errors earlier.
+        .collect::<Vec<_>>()
+        .into_iter())
+}
+
+fn extract_diff(chat_response: &str) -> Result<String> {
+    let fragments = regex!(r#"^```diff.*?^(.*?)^```.*?($|\z)"#sm)
+        .captures_iter(chat_response)
+        .map(|c| c.get(1).unwrap().as_str())
+        .collect::<String>();
+
+    if fragments.is_empty() {
+        bail!("chat response didn't contain any diff blocks");
+    } else {
+        Ok(fragments)
+    }
+}
+
+/// Parse a diff, allowing for some formatting errors.
+pub fn relaxed_parse(diff: &str) -> impl Iterator<Item = DiffChunk> + '_ {
+    split_chunks(diff).map(|mut chunk| {
+        dbg!(&chunk);
+        chunk.fixup_hunks();
+        chunk
+    })
+}
+
+fn split_chunks(diff: &str) -> impl Iterator<Item = DiffChunk> + '_ {
+    let chunk_regex = regex!(r#"(?: (.*)$\n^\+\+\+ (.*)$)\n((?:^$\n?|^[-+@ ].*\n?)+)"#m);
+
+    regex!("^---"m).split(diff).filter_map(|chunk| {
+        let caps = chunk_regex.captures(chunk)?;
+        Some(DiffChunk {
+            src: match caps.get(1).unwrap().as_str() {
+                "/dev/null" => None,
+                s => Some(s.to_owned()),
+            },
+            dst: match caps.get(2).unwrap().as_str() {
+                "/dev/null" => None,
+                s => Some(s.to_owned()),
+            },
+            hunks: split_hunks(caps.get(3).unwrap().as_str()).collect(),
+        })
+    })
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DiffChunk {
+    pub src: Option<String>,
+    pub dst: Option<String>,
+    pub hunks: Vec<DiffHunk>,
+}
+
+impl DiffChunk {
+    pub fn fixup_hunks(&mut self) {
+        self.hunks.retain_mut(|h| {
+            if !h.fixup() {
+                false
+            } else {
+                h.lines.iter().any(|l| !matches!(l, Line::Context(_)))
+            }
+        });
+    }
+}
+
+impl fmt::Display for DiffChunk {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let hunks_str = self.hunks.iter().map(|h| h.to_string()).collect::<String>();
+
+        let src = if let Some(s) = self.src.as_deref() {
+            s
+        } else {
+            "/dev/null"
+        };
+
+        let dst = if let Some(s) = self.dst.as_deref() {
+            s
+        } else {
+            "/dev/null"
+        };
+
+        write!(f, "--- {src}\n+++ {dst}\n{hunks_str}")
+    }
+}
+
+fn split_hunks(hunks: &str) -> impl Iterator<Item = DiffHunk> + '_ {
+    let hunk_regex =
+        regex!(r#"@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@.*\n((?:^\n|^[-+ ].*\n?)*)"#m);
+
+    hunk_regex.captures_iter(hunks).map(|caps| DiffHunk {
+        src_line: caps.get(1).unwrap().as_str().parse().unwrap(),
+        src_count: caps
+            .get(2)
+            .and_then(|m| m.as_str().parse().ok())
+            .unwrap_or(0),
+        dst_line: caps.get(3).unwrap().as_str().parse().unwrap(),
+        dst_count: caps
+            .get(4)
+            .and_then(|m| m.as_str().parse().ok())
+            .unwrap_or(0),
+        lines: {
+            caps.get(5)
+                .unwrap()
+                .as_str()
+                .lines()
+                .map(|l| {
+                    if !l.is_empty() {
+                        l.split_at(1)
+                    } else {
+                        (" ", "")
+                    }
+                })
+                .map(|(type_, line)| match type_ {
+                    " " => Line::Context(line.into()),
+                    "+" => Line::AddLine(line.into()),
+                    "-" => Line::DelLine(line.into()),
+                    _ => unreachable!("unknown character slipped through regex"),
+                })
+                .collect()
+        },
+    })
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DiffHunk {
+    pub src_line: usize,
+    pub dst_line: usize,
+    pub src_count: usize,
+    pub dst_count: usize,
+
+    pub lines: Vec<Line>,
+}
+
+impl DiffHunk {
+    fn fixup(&mut self) -> bool {
+        let src = self
+            .lines
+            .iter()
+            .filter_map(|line| match line {
+                Line::Context(l) => Some(format!("{l}\n")),
+                Line::AddLine(_) => None,
+                Line::DelLine(l) => Some(format!("{l}\n")),
+            })
+            .collect::<String>();
+
+        let dst = self
+            .lines
+            .iter()
+            .filter_map(|line| match line {
+                Line::Context(l) => Some(format!("{l}\n")),
+                Line::AddLine(l) => Some(format!("{l}\n")),
+                Line::DelLine(_) => None,
+            })
+            .collect::<String>();
+
+        let patch = diffy::DiffOptions::default()
+            .set_context_len(usize::MAX)
+            .create_patch(&src, &dst);
+        let patch = patch.to_string();
+
+        let mut new_hunks = split_hunks(&patch).collect::<Vec<_>>();
+
+        if new_hunks.is_empty() {
+            return false;
+        }
+
+        assert_eq!(
+            new_hunks.len(),
+            1,
+            "regenerated hunk's patch was malformed:\n\n{patch}"
+        );
+        self.lines = new_hunks.pop().unwrap().lines.into_iter().collect();
+
+        self.src_count = self
+            .lines
+            .iter()
+            .map(|l| match l {
+                Line::Context(_) | Line::DelLine(_) => 1,
+                Line::AddLine(_) => 0,
+            })
+            .sum();
+
+        self.dst_count = self
+            .lines
+            .iter()
+            .map(|l| match l {
+                Line::Context(_) | Line::AddLine(_) => 1,
+                Line::DelLine(_) => 0,
+            })
+            .sum();
+
+        true
+    }
+}
+
+impl fmt::Display for DiffHunk {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(
+            f,
+            "@@ -{},{} +{},{} @@",
+            self.src_line, self.src_count, self.dst_line, self.dst_count
+        )?;
+
+        for line in &self.lines {
+            <Line as fmt::Display>::fmt(line, f)?;
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Line {
+    Context(String),
+    AddLine(String),
+    DelLine(String),
+}
+
+impl fmt::Display for Line {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Line::Context(line) => writeln!(f, " {line}"),
+            Line::AddLine(line) => writeln!(f, "+{line}"),
+            Line::DelLine(line) => writeln!(f, "-{line}"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn test_extract_diff() {
+        let s = "```diff
+foo bar
+```";
+
+        assert_eq!(extract_diff(s).unwrap(), "foo bar\n");
+    }
+
+    #[test]
+    fn test_extract_diff_complex() {
+        let s = "```diff
+x
+
+    ```diff
+foo bar
+ ```
+```";
+
+        assert_eq!(
+            extract_diff(s).unwrap(),
+            "x\n\n    ```diff\nfoo bar\n ```\n"
+        );
+    }
+
+    #[test]
+    fn test_relaxed_parse() {
+        let s = "\
+--- foo.rs
++++ foo.rs
+@@ -1,1 +1,1 @@
+-foo
++bar
+@@ -10,1 +10,1 @@
+ quux
+ quux2
++quux3
+ quux4
+--- bar.rs
++++ bar.rs
+@@ -10 +10 @@
+-bar
++fred
+@@ -100,1 +100,1 @@
+ baz
+-bar
++thud
+ baz
++thud
+ baz";
+
+        let expected = "\
+--- foo.rs
++++ foo.rs
+@@ -1,1 +1,1 @@
+-foo
++bar
+@@ -10,3 +10,4 @@
+ quux
+ quux2
++quux3
+ quux4
+--- bar.rs
++++ bar.rs
+@@ -10,1 +10,1 @@
+-bar
++fred
+@@ -100,4 +100,5 @@
+ baz
+-bar
++thud
+ baz
++thud
+ baz
+";
+        let output = relaxed_parse(s)
+            .map(|chunk| chunk.to_string())
+            .collect::<String>();
+        assert_eq!(expected, output);
+    }
+
+    #[test]
+    fn test_split_hunks() {
+        let hunks = "@@ -1,1 +1,1 @@
+ context
+ the line right below this one is intentionally empty
+
+-foo
++bar
+@@ -10,1 +10,2 @@
+-bar
++quux
++quux2";
+
+        let expected = vec![
+            DiffHunk {
+                src_line: 1,
+                src_count: 1,
+                dst_line: 1,
+                dst_count: 1,
+                lines: vec![
+                    Line::Context("context".to_owned()),
+                    Line::Context(
+                        "the line right below this one is intentionally empty".to_owned(),
+                    ),
+                    Line::Context("".to_owned()),
+                    Line::DelLine("foo".to_owned()),
+                    Line::AddLine("bar".to_owned()),
+                ],
+            },
+            DiffHunk {
+                src_line: 10,
+                src_count: 1,
+                dst_line: 10,
+                dst_count: 2,
+                lines: vec![
+                    Line::DelLine("bar".to_owned()),
+                    Line::AddLine("quux".to_owned()),
+                    Line::AddLine("quux2".to_owned()),
+                ],
+            },
+        ];
+
+        let output = split_hunks(hunks).collect::<Vec<_>>();
+
+        assert_eq!(expected, output);
+    }
+
+    #[test]
+    fn test_split_chunks() {
+        let diff = "    A simple diff description.
+
+--- foo.rs
++++ foo.rs
+@@ -1,1 +1,1 @@
+ context
+ the line right below this one is intentionally empty
+
+-foo
++bar
+--- bar.rs
++++ bar.rs
+@@ -10,1 +10,2 @@
+-bar
++quux
++quux2";
+
+        let expected = vec![
+            DiffChunk {
+                src: Some("foo.rs".to_owned()),
+                dst: Some("foo.rs".to_owned()),
+                hunks: vec![DiffHunk {
+                    src_line: 1,
+                    src_count: 1,
+                    dst_line: 1,
+                    dst_count: 1,
+                    lines: vec![
+                        Line::Context("context".to_owned()),
+                        Line::Context(
+                            "the line right below this one is intentionally empty".to_owned(),
+                        ),
+                        Line::Context("".to_owned()),
+                        Line::DelLine("foo".to_owned()),
+                        Line::AddLine("bar".to_owned()),
+                    ],
+                }],
+            },
+            DiffChunk {
+                src: Some("bar.rs".to_owned()),
+                dst: Some("bar.rs".to_owned()),
+                hunks: vec![DiffHunk {
+                    src_line: 10,
+                    src_count: 1,
+                    dst_line: 10,
+                    dst_count: 2,
+                    lines: vec![
+                        Line::DelLine("bar".to_owned()),
+                        Line::AddLine("quux".to_owned()),
+                        Line::AddLine("quux2".to_owned()),
+                    ],
+                }],
+            },
+        ];
+
+        let output = split_chunks(diff).collect::<Vec<_>>();
+
+        assert_eq!(expected, output);
+    }
+
+    #[test]
+    fn test_bug_split() {
+        let chat_response = r#"```diff
+--- server/bleep/src/analytics.rs
++++ server/bleep/src/analytics.rs
+@@ -215,6 +215,22 @@ impl RudderHub {
+             }));
+         }
+     }
++    
++    pub fn track_index_repo(&self, user: &crate::webserver::middleware::User, repo_ref: RepoRef) {
++        if let Some(options) = &self.options {
++            self.send(Message::Track(Track {
++                user_id: Some(self.tracking_id(user.username())),
++                event: "index repo".to_owned(),
++                properties: Some(json!({
++                    "device_id": self.device_id(),
++                    "repo_ref": repo_ref.to_string(),
++                    "package_metadata": options.package_metadata,
++                })),
++                ..Default::default()
++            }));
++        }
++    }
+ }
+ 
+ impl From<Option<String>> for DeviceId {
+
+--- server/bleep/src/indexes.rs
++++ server/bleep/src/indexes.rs
+@@ -61,7 +61,9 @@ impl<'a> GlobalWriteHandle<'a> {
+     }
+ 
+     pub(crate) async fn index(
+-        &self,
++        &self,
++        analytics: &RudderHub,  // Pass in the RudderHub instance
++        user: &crate::webserver::middleware::User,  // Pass in the current user
+         sync_handle: &SyncHandle,
+         repo: &Repository,
+     ) -> Result<Arc<RepoMetadata>, RepoError> {
+@@ -70,6 +72,9 @@ impl<'a> GlobalWriteHandle<'a> {
+ 
+         for h in &self.handles {
+             h.index(sync_handle, repo, &metadata).await?;
++            
++            // Track the repo indexing event
++            analytics.track_index_repo(user, repo.repo_ref.clone());
+         }
+ 
+         Ok(metadata)
+```"#;
+        let expected = vec![
+            DiffChunk {
+                src: Some("server/bleep/src/analytics.rs".to_owned()),
+                dst: Some("server/bleep/src/analytics.rs".to_owned()),
+                hunks: vec![DiffHunk {
+                    src_line: 215,
+                    src_count: 7,
+                    dst_line: 215,
+                    dst_count: 22,
+                    lines: vec![
+                        Line::Context("            }));".to_owned()),
+                        Line::Context("        }".to_owned()),
+                        Line::Context("    }".to_owned()),
+                        Line::AddLine("    ".to_owned()),
+                        Line::AddLine("    pub fn track_index_repo(&self, user: &crate::webserver::middleware::User, repo_ref: RepoRef) {".to_owned()),
+                        Line::AddLine(r#"        if let Some(options) = &self.options {"#.to_owned()),
+                        Line::AddLine(r#"            self.send(Message::Track(Track {"#.to_owned()),
+                        Line::AddLine(r#"                user_id: Some(self.tracking_id(user.username())),"#.to_owned()),
+                        Line::AddLine(r#"                event: "index repo".to_owned(),"#.to_owned()),
+                        Line::AddLine(r#"                properties: Some(json!({"#.to_owned()),
+                        Line::AddLine(r#"                    "device_id": self.device_id(),"#.to_owned()),
+                        Line::AddLine(r#"                    "repo_ref": repo_ref.to_string(),"#.to_owned()),
+                        Line::AddLine(r#"                    "package_metadata": options.package_metadata,"#.to_owned()),
+                        Line::AddLine(r#"                })),"#.to_owned()),
+                        Line::AddLine(r#"                ..Default::default()"#.to_owned()),
+                        Line::AddLine(r#"            }));"#.to_owned()),
+                        Line::AddLine(r#"        }"#.to_owned()),
+                        Line::AddLine(r#"    }"#.to_owned()),
+                        Line::Context("}".to_owned()),
+                        Line::Context("".to_owned()),
+                        Line::Context("impl From<Option<String>> for DeviceId {".to_owned()),
+                        Line::Context("".to_owned()),
+                    ],
+                }],
+            },
+            DiffChunk {
+                src: Some("server/bleep/src/indexes.rs".to_owned()),
+                dst: Some("server/bleep/src/indexes.rs".to_owned()),
+                hunks: vec![
+                    DiffHunk {
+                        src_line: 61,
+                        src_count: 7,
+                        dst_line: 61,
+                        dst_count: 9,
+                        lines: vec![
+                            Line::Context(r#"    }"#.to_owned()),
+                            Line::Context(r#""#.to_owned()),
+                            Line::Context(r#"    pub(crate) async fn index("#.to_owned()),
+                            Line::Context(r#"        &self,"#.to_owned()),
+                            Line::AddLine(r#"        analytics: &RudderHub,  // Pass in the RudderHub instance"#.to_owned()),
+                            Line::AddLine(r#"        user: &crate::webserver::middleware::User,  // Pass in the current user"#.to_owned()),
+                            Line::Context(r#"        sync_handle: &SyncHandle,"#.to_owned()),
+                            Line::Context(r#"        repo: &Repository,"#.to_owned()),
+                            Line::Context(r#"    ) -> Result<Arc<RepoMetadata>, RepoError> {"#.to_owned()),
+                        ],
+                    },
+                    DiffHunk {
+                        src_line: 70,
+                        src_count: 6,
+                        dst_line: 72,
+                        dst_count: 9,
+                        lines: vec![
+                            Line::Context(r#""#.to_owned()),
+                            Line::Context(r#"        for h in &self.handles {"#.to_owned()),
+                            Line::Context(r#"            h.index(sync_handle, repo, &metadata).await?;"#.to_owned()),
+                            Line::AddLine(r#"            "#.to_owned()),
+                            Line::AddLine(r#"            // Track the repo indexing event"#.to_owned()),
+                            Line::AddLine(r#"            analytics.track_index_repo(user, repo.repo_ref.clone());"#.to_owned()),
+                            Line::Context(r#"        }"#.to_owned()),
+                            Line::Context(r#""#.to_owned()),
+                            Line::Context(r#"        Ok(metadata)"#.to_owned()),
+                        ],
+                    },
+                ],
+            },
+        ];
+
+        let output = extract(chat_response).unwrap().collect::<Vec<_>>();
+
+        assert_eq!(expected, output);
+    }
+
+    #[test]
+    fn test_split_chunks_no_count() {}
+
+    #[test]
+    fn test_fixup_remove_redundancy() {
+        let mut hunk = DiffHunk {
+            src_line: 10,
+            src_count: 5,
+            dst_line: 10,
+            dst_count: 5,
+            lines: vec![
+                Line::DelLine("fn main() {".to_owned()),
+                Line::AddLine("fn main() {".to_owned()),
+                Line::Context("    let a = 123;".to_owned()),
+                Line::DelLine("    println!(\"the value of `a` is {a:?}\");".to_owned()),
+                Line::AddLine("    dbg!(&a);".to_owned()),
+                Line::Context("    drop(a);".to_owned()),
+                Line::Context("}".to_owned()),
+            ],
+        };
+
+        hunk.fixup();
+
+        let expected = DiffHunk {
+            src_line: 10,
+            src_count: 5,
+            dst_line: 10,
+            dst_count: 5,
+            lines: vec![
+                Line::Context("fn main() {".to_owned()),
+                Line::Context("    let a = 123;".to_owned()),
+                Line::DelLine("    println!(\"the value of `a` is {a:?}\");".to_owned()),
+                Line::AddLine("    dbg!(&a);".to_owned()),
+                Line::Context("    drop(a);".to_owned()),
+                Line::Context("}".to_owned()),
+            ],
+        };
+
+        assert_eq!(expected, hunk);
+    }
+
+    #[test]
+    fn test_extract_redundant() {
+        let chat_response = "```diff
+--- server/bleep/src/query/parser.rs
++++ server/bleep/src/query/parser.rs
+@@ -64,7 +64,7 @@
+     }
+ 
+     pub fn from_str(query: String, repo_ref: String) -> Self {
+-        Self {
++        Self {
+             target: Some(Literal::Plain(Cow::Owned(query))),
+             repos: [Literal::Plain(Cow::Owned(repo_ref))].into(),
+             ..Default::default()
+```";
+
+        for _ in extract(&chat_response).unwrap() {}
+    }
+
+    #[test]
+    fn test_multiple_diff_blocks() {
+        let chat_response = r#"```diff
+--- server/bleep/src/analytics.rs
++++ server/bleep/src/analytics.rs
+@@ -215,6 +215,22 @@ impl RudderHub {
+             }));
+         }
+     }
++    
++    pub fn track_index_repo(&self, user: &crate::webserver::middleware::User, repo_ref: RepoRef) {
++        if let Some(options) = &self.options {
++            self.send(Message::Track(Track {
++                user_id: Some(self.tracking_id(user.username())),
++                event: "index repo".to_owned(),
++                properties: Some(json!({
++                    "device_id": self.device_id(),
++                    "repo_ref": repo_ref.to_string(),
++                    "package_metadata": options.package_metadata,
++                })),
++                ..Default::default()
++            }));
++        }
++    }
+ }
+ 
+ impl From<Option<String>> for DeviceId {
+```
+
+```diff
+--- server/bleep/src/indexes.rs
++++ server/bleep/src/indexes.rs
+@@ -61,7 +61,9 @@ impl<'a> GlobalWriteHandle<'a> {
+     }
+ 
+     pub(crate) async fn index(
+-        &self,
++        &self,
++        analytics: &RudderHub,  // Pass in the RudderHub instance
++        user: &crate::webserver::middleware::User,  // Pass in the current user
+         sync_handle: &SyncHandle,
+         repo: &Repository,
+     ) -> Result<Arc<RepoMetadata>, RepoError> {
+@@ -70,6 +72,9 @@ impl<'a> GlobalWriteHandle<'a> {
+ 
+         for h in &self.handles {
+             h.index(sync_handle, repo, &metadata).await?;
++            
++            // Track the repo indexing event
++            analytics.track_index_repo(user, repo.repo_ref.clone());
+         }
+ 
+         Ok(metadata)
+```"#;
+
+        let expected = r#"--- server/bleep/src/analytics.rs
++++ server/bleep/src/analytics.rs
+@@ -215,6 +215,22 @@ impl RudderHub {
+             }));
+         }
+     }
++    
++    pub fn track_index_repo(&self, user: &crate::webserver::middleware::User, repo_ref: RepoRef) {
++        if let Some(options) = &self.options {
++            self.send(Message::Track(Track {
++                user_id: Some(self.tracking_id(user.username())),
++                event: "index repo".to_owned(),
++                properties: Some(json!({
++                    "device_id": self.device_id(),
++                    "repo_ref": repo_ref.to_string(),
++                    "package_metadata": options.package_metadata,
++                })),
++                ..Default::default()
++            }));
++        }
++    }
+ }
+ 
+ impl From<Option<String>> for DeviceId {
+--- server/bleep/src/indexes.rs
++++ server/bleep/src/indexes.rs
+@@ -61,7 +61,9 @@ impl<'a> GlobalWriteHandle<'a> {
+     }
+ 
+     pub(crate) async fn index(
+-        &self,
++        &self,
++        analytics: &RudderHub,  // Pass in the RudderHub instance
++        user: &crate::webserver::middleware::User,  // Pass in the current user
+         sync_handle: &SyncHandle,
+         repo: &Repository,
+     ) -> Result<Arc<RepoMetadata>, RepoError> {
+@@ -70,6 +72,9 @@ impl<'a> GlobalWriteHandle<'a> {
+ 
+         for h in &self.handles {
+             h.index(sync_handle, repo, &metadata).await?;
++            
++            // Track the repo indexing event
++            analytics.track_index_repo(user, repo.repo_ref.clone());
+         }
+ 
+         Ok(metadata)
+"#;
+
+        let output = extract_diff(chat_response).unwrap();
+
+        assert_eq!(expected, output);
+    }
+}


### PR DESCRIPTION
WIP

This can be tested by making a studio request, and then querying `GET /studio/:id/diff`. The response will be an ingested and reformatted diff, and hunk application test results will be noted in the console. Make sure you run with `BLOOP_LOG=bleep=info` at least, in order to view the application results.

Route overview:

- `GET /studio/:id/diff`: This route reads the given studio, extracts the final user and assistant messages, and creates a _unified diff_ corresponding to changes described in the assistant's response to the user query. This patch can be passed directly to `/studio/:id/diff/apply`
  - **Optional parameter** `?apply=[true|false]`: If present and `true`, this will try to automatically apply the given code diff to the repository, if it is a local repo on the filesystem.
- `POST /studio/:studio_id/diff/apply`: This route accepts a plaintext body containing a diff (can be generated by `GET /studio/:id/diff`), and tries to apply it to a repo, if the studio's repository is a locally indexed repo.

<a href="https://gitpod.io/#https://github.com/BloopAI/bloop/pull/1041"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

