### PR TITLE
Refresh cognito config from public API

### DIFF
--- a/.github/workflows/tauri-release.yml
+++ b/.github/workflows/tauri-release.yml
@@ -92,7 +92,7 @@ jobs:
         run: exit 1
 
       - name: Set environment
-        run: echo "{\"analytics_key\":\"${{ secrets.ANALYTICS_BE_WRITE_KEY_PROD }}\",\"analytics_data_plane\":\"${{ secrets.ANALYTICS_DATA_PLANE_URL }}\",\"sentry_dsn_fe\":\"${{ secrets.SENTRY_DSN_FE }}\",\"sentry_dsn\":\"${{ secrets.SENTRY_DSN_BE }}\",\"analytics_key_fe\":\"${{ secrets.ANALYTICS_FE_WRITE_KEY_PROD }}\",\"answer_api_url\":\"${{ secrets.ANSWER_API_URL }}\",\"cognito_userpool_id\":\"${{ secrets.COGNITO_USERPOOL_ID }}\",\"cognito_client_id\":\"${{ secrets.COGNITO_CLIENT_ID }}\",\"cognito_auth_url\":\"${{ secrets.COGNITO_AUTH_URL }}\",\"cognito_mgmt_url\":\"${{ secrets.COGNITO_MGMT_URL }}\"}" > apps/desktop/src-tauri/config/config.json
+        run: echo "{\"analytics_key\":\"${{ secrets.ANALYTICS_BE_WRITE_KEY_PROD }}\",\"analytics_data_plane\":\"${{ secrets.ANALYTICS_DATA_PLANE_URL }}\",\"sentry_dsn_fe\":\"${{ secrets.SENTRY_DSN_FE }}\",\"sentry_dsn\":\"${{ secrets.SENTRY_DSN_BE }}\",\"analytics_key_fe\":\"${{ secrets.ANALYTICS_FE_WRITE_KEY_PROD }}\",\"answer_api_url\":\"${{ secrets.ANSWER_API_URL }}\",\"cognito_userpool_id\":\"${{ secrets.COGNITO_USERPOOL_ID }}\",\"cognito_client_id\":\"${{ secrets.COGNITO_CLIENT_ID }}\",\"cognito_auth_url\":\"${{ secrets.COGNITO_AUTH_URL }}\",\"cognito_mgmt_url\":\"${{ secrets.COGNITO_MGMT_URL }}\",\"cognito_config_url\":\"${{ secrets.COGNITO_CONFIG_URL }}\"}" > apps/desktop/src-tauri/config/config.json
 
       - name: Check environment is set
         run: du -h apps/desktop/src-tauri/config/config.json

--- a/server/bleep/src/config.rs
+++ b/server/bleep/src/config.rs
@@ -202,6 +202,14 @@ macro_rules! right_if_default {
     };
 }
 
+#[derive(Deserialize)]
+struct RemoteConfig {
+    auth_url: reqwest::Url,
+    mgmt_url: reqwest::Url,
+    client_id: String,
+    userpool_id: String,
+}
+
 impl Configuration {
     pub fn read(file: impl AsRef<Path>) -> Result<Self> {
         let file = std::fs::File::open(file)?;
@@ -236,43 +244,12 @@ impl Configuration {
             .clone()
             .context("Invalid config, cognito_config_url missing")?;
 
-        let config: serde_json::Value = reqwest::get(url).await?.json().await?;
+        let config: RemoteConfig = reqwest::get(url).await?.json().await?;
 
-        self.cognito_auth_url = Some(
-            config
-                .get("auth_url")
-                .context("bad response")?
-                .as_str()
-                .context("bad response")?
-                .parse()?,
-        );
-
-        self.cognito_mgmt_url = Some(
-            config
-                .get("mgmt_url")
-                .context("bad response")?
-                .as_str()
-                .context("bad response")?
-                .parse()?,
-        );
-
-        self.cognito_client_id = Some(
-            config
-                .get("client_id")
-                .context("bad response")?
-                .as_str()
-                .context("bad response")?
-                .to_owned(),
-        );
-
-        self.cognito_userpool_id = Some(
-            config
-                .get("userpool_id")
-                .context("bad response")?
-                .as_str()
-                .context("bad response")?
-                .to_owned(),
-        );
+        self.cognito_auth_url = Some(config.auth_url);
+        self.cognito_mgmt_url = Some(config.mgmt_url);
+        self.cognito_client_id = Some(config.client_id);
+        self.cognito_userpool_id = Some(config.userpool_id);
 
         Ok(self)
     }

--- a/server/bleep/src/config.rs
+++ b/server/bleep/src/config.rs
@@ -156,6 +156,10 @@ pub struct Configuration {
     #[clap(long)]
     pub cognito_mgmt_url: Option<reqwest::Url>,
 
+    /// URL from which to initialize Cognito configuration
+    #[clap(long)]
+    pub cognito_config_url: Option<reqwest::Url>,
+
     //
     // Cloud-based Github App installation-specific values
     //
@@ -224,6 +228,53 @@ impl Configuration {
         };
 
         Ok(Self::merge(file, cli))
+    }
+
+    pub async fn with_remote_cognito_config(mut self) -> Result<Self> {
+        let url = self
+            .cognito_config_url
+            .clone()
+            .context("Invalid config, cognito_config_url missing")?;
+
+        let config: serde_json::Value = reqwest::get(url).await?.json().await?;
+
+        self.cognito_auth_url = Some(
+            config
+                .get("auth_url")
+                .context("bad response")?
+                .as_str()
+                .context("bad response")?
+                .parse()?,
+        );
+
+        self.cognito_mgmt_url = Some(
+            config
+                .get("mgmt_url")
+                .context("bad response")?
+                .as_str()
+                .context("bad response")?
+                .parse()?,
+        );
+
+        self.cognito_client_id = Some(
+            config
+                .get("client_id")
+                .context("bad response")?
+                .as_str()
+                .context("bad response")?
+                .to_owned(),
+        );
+
+        self.cognito_userpool_id = Some(
+            config
+                .get("userpool_id")
+                .context("bad response")?
+                .as_str()
+                .context("bad response")?
+                .to_owned(),
+        );
+
+        Ok(self)
     }
 
     /// Merge 2 configurations with values from `b` taking precedence
@@ -302,6 +353,8 @@ impl Configuration {
             cognito_auth_url: b.cognito_auth_url.or(a.cognito_auth_url),
 
             cognito_mgmt_url: b.cognito_mgmt_url.or(a.cognito_mgmt_url),
+
+            cognito_config_url: b.cognito_config_url.or(a.cognito_config_url),
 
             bloop_instance_secret: b.bloop_instance_secret.or(a.bloop_instance_secret),
 


### PR DESCRIPTION
Instead of hard-coding these details, rely on a cloud endpoint to provide the login flow details to the app. This gives us more flexibility in resolving potential future issues and adding new features. 