### PR TITLE
Limit maximum number of steps, not exchanges

### DIFF
--- a/server/bleep/src/agent.rs
+++ b/server/bleep/src/agent.rs
@@ -221,7 +221,7 @@ impl Agent {
             Action::Proc { query, paths } => self.process_files(query, paths).await?,
         };
 
-        if self.exchanges.len() >= MAX_STEPS {
+        if self.last_exchange().search_steps.len() >= MAX_STEPS {
             return Ok(Some(Action::Answer {
                 paths: self.paths().enumerate().map(|(i, _)| i).collect(),
             }));


### PR DESCRIPTION
Currently, the agent will avoid building up the context further after reaching a maximum number of *exchanges*, not steps. In practice, this means that after the 10th exchange, future exchanges will always be answered instantly based on existing context.

This fixes the logic so that we instead avoid creating more than 10 search steps in a single exchange.

---

This was introduced in #989, and seems to have been merged in due to lack of test cases.