### PR TITLE
Don't vacate credentials if github validation fails.

### DIFF
--- a/server/bleep/src/periodic/remotes.rs
+++ b/server/bleep/src/periodic/remotes.rs
@@ -181,7 +181,7 @@ async fn update_credentials(app: &Application) {
             }
         };
 
-        debug!(?rotate_access_key, "continue with rotating access key");
+        debug!(rotate_access_key, "continue with rotating access key");
         if rotate_access_key {
             let query_url = format!(
                 "{url_base}/refresh_token?refresh_token={token}",


### PR DESCRIPTION
This could also be due to network errors. We have an expiration logic for the bloop tokens, the refresh of which will deal with any related GH token expiries, so we can piggyback on that authorization process.