### PR TITLE
Don't use credentials to fetch public repos

### DIFF
--- a/server/bleep/src/remotes.rs
+++ b/server/bleep/src/remotes.rs
@@ -128,25 +128,29 @@ macro_rules! creds_callback(($auth:ident) => {{
     }
 }});
 
-async fn git_clone(auth: GitCreds, url: &str, target: &Path) -> Result<()> {
+async fn git_clone(auth: Option<GitCreds>, url: &str, target: &Path) -> Result<()> {
     let url = url.to_owned();
     let target = target.to_owned();
 
     tokio::task::spawn_blocking(move || {
-        let clone = gix::prepare_clone_bare(url, target)?;
-        let (_repo, _outcome) = clone
-            .configure_connection(move |con| {
-                con.set_credentials(creds_callback!(auth));
-                Ok(())
-            })
-            .fetch_only(gix::progress::Discard, &false.into())?;
+        let mut clone = {
+            let c = gix::prepare_clone_bare(url, target)?;
+            match auth {
+                Some(auth) => c.configure_connection(move |con| {
+                    con.set_credentials(creds_callback!(auth));
+                    Ok(())
+                }),
+                None => c,
+            }
+        };
 
+        let (_repo, _outcome) = clone.fetch_only(gix::progress::Discard, &false.into())?;
         Ok(())
     })
     .await?
 }
 
-async fn git_pull(auth: GitCreds, repo: &Repository) -> Result<()> {
+async fn git_pull(auth: Option<GitCreds>, repo: &Repository) -> Result<()> {
     use gix::remote::Direction;
 
     let disk_path = repo.disk_path.to_owned();
@@ -155,9 +159,16 @@ async fn git_pull(auth: GitCreds, repo: &Repository) -> Result<()> {
         let remote = repo
             .find_default_remote(Direction::Fetch)
             .context("no remote found")??;
-        remote
-            .connect(Direction::Fetch)?
-            .with_credentials(creds_callback!(auth))
+
+        let connection = {
+            let c = remote.connect(Direction::Fetch)?;
+            match auth {
+                Some(auth) => c.with_credentials(creds_callback!(auth)),
+                None => c,
+            }
+        };
+
+        connection
             .prepare_fetch(gix::progress::Discard, Default::default())?
             .receive(gix::progress::Discard, &false.into())?;
 

--- a/server/bleep/src/remotes/github.rs
+++ b/server/bleep/src/remotes/github.rs
@@ -130,10 +130,13 @@ impl Auth {
             Ok(details) => details,
         };
 
-        Ok(repo
-            .private
-            .map(|private| if private { Some(self.git_cred()) } else { None })
-            .unwrap_or_else(|| Some(self.git_cred())))
+        Ok(match repo.private {
+            // No credentials for public repos
+            Some(false) => None,
+            // Not sure there's a reason GitHub API wouldn't return a value,
+            // but provide credentials by default to be on the safe side.
+            _ => Some(self.git_cred()),
+        })
     }
 
     fn git_cred(&self) -> GitCreds {

--- a/server/bleep/src/remotes/github.rs
+++ b/server/bleep/src/remotes/github.rs
@@ -96,16 +96,16 @@ impl From<Auth> for State {
 
 impl Auth {
     pub(crate) async fn clone_repo(&self, repo: &Repository) -> Result<()> {
-        self.check_repo(repo).await?;
-        git_clone(self.git_cred(), &repo.remote.to_string(), &repo.disk_path).await
+        let creds = self.creds_for_private_repos(repo).await?;
+        git_clone(creds, &repo.remote.to_string(), &repo.disk_path).await
     }
 
     pub(crate) async fn pull_repo(&self, repo: &Repository) -> Result<()> {
-        self.check_repo(repo).await?;
-        git_pull(self.git_cred(), repo).await
+        let creds = self.creds_for_private_repos(repo).await?;
+        git_pull(creds, repo).await
     }
 
-    pub async fn check_repo(&self, repo: &Repository) -> Result<()> {
+    async fn creds_for_private_repos(&self, repo: &Repository) -> Result<Option<GitCreds>> {
         let RepoRemote::Git(GitRemote { ref address, .. }) = repo.remote else {
             return Err(RemoteError::NotSupported("github without git backend"));
         };
@@ -115,18 +115,25 @@ impl Auth {
             .ok_or(RemoteError::NotSupported("invalid repo address"))?;
 
         let response = self.client()?.repos(org, reponame).get().await;
-        match response {
-            Err(octocrab::Error::GitHub { ref source, .. }) => match source.message.as_str() {
+        let repo = match response {
+            Err(octocrab::Error::GitHub { ref source, .. })
+                if "Not Found" == source.message.as_str() =>
+            {
                 // GitHub API will send 403 for API-level issues, not object-level permissions
                 // A user having had their permissions removed will receive 404.
-                "Not Found" => Err(RemoteError::RemoteNotFound),
-                _ => Ok(response.map(|_| ())?),
-            },
+                return Err(RemoteError::RemoteNotFound);
+            }
             // I'm leaving this here for completeness' sake, this likely isn't exercised
             // Octocrab seems to treat GitHub application-layer errors as higher priority
-            Err(octocrab::Error::Http { .. }) => Err(RemoteError::PermissionDenied),
-            _ => Ok(response.map(|_| ())?),
-        }
+            Err(octocrab::Error::Http { .. }) => return Err(RemoteError::PermissionDenied),
+            Err(err) => return Err(err)?,
+            Ok(details) => details,
+        };
+
+        Ok(repo
+            .private
+            .map(|private| if private { Some(self.git_cred()) } else { None })
+            .unwrap_or_else(|| Some(self.git_cred())))
     }
 
     fn git_cred(&self) -> GitCreds {


### PR DESCRIPTION
This can occasionally cause issues with certain organizations which enforce a SAML policy regime on their staff.

Even if the repository is public, access by a 3rd party app can be denied. Therefore for all public repos, bleep will not use credentials.