### PR TITLE
Improve error logging on status changes

### DIFF
--- a/server/bleep/src/background/sync.rs
+++ b/server/bleep/src/background/sync.rs
@@ -171,7 +171,6 @@ impl SyncHandle {
                     }
                 }
                 Err(err) => {
-                    error!(?err, ?self.reporef, "failed to sync repository");
                     self.set_status(|_| SyncStatus::Error {
                         message: err.to_string(),
                     })
@@ -225,12 +224,9 @@ impl SyncHandle {
                 self.set_status(|_| SyncStatus::Done)
             }
             Err(SyncError::Cancelled) => self.set_status(|_| SyncStatus::Cancelled),
-            Err(err) => {
-                error!(?err, ?self.reporef, "failed to index repository");
-                self.set_status(|_| SyncStatus::Error {
-                    message: err.to_string(),
-                })
-            }
+            Err(err) => self.set_status(|_| SyncStatus::Error {
+                message: err.to_string(),
+            }),
         };
 
         Ok(status.expect("failed to update repo status"))
@@ -446,7 +442,11 @@ impl SyncHandle {
             repo.sync_status.clone()
         })?;
 
-        debug!(?self.reporef, ?new_status, "new status");
+        if let SyncStatus::Error { ref message } = new_status {
+            error!(?self.reporef, err=?message, "indexing failed");
+        } else {
+            debug!(?self.reporef, ?new_status, "new status");
+        }
         self.pipes.status(new_status.clone());
         Some(new_status)
     }


### PR DESCRIPTION
Unify logging better for erroneous status changes during sync. This would help highlight if something goes wrong.