### PR TITLE
Filter entries that are neither files nor directories

### DIFF
--- a/server/bleep/src/indexes/file.rs
+++ b/server/bleep/src/indexes/file.rs
@@ -65,7 +65,7 @@ impl<'a> Workload<'a> {
         };
 
         let tantivy_hash = {
-            let branch_list = dir_entry.branches().unwrap_or_default();
+            let branch_list = dir_entry.branches();
             let mut hash = blake3::Hasher::new();
             hash.update(semantic_hash.as_ref());
             hash.update(branch_list.join("\n").as_bytes());
@@ -101,7 +101,7 @@ impl Indexable for File {
                 let completed = processed.fetch_add(1, Ordering::Relaxed);
                 pipes.index_percent(((completed as f32 / count as f32) * 100f32) as u8);
 
-                let entry_disk_path = dir_entry.path().unwrap().to_owned();
+                let entry_disk_path = dir_entry.path().to_owned();
                 let relative_path = {
                     let entry_srcpath = PathBuf::from(&entry_disk_path);
                     entry_srcpath
@@ -575,7 +575,6 @@ impl File {
 
                 trace!("file document written");
             }
-            RepoDirEntry::Other => anyhow::bail!("dir entry was neither a file nor a directory"),
         }
 
         #[cfg(feature = "debug")]

--- a/server/bleep/src/repo/iterator.rs
+++ b/server/bleep/src/repo/iterator.rs
@@ -53,15 +53,13 @@ pub trait FileSource {
 pub enum RepoDirEntry {
     Dir(RepoDir),
     File(RepoFile),
-    Other,
 }
 
 impl RepoDirEntry {
-    pub fn path(&self) -> Option<&str> {
+    pub fn path(&self) -> &str {
         match self {
-            Self::File(file) => Some(file.path.as_str()),
-            Self::Dir(dir) => Some(dir.path.as_str()),
-            Self::Other => None,
+            Self::File(file) => file.path.as_str(),
+            Self::Dir(dir) => dir.path.as_str(),
         }
     }
 
@@ -72,11 +70,10 @@ impl RepoDirEntry {
         }
     }
 
-    pub fn branches(&self) -> Option<&[String]> {
+    pub fn branches(&self) -> &[String] {
         match self {
-            RepoDirEntry::Dir(d) => Some(&d.branches),
-            RepoDirEntry::File(f) => Some(&f.branches),
-            RepoDirEntry::Other => None,
+            RepoDirEntry::Dir(d) => &d.branches,
+            RepoDirEntry::File(f) => &f.branches,
         }
     }
 }

--- a/server/bleep/src/repo/iterator/fs.rs
+++ b/server/bleep/src/repo/iterator/fs.rs
@@ -2,7 +2,7 @@ use crate::background;
 
 use super::*;
 
-use tracing::warn;
+use tracing::{debug, warn};
 
 use std::path::{Path, PathBuf};
 
@@ -69,7 +69,8 @@ impl FileSource for FileWalker {
                             branches: vec![self.branch.clone()],
                         }))
                     } else {
-                        Some(RepoDirEntry::Other)
+                        debug!(?entry_disk_path, "skipping entry, not a file or directory");
+                        None
                     }
                 })
                 .take_any_while(|_| !pipes.is_cancelled())


### PR DESCRIPTION
This fixes some issues we see on Sentry; which can occur when trying to index a repository that contains an exotic object like a domain socket, or a FIFO special file.