### PR TITLE
Synchronicity issues with login flows

### DIFF
--- a/server/bleep/src/periodic/remotes.rs
+++ b/server/bleep/src/periodic/remotes.rs
@@ -122,7 +122,7 @@ pub(crate) async fn update_credentials(app: &Application) {
     if app.env.allow(Feature::DesktopUserAuth) {
         let Some(github::State {
             auth: github::Auth::OAuth(ref creds),
-            ..
+            repositories,
         }) = app.credentials.github()
         else {
             return;
@@ -197,14 +197,14 @@ pub(crate) async fn update_credentials(app: &Application) {
                 }
             };
 
-        app.credentials
-            .set_github(github::State::with_auth(Auth::OAuth(
-                CognitoGithubTokenBundle {
-                    access_token: tokens.access_token,
-                    refresh_token: creds.refresh_token.clone(),
-                    github_access_token: creds.github_access_token.clone(),
-                },
-            )));
+        app.credentials.set_github(github::State {
+            repositories,
+            auth: Auth::OAuth(CognitoGithubTokenBundle {
+                access_token: tokens.access_token,
+                refresh_token: creds.refresh_token.clone(),
+                github_access_token: creds.github_access_token.clone(),
+            }),
+        });
 
         app.credentials.store().unwrap();
         info!("new bloop access keys saved");

--- a/server/bleep/src/periodic/remotes.rs
+++ b/server/bleep/src/periodic/remotes.rs
@@ -71,12 +71,12 @@ pub(crate) async fn sync_github_status(app: Application) {
     loop {
         // then retrieve username & other maintenance
         update_credentials(&app).await;
-
+        update_repo_list(&app).await;
         sleep_systime(POLL_PERIOD).await;
     }
 }
 
-async fn update_repo_list(app: &Application) {
+pub(crate) async fn update_repo_list(app: &Application) {
     if let Some(gh) = app.credentials.github() {
         let repos = match gh.current_repo_list().await {
             Ok(repos) => {
@@ -224,7 +224,7 @@ pub(crate) async fn validate_github_credentials(app: &Application) {
 
         username.is_err()
     } else {
-        println!("failed to create github client?");
+        error!("failed to create github client?");
         true
     };
 
@@ -232,8 +232,6 @@ pub(crate) async fn validate_github_credentials(app: &Application) {
         app.credentials.store().unwrap();
         debug!("github oauth is invalid; credentials removed");
     }
-
-    update_repo_list(app).await;
 }
 
 pub(crate) async fn check_repo_updates(app: Application) {

--- a/server/bleep/src/webserver/github.rs
+++ b/server/bleep/src/webserver/github.rs
@@ -160,6 +160,7 @@ async fn poll_for_oauth_token(code: String, app: Application) {
     debug!("acquired credentials");
     app.credentials.set_github(github::Auth::OAuth(auth));
     crate::periodic::validate_github_credentials(&app).await;
+    crate::periodic::update_repo_list(&app).await;
 
     let username = app
         .credentials

--- a/server/bleep/src/webserver/github.rs
+++ b/server/bleep/src/webserver/github.rs
@@ -159,6 +159,8 @@ async fn poll_for_oauth_token(code: String, app: Application) {
 
     debug!("acquired credentials");
     app.credentials.set_github(github::Auth::OAuth(auth));
+    crate::periodic::validate_github_credentials(&app).await;
+
     let username = app
         .credentials
         .github()


### PR DESCRIPTION
The 2 patches resolve 2 separate issues:
 * preserve the list of repositories between credential updates to avoid weird side-effects
 * immediately cache the users's profile after successful authentication to cut down on login time