### PR TITLE
Refactor credentials handling

### DIFF
--- a/apps/desktop/src-tauri/src/backend.rs
+++ b/apps/desktop/src-tauri/src/backend.rs
@@ -110,12 +110,12 @@ async fn start_backend<R: Runtime>(configuration: Configuration, app: tauri::App
 
     match initialized {
         Ok(backend) => {
-            let auth = backend.user().await;
             sentry::Hub::main().configure_scope(|scope| {
                 let backend = backend.clone();
                 scope.add_event_processor(move |mut event| {
                     event.user = Some(sentry_user()).map(|mut user| {
-                        let username = auth.login();
+                        let username = backend.username();
+
                         user.id = Some(
                             if let (Some(analytics), Some(username)) =
                                 (&backend.analytics, &username)
@@ -125,7 +125,7 @@ async fn start_backend<R: Runtime>(configuration: Configuration, app: tauri::App
                                 get_device_id()
                             },
                         );
-                        user.username = username.map(str::to_owned);
+                        user.username = username;
                         user
                     });
 

--- a/apps/desktop/src-tauri/src/backend.rs
+++ b/apps/desktop/src-tauri/src/backend.rs
@@ -115,14 +115,17 @@ async fn start_backend<R: Runtime>(configuration: Configuration, app: tauri::App
                 scope.add_event_processor(move |mut event| {
                     event.user = Some(sentry_user()).map(|mut user| {
                         let auth = backend.user();
+                        let username = auth.login();
                         user.id = Some(
-                            if let (Some(analytics), Some(username)) = (&backend.analytics, &auth) {
+                            if let (Some(analytics), Some(username)) =
+                                (&backend.analytics, &username)
+                            {
                                 analytics.tracking_id(Some(username))
                             } else {
                                 get_device_id()
                             },
                         );
-                        user.username = auth;
+                        user.username = username.map(str::to_owned);
                         user
                     });
 

--- a/apps/desktop/src-tauri/src/backend.rs
+++ b/apps/desktop/src-tauri/src/backend.rs
@@ -110,11 +110,11 @@ async fn start_backend<R: Runtime>(configuration: Configuration, app: tauri::App
 
     match initialized {
         Ok(backend) => {
+            let auth = backend.user().await;
             sentry::Hub::main().configure_scope(|scope| {
                 let backend = backend.clone();
                 scope.add_event_processor(move |mut event| {
                     event.user = Some(sentry_user()).map(|mut user| {
-                        let auth = backend.user();
                         let username = auth.login();
                         user.id = Some(
                             if let (Some(analytics), Some(username)) =

--- a/server/bleep/src/analytics.rs
+++ b/server/bleep/src/analytics.rs
@@ -232,12 +232,7 @@ impl RudderHub {
         }
     }
 
-    pub fn track_synced_repos(
-        &self,
-        count: usize,
-        username: Option<&str>,
-        org_name: Option<String>,
-    ) {
+    pub fn track_synced_repos(&self, count: usize, username: Option<&str>, org_name: Option<&str>) {
         self.send(Message::Track(Track {
             user_id: Some(self.tracking_id(username)),
             event: "track_synced_repos".into(),

--- a/server/bleep/src/background/sync.rs
+++ b/server/bleep/src/background/sync.rs
@@ -195,7 +195,7 @@ impl SyncHandle {
 
         let tutorial_questions = if repository.last_index_unix_secs == 0 {
             let db = self.app.sql.clone();
-            let llm_gateway = self.app.user().llm_gateway(&self.app);
+            let llm_gateway = self.app.user().llm_gateway(&self.app).await;
             let repo_pool = self.app.repo_pool.clone();
             let reporef = self.reporef.clone();
 

--- a/server/bleep/src/background/sync.rs
+++ b/server/bleep/src/background/sync.rs
@@ -195,7 +195,7 @@ impl SyncHandle {
 
         let tutorial_questions = if repository.last_index_unix_secs == 0 {
             let db = self.app.sql.clone();
-            let llm_gateway = self.app.user().llm_gateway(&self.app).await;
+            let llm_gateway = self.app.user().await.llm_gateway(&self.app).await;
             let repo_pool = self.app.repo_pool.clone();
             let reporef = self.reporef.clone();
 

--- a/server/bleep/src/background/sync.rs
+++ b/server/bleep/src/background/sync.rs
@@ -195,7 +195,7 @@ impl SyncHandle {
 
         let tutorial_questions = if repository.last_index_unix_secs == 0 {
             let db = self.app.sql.clone();
-            let llm_gateway = self.app.llm_gateway_client();
+            let llm_gateway = self.app.user().llm_gateway(&self.app);
             let repo_pool = self.app.repo_pool.clone();
             let reporef = self.reporef.clone();
 

--- a/server/bleep/src/indexes.rs
+++ b/server/bleep/src/indexes.rs
@@ -65,14 +65,9 @@ impl<'a> GlobalWriteHandle<'a> {
     ) -> Result<Arc<RepoMetadata>, RepoError> {
         let metadata = repo.get_repo_metadata().await;
 
-        futures::future::join_all(
-            self.handles
-                .iter()
-                .map(|handle| handle.index(sync_handle, repo, &metadata)),
-        )
-        .await
-        .into_iter()
-        .collect::<Result<Vec<_>, _>>()?;
+        for h in &self.handles {
+            h.index(sync_handle, repo, &metadata).await?;
+        }
 
         Ok(metadata)
     }

--- a/server/bleep/src/lib.rs
+++ b/server/bleep/src/lib.rs
@@ -310,7 +310,11 @@ impl Application {
         self.analytics.as_ref().map(f)
     }
 
-    pub async fn user(&self) -> User {
+    pub fn username(&self) -> Option<String> {
+        self.credentials.user().clone()
+    }
+
+    pub(crate) async fn user(&self) -> User {
         crate::periodic::update_credentials(self).await;
 
         self.credentials

--- a/server/bleep/src/lib.rs
+++ b/server/bleep/src/lib.rs
@@ -310,7 +310,9 @@ impl Application {
         self.analytics.as_ref().map(f)
     }
 
-    pub fn user(&self) -> User {
+    pub async fn user(&self) -> User {
+        crate::periodic::update_credentials(self).await;
+
         self.credentials
             .user()
             .zip(self.credentials.github())

--- a/server/bleep/src/lib.rs
+++ b/server/bleep/src/lib.rs
@@ -264,13 +264,7 @@ impl Application {
             joins.spawn(self.write_index().startup_scan());
         } else {
             if !self.config.disable_background {
-                tokio::spawn(periodic::sync_github_status(self.clone()));
-                tokio::spawn(periodic::check_repo_updates(self.clone()));
-                tokio::spawn(periodic::log_and_branch_rotate(self.clone()));
-
-                if !self.env.is_cloud_instance() {
-                    tokio::spawn(periodic::clear_disk_logs(self.clone()));
-                }
+                periodic::start_background_jobs(self.clone());
             }
 
             joins.spawn(webserver::start(self));

--- a/server/bleep/src/periodic.rs
+++ b/server/bleep/src/periodic.rs
@@ -2,7 +2,7 @@ mod logrotate;
 mod remotes;
 
 use logrotate::*;
-pub use remotes::*;
+pub(crate) use remotes::*;
 
 use crate::Application;
 

--- a/server/bleep/src/periodic.rs
+++ b/server/bleep/src/periodic.rs
@@ -1,5 +1,53 @@
 mod logrotate;
 mod remotes;
 
-pub(crate) use logrotate::*;
-pub(crate) use remotes::*;
+use logrotate::*;
+use remotes::*;
+
+use crate::Application;
+
+pub(crate) fn start_background_jobs(app: Application) {
+    if !app.env.is_cloud_instance() {
+        let app = app.clone();
+        std::thread::spawn(move || {
+            tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("failed to start background jobs")
+                .block_on(clear_disk_logs(app.clone()));
+        });
+    }
+
+    {
+        let app = app.clone();
+        std::thread::spawn(move || {
+            tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("failed to start background jobs")
+                .block_on(sync_github_status(app.clone()));
+        });
+    }
+
+    {
+        let app = app.clone();
+        std::thread::spawn(move || {
+            tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("failed to start background jobs")
+                .block_on(check_repo_updates(app.clone()));
+        });
+    }
+
+    {
+        let app = app.clone();
+        std::thread::spawn(move || {
+            tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("failed to start background jobs")
+                .block_on(log_and_branch_rotate(app.clone()));
+        });
+    }
+}

--- a/server/bleep/src/periodic.rs
+++ b/server/bleep/src/periodic.rs
@@ -2,7 +2,7 @@ mod logrotate;
 mod remotes;
 
 use logrotate::*;
-use remotes::*;
+pub use remotes::*;
 
 use crate::Application;
 

--- a/server/bleep/src/periodic/remotes.rs
+++ b/server/bleep/src/periodic/remotes.rs
@@ -83,11 +83,11 @@ pub(crate) async fn sync_github_status(app: Application) {
                     debug!("github credentials changed; refreshing repositories");
                     return now;
                 }
-                (Ok(Err(flume::RecvError::Disconnected)), _) => {
-                    return SystemTime::now();
+                (Ok(_), _) => {
+                    return now;
                 }
                 (_, Err(_)) => {
-                    return SystemTime::now();
+                    return now;
                 }
                 _ => {
                     continue;

--- a/server/bleep/src/webserver/answer.rs
+++ b/server/bleep/src/webserver/answer.rs
@@ -206,7 +206,8 @@ async fn try_execute_agent(
     QueryLog::new(&app.sql).insert(&params.q).await?;
 
     let llm_gateway = user
-        .llm_gateway(&app)?
+        .llm_gateway(&app)
+        .await?
         .temperature(0.0)
         .session_reference_id(conversation_id.to_string());
 

--- a/server/bleep/src/webserver/answer.rs
+++ b/server/bleep/src/webserver/answer.rs
@@ -1,4 +1,3 @@
-use secrecy::ExposeSecret;
 use std::{panic::AssertUnwindSafe, time::Duration};
 
 use anyhow::{anyhow, Context, Result};
@@ -26,7 +25,6 @@ use crate::{
     },
     analytics::{EventData, QueryEvent},
     db::QueryLog,
-    llm_gateway,
     query::parser::{self, Literal},
     repo::RepoRef,
     Application,
@@ -207,14 +205,9 @@ async fn try_execute_agent(
 > {
     QueryLog::new(&app.sql).insert(&params.q).await?;
 
-    let answer_api_token = app
-        .answer_api_token()
-        .map_err(|e| super::Error::user(e).with_status(StatusCode::UNAUTHORIZED))?
-        .map(|s| s.expose_secret().clone());
-
-    let llm_gateway = llm_gateway::Client::new(&app.config.answer_api_url)
+    let llm_gateway = user
+        .llm_gateway(&app)?
         .temperature(0.0)
-        .bearer(answer_api_token)
         .session_reference_id(conversation_id.to_string());
 
     // confirm client compatibility with answer-api

--- a/server/bleep/src/webserver/github.rs
+++ b/server/bleep/src/webserver/github.rs
@@ -177,12 +177,14 @@ async fn poll_for_oauth_token(code: String, app: Application) {
         .map(|a| a.tracking_id(Some(&username)))
         .unwrap_or_default();
 
+    let user = app.user().await;
+
     app.with_analytics(|analytics| {
         use rudderanalytics::message::{Identify, Message};
         analytics.send(Message::Identify(Identify {
             user_id: Some(tracking_id.clone()),
             traits: Some(serde_json::json!({
-                "org_name": app.user().org_name(),
+                "org_name": user.org_name(),
                 "device_id": analytics.device_id(),
                 "is_self_serve": app.env.is_cloud_instance(),
                 "github_username": username,

--- a/server/bleep/src/webserver/github.rs
+++ b/server/bleep/src/webserver/github.rs
@@ -182,7 +182,7 @@ async fn poll_for_oauth_token(code: String, app: Application) {
         analytics.send(Message::Identify(Identify {
             user_id: Some(tracking_id.clone()),
             traits: Some(serde_json::json!({
-                "org_name": app.org_name(),
+                "org_name": app.user().org_name(),
                 "device_id": analytics.device_id(),
                 "is_self_serve": app.env.is_cloud_instance(),
                 "github_username": username,

--- a/server/bleep/src/webserver/middleware.rs
+++ b/server/bleep/src/webserver/middleware.rs
@@ -54,8 +54,6 @@ impl User {
         &self,
         app: &Application,
     ) -> anyhow::Result<llm_gateway::Client> {
-        crate::periodic::update_credentials(app).await;
-
         let User::Authenticated { api_token, .. } = self else {
             bail!("user not logged in");
         };
@@ -140,7 +138,7 @@ async fn local_user_mw<B>(
     mut request: Request<B>,
     next: Next<B>,
 ) -> Response {
-    request.extensions_mut().insert(app.user());
+    request.extensions_mut().insert(app.user().await);
     next.run(request).await
 }
 

--- a/server/bleep/src/webserver/middleware.rs
+++ b/server/bleep/src/webserver/middleware.rs
@@ -50,7 +50,12 @@ impl User {
         crab().ok()
     }
 
-    pub(crate) fn llm_gateway(&self, app: &Application) -> anyhow::Result<llm_gateway::Client> {
+    pub(crate) async fn llm_gateway(
+        &self,
+        app: &Application,
+    ) -> anyhow::Result<llm_gateway::Client> {
+        crate::periodic::update_credentials(app).await;
+
         let User::Authenticated { api_token, .. } = self else {
             bail!("user not logged in");
         };

--- a/server/bleep/src/webserver/quota.rs
+++ b/server/bleep/src/webserver/quota.rs
@@ -38,7 +38,11 @@ async fn get_request<T: for<'a> Deserialize<'a>>(
     Extension(user): Extension<User>,
     endpoint: &str,
 ) -> super::Result<Json<T>> {
-    let User::Authenticated { api_token, .. } = user else {
+    let User::Authenticated {
+        api_token: Some(api_token),
+        ..
+    } = user
+    else {
         return Err(Error::unauthorized("answer API token was not present"));
     };
 

--- a/server/bleep/src/webserver/quota.rs
+++ b/server/bleep/src/webserver/quota.rs
@@ -38,11 +38,7 @@ async fn get_request<T: for<'a> Deserialize<'a>>(
     Extension(user): Extension<User>,
     endpoint: &str,
 ) -> super::Result<Json<T>> {
-    let User::Authenticated {
-        api_token: Some(api_token),
-        ..
-    } = user
-    else {
+    let Some(api_token) = user.api_token() else {
         return Err(Error::unauthorized("answer API token was not present"));
     };
 

--- a/server/bleep/src/webserver/repos.rs
+++ b/server/bleep/src/webserver/repos.rs
@@ -307,7 +307,7 @@ pub(super) async fn delete_by_id(
     let num_deleted = if found { 1 } else { 0 };
 
     app.with_analytics(|analytics| {
-        analytics.track_synced_repos(num_repos - num_deleted, user.login(), app.org_name());
+        analytics.track_synced_repos(num_repos - num_deleted, user.login(), user.org_name());
     });
 
     if found {
@@ -329,7 +329,7 @@ pub(super) async fn sync(
     let num_queued = app.write_index().enqueue_sync(vec![repo]).await;
 
     app.with_analytics(|analytics| {
-        analytics.track_synced_repos(num_repos + num_queued, user.login(), app.org_name());
+        analytics.track_synced_repos(num_repos + num_queued, user.login(), user.org_name());
     });
 
     Ok(json(ReposResponse::SyncQueued))
@@ -402,7 +402,7 @@ pub(super) async fn set_indexed(
     let mut repo_list = new_list.indexed.into_iter().collect::<HashSet<_>>();
 
     app.with_analytics(|analytics| {
-        analytics.track_synced_repos(repo_list.len(), user.login(), app.org_name());
+        analytics.track_synced_repos(repo_list.len(), user.login(), user.org_name());
     });
 
     app.repo_pool

--- a/server/bleep/src/webserver/studio.rs
+++ b/server/bleep/src/webserver/studio.rs
@@ -575,6 +575,7 @@ pub async fn generate(
 
     let llm_gateway = user
         .llm_gateway(&app)
+        .await
         .map_err(|e| Error::user(e).with_status(StatusCode::UNAUTHORIZED))?
         .quota_gated(!app.env.is_cloud_instance())
         .model(LLM_GATEWAY_MODEL)
@@ -752,6 +753,7 @@ async fn populate_studio_name(
 
     let llm_gateway = user
         .llm_gateway(&app)
+        .await
         .map_err(|e| Error::user(e).with_status(StatusCode::UNAUTHORIZED))?
         .model("gpt-3.5-turbo-16k-0613")
         .temperature(0.0);
@@ -905,6 +907,7 @@ async fn extract_relevant_chunks(
 
     let llm_gateway = user
         .llm_gateway(app)
+        .await
         .map_err(|e| Error::user(e).with_status(StatusCode::UNAUTHORIZED))?
         .model(LLM_GATEWAY_MODEL)
         .temperature(0.0);


### PR DESCRIPTION
There are a few things here:

 * put all background jobs to their dedicated single-threaded executor, so we only debug one at a time instead of a complex multi-threaded soup (and thus avoid [strange tokio bugs](https://github.com/tokio-rs/tokio/issues/4730))
 * eliminate use of `flume` to signal updated credentials, this isn't necessary anymore, because of the next item
 * centralize the llm constructor & some user management so we can make sure we update the creds whenever they expire
 * get rid of `futures::join_all` everywhere in favour of `tokio::task::JoinSet`