### PR TITLE
Fix race in credentials polling

### DIFF
--- a/server/bleep/src/periodic/remotes.rs
+++ b/server/bleep/src/periodic/remotes.rs
@@ -110,7 +110,11 @@ pub(crate) async fn sync_github_status(app: Application) {
         };
         debug!("repo list updated");
 
-        let updated = app.credentials.github_updated().unwrap();
+        let updated = match app.credentials.github_updated() {
+            Some(receiver) => receiver,
+            // This is a race condition, let's need to start from scratch.
+            None => continue,
+        };
         let new = github.update_repositories(repos);
 
         // store the updated credentials here


### PR DESCRIPTION
Previously the assumption here was that this path is locked & safe when there is a furnished github cred in the system. However, when the user logs out, the `unwrap()` call can blow up the task, and this may cause issues.