### PR TITLE
Remove tantivy global reader lock

### DIFF
--- a/server/bleep/src/background/sync.rs
+++ b/server/bleep/src/background/sync.rs
@@ -281,7 +281,7 @@ impl SyncHandle {
 
         match indexed {
             Ok(_) => {
-                writers.commit().await.map_err(SyncError::Tantivy)?;
+                writers.commit().map_err(SyncError::Tantivy)?;
                 indexed.map_err(SyncError::Indexing)
             }
             Err(_) if self.pipes.is_removed() => self.delete_repo(&repo, writers).await,
@@ -306,7 +306,7 @@ impl SyncHandle {
 
         let deleted = self.delete_repo_indexes(repo, &writers).await;
         if deleted.is_ok() {
-            writers.commit().await.map_err(SyncError::Tantivy)?;
+            writers.commit().map_err(SyncError::Tantivy)?;
             self.app
                 .config
                 .source

--- a/server/bleep/src/indexes.rs
+++ b/server/bleep/src/indexes.rs
@@ -86,7 +86,7 @@ pub struct Indexes {
 }
 
 impl Indexes {
-    pub async fn new(config: &Configuration) -> Result<Self> {
+    pub fn new(config: &Configuration) -> Result<Self> {
         Ok(Self {
             repo: Indexer::create(
                 Repo::new(),
@@ -234,7 +234,6 @@ impl<T: Indexable> Indexer<T> {
         let mut index =
             tantivy::Index::open_or_create(tantivy::directory::MmapDirectory::open(path)?, schema)?;
 
-        index.set_default_multithread_executor()?;
         index.set_multithread_executor(threads)?;
         index
             .tokenizers()

--- a/server/bleep/src/indexes.rs
+++ b/server/bleep/src/indexes.rs
@@ -103,11 +103,11 @@ impl Indexes {
         })
     }
 
-    pub async fn reset_databases(config: &Configuration) -> Result<()> {
+    pub fn reset_databases(config: &Configuration) -> Result<()> {
         // we don't support old schemas, and tantivy will hard
         // error if we try to open a db with a different schema.
-        tokio::fs::remove_dir_all(config.index_path("repo")).await?;
-        tokio::fs::remove_dir_all(config.index_path("content")).await?;
+        std::fs::remove_dir_all(config.index_path("repo"))?;
+        std::fs::remove_dir_all(config.index_path("content"))?;
         Ok(())
     }
 

--- a/server/bleep/src/indexes.rs
+++ b/server/bleep/src/indexes.rs
@@ -50,9 +50,9 @@ impl<'a> GlobalWriteHandle<'a> {
         Ok(())
     }
 
-    pub(crate) async fn commit(self) -> Result<()> {
+    pub(crate) fn commit(self) -> Result<()> {
         for mut handle in self.handles {
-            handle.commit().await?
+            handle.commit()?
         }
 
         Ok(())
@@ -185,7 +185,7 @@ impl<'a> IndexWriteHandle<'a> {
             .await
     }
 
-    pub async fn commit(&mut self) -> Result<()> {
+    pub fn commit(&mut self) -> Result<()> {
         self.writer.commit()?;
         self.reader.reload()?;
 

--- a/server/bleep/src/indexes/file.rs
+++ b/server/bleep/src/indexes/file.rs
@@ -208,8 +208,7 @@ impl Indexer<File> {
         limit: usize,
     ) -> impl Iterator<Item = FileDocument> + '_ {
         // lifted from query::compiler
-        let reader = self.reader.read().await;
-        let searcher = reader.searcher();
+        let searcher = self.reader.searcher();
         let collector = TopDocs::with_limit(5 * limit); // TODO: tune this
         let file_source = &self.source;
 
@@ -315,8 +314,7 @@ impl Indexer<File> {
         branch: Option<&str>,
         limit: usize,
     ) -> impl Iterator<Item = FileDocument> + '_ {
-        let reader = self.reader.read().await;
-        let searcher = reader.searcher();
+        let searcher = self.reader.searcher();
         let file_source = &self.source;
 
         let repo_ref_term = Box::new(TermQuery::new(
@@ -405,8 +403,7 @@ impl Indexer<File> {
         relative_path: &str,
         branch: Option<&str>,
     ) -> Result<Option<ContentDocument>> {
-        let reader = self.reader.read().await;
-        let searcher = reader.searcher();
+        let searcher = self.reader.searcher();
 
         let file_index = searcher.index();
 
@@ -478,8 +475,7 @@ impl Indexer<File> {
         langs: impl Iterator<Item = S>,
         branch: Option<&str>,
     ) -> Vec<ContentDocument> {
-        let reader = self.reader.read().await;
-        let searcher = reader.searcher();
+        let searcher = self.reader.searcher();
 
         let mut query = vec![];
 

--- a/server/bleep/src/lib.rs
+++ b/server/bleep/src/lib.rs
@@ -164,11 +164,11 @@ impl Application {
             debug!("state reset complete");
         }
 
-        debug!("saving index version");
         config.source.save_index_version()?;
+        debug!("index version saved");
 
-        debug!("initializing indexes");
-        let indexes = Indexes::new(&config).await?.into();
+        let indexes = Indexes::new(&config)?.into();
+        debug!("indexes initialized");
 
         // Enforce capabilies and features depending on environment
         let env = if config.bloop_instance_secret.is_some() {

--- a/server/bleep/src/lib.rs
+++ b/server/bleep/src/lib.rs
@@ -150,7 +150,7 @@ impl Application {
         if config.source.index_version_mismatch() {
             debug!("schema version mismatch, resetting state");
 
-            Indexes::reset_databases(&config).await?;
+            Indexes::reset_databases(&config)?;
             debug!("tantivy indexes deleted");
 
             cache::FileCache::new(sql.clone(), semantic.clone())

--- a/server/bleep/src/webserver/intelligence.rs
+++ b/server/bleep/src/webserver/intelligence.rs
@@ -413,8 +413,7 @@ async fn search_nav(
         BooleanQuery::intersection(terms)
     };
     let collector = TopDocs::with_limit(500);
-    let reader = indexes.file.reader.read().await;
-    let searcher = reader.searcher();
+    let searcher = indexes.file.reader.searcher();
     let results = searcher
         .search(&query, &collector)
         .expect("failed to search index");


### PR DESCRIPTION
Tantivy has an internal mechanism for moving the internal pointer to the latest commit, so just use that instead of an external `RwLock`.