### PR TITLE
Disable back/forward keyboard navigation if user is typing

### DIFF
--- a/client/src/components/CodeBlock/CodeFull/ExplainButton.tsx
+++ b/client/src/components/CodeBlock/CodeFull/ExplainButton.tsx
@@ -3,7 +3,6 @@ import { Trans } from 'react-i18next';
 import React, { memo, useContext } from 'react';
 import { Clipboard, Feather, Info, Sparkle } from '../../../icons';
 import { findElementInCurrentTab } from '../../../utils/domUtils';
-import PortalContainer from '../../PortalContainer';
 import { ChatContext } from '../../../context/chatContext';
 import { DeviceContext } from '../../../context/deviceContext';
 import { copyToClipboard } from '../../../utils';
@@ -42,109 +41,106 @@ const ExplainButton = ({
   const { isSelfServe } = useContext(DeviceContext);
 
   return (
-    <PortalContainer>
-      <AnimatePresence>
-        {popupPosition && currentSelection?.length === 2 && (
-          <motion.div
-            className="fixed z-[120]"
-            style={popupPosition}
-            initial={{ opacity: 0, transform: 'translateY(1rem)' }}
-            animate={{ transform: 'translateY(0rem)', opacity: 1 }}
-            exit={{ opacity: 0, transform: 'translateY(1rem)' }}
-          >
-            <div className="bg-bg-base border border-bg-border rounded-md shadow-high flex overflow-hidden select-none">
-              {selectedLinesLength > 1000 ? (
-                <button
-                  className="h-8 flex items-center justify-center gap-1 px-2 caption text-label-muted"
-                  disabled
-                >
-                  <div className="w-4 h-4">
-                    <Info raw />
-                  </div>
-                  <Trans>Select less code</Trans>
-                </button>
-              ) : (
-                <>
-                  {isSelfServe && (
-                    <button
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        setPopupPosition(null);
-                        const url = new URL(window.location.href);
-                        url.searchParams.set(
-                          'scrollToLine',
-                          `${currentSelection[0][0]}_${currentSelection[1][0]}`,
-                        );
-                        copyToClipboard(url.toString());
-                        closePopup?.();
-                      }}
-                      className="h-8 flex items-center justify-center gap-1 px-2 hover:bg-bg-base-hover border-r border-bg-border caption text-label-title"
-                    >
-                      <div className="w-4 h-4">
-                        <Clipboard raw />
-                      </div>
-                      <Trans>Copy link</Trans>
-                    </button>
-                  )}
+    <AnimatePresence>
+      {popupPosition && currentSelection?.length === 2 && (
+        <motion.div
+          className="fixed z-[120]"
+          style={popupPosition}
+          initial={{ opacity: 0, transform: 'translateY(1rem)' }}
+          animate={{ transform: 'translateY(0rem)', opacity: 1 }}
+          exit={{ opacity: 0, transform: 'translateY(1rem)' }}
+        >
+          <div className="bg-bg-base border border-bg-border rounded-md shadow-high flex overflow-hidden select-none">
+            {selectedLinesLength > 1000 ? (
+              <button
+                className="h-8 flex items-center justify-center gap-1 px-2 caption text-label-muted"
+                disabled
+              >
+                <div className="w-4 h-4">
+                  <Info raw />
+                </div>
+                <Trans>Select less code</Trans>
+              </button>
+            ) : (
+              <>
+                {isSelfServe && (
                   <button
                     onClick={(e) => {
                       e.stopPropagation();
-                      setChatOpen(true);
                       setPopupPosition(null);
-                      setIsHistoryTab(false);
-                      setThreadId('');
-                      setConversation([]);
-                      setSelectedLines([
-                        currentSelection[0][0],
-                        currentSelection[1][0],
-                      ]);
-                      closePopup?.();
-                      setTimeout(
-                        () =>
-                          findElementInCurrentTab('#question-input')?.focus(),
-                        300,
+                      const url = new URL(window.location.href);
+                      url.searchParams.set(
+                        'scrollToLine',
+                        `${currentSelection[0][0]}_${currentSelection[1][0]}`,
                       );
+                      copyToClipboard(url.toString());
+                      closePopup?.();
                     }}
                     className="h-8 flex items-center justify-center gap-1 px-2 hover:bg-bg-base-hover border-r border-bg-border caption text-label-title"
                   >
                     <div className="w-4 h-4">
-                      <Feather raw />
+                      <Clipboard raw />
                     </div>
-                    <Trans>Ask bloop</Trans>
+                    <Trans>Copy link</Trans>
                   </button>
-                  <button
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      setConversation([]);
-                      setThreadId('');
-                      setSelectedLines([
-                        currentSelection[0][0],
-                        currentSelection[1][0],
-                      ]);
-                      setIsHistoryTab(false);
-                      setSubmittedQuery(
-                        `#explain_${relativePath}:${currentSelection[0][0]}-${
-                          currentSelection[1][0]
-                        }-${Date.now()}`,
-                      );
-                      setChatOpen(true);
-                      setPopupPosition(null);
-                      closePopup?.();
-                    }}
-                    className="h-8 flex items-center justify-center gap-1 px-2 hover:bg-bg-base-hover caption text-label-title"
-                  >
-                    <div className="w-4 h-4">
-                      <Sparkle raw />
-                    </div>
-                    <Trans>Explain</Trans>
-                  </button>
-                </>
-              )}
-            </div>
-          </motion.div>
-        )}
-      </AnimatePresence>
-    </PortalContainer>
+                )}
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    setChatOpen(true);
+                    setPopupPosition(null);
+                    setIsHistoryTab(false);
+                    setThreadId('');
+                    setConversation([]);
+                    setSelectedLines([
+                      currentSelection[0][0],
+                      currentSelection[1][0],
+                    ]);
+                    closePopup?.();
+                    setTimeout(
+                      () => findElementInCurrentTab('#question-input')?.focus(),
+                      300,
+                    );
+                  }}
+                  className="h-8 flex items-center justify-center gap-1 px-2 hover:bg-bg-base-hover border-r border-bg-border caption text-label-title"
+                >
+                  <div className="w-4 h-4">
+                    <Feather raw />
+                  </div>
+                  <Trans>Ask bloop</Trans>
+                </button>
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    setConversation([]);
+                    setThreadId('');
+                    setSelectedLines([
+                      currentSelection[0][0],
+                      currentSelection[1][0],
+                    ]);
+                    setIsHistoryTab(false);
+                    setSubmittedQuery(
+                      `#explain_${relativePath}:${currentSelection[0][0]}-${
+                        currentSelection[1][0]
+                      }-${Date.now()}`,
+                    );
+                    setChatOpen(true);
+                    setPopupPosition(null);
+                    closePopup?.();
+                  }}
+                  className="h-8 flex items-center justify-center gap-1 px-2 hover:bg-bg-base-hover caption text-label-title"
+                >
+                  <div className="w-4 h-4">
+                    <Sparkle raw />
+                  </div>
+                  <Trans>Explain</Trans>
+                </button>
+              </>
+            )}
+          </div>
+        </motion.div>
+      )}
+    </AnimatePresence>
   );
 };
 

--- a/client/src/components/CodeBlock/CodeFull/index.tsx
+++ b/client/src/components/CodeBlock/CodeFull/index.tsx
@@ -306,16 +306,26 @@ const CodeFull = ({
 
   const calculatePopupPosition = useCallback(
     (top: number, left: number) => {
+      let isInModal = true;
       let container = findElementInCurrentTab('.code-modal-container');
       if (!container) {
         container = findElementInCurrentTab('#result-full-code-container');
+        isInModal = false;
       }
       if (!container) {
         return null;
       }
       const containerRect = container?.getBoundingClientRect();
       if (currentSelection.length !== 0) {
-        return calculatePopupPositionInsideContainer(top, left, containerRect);
+        const fixedPositionInsideContainer =
+          calculatePopupPositionInsideContainer(top, left, containerRect);
+        if (isInModal) {
+          fixedPositionInsideContainer.top =
+            fixedPositionInsideContainer.top - containerRect.top / 2;
+          fixedPositionInsideContainer.left =
+            fixedPositionInsideContainer.left - containerRect.left;
+        }
+        return fixedPositionInsideContainer;
       }
       return null;
     },

--- a/client/src/components/PageTemplate/Subheader.tsx
+++ b/client/src/components/PageTemplate/Subheader.tsx
@@ -21,6 +21,7 @@ import { DropdownWithIcon } from '../Dropdown';
 import { ContextMenuItem } from '../ContextMenu';
 import { MenuItemType } from '../../types/general';
 import useKeyboardNavigation from '../../hooks/useKeyboardNavigation';
+import { isFocusInInput } from '../../utils/domUtils';
 import BranchSelector from './BranchSelector';
 import RepoHomeBtn from './RepoHomeBtn';
 import Separator from './Separator';
@@ -139,7 +140,7 @@ const Subheader = () => {
 
   const handleKeyEvent = useCallback(
     (e: KeyboardEvent) => {
-      if (e.metaKey || e.ctrlKey) {
+      if ((e.metaKey || e.ctrlKey) && !isFocusInInput()) {
         if (e.key === 'ArrowLeft' && navigationHistory.length > 1) {
           e.preventDefault();
           navigateBack('auto');

--- a/client/src/utils/domUtils.ts
+++ b/client/src/utils/domUtils.ts
@@ -12,3 +12,6 @@ export const findAllElementsInCurrentTab = <
 ): NodeListOf<T> | null => {
   return document.querySelectorAll(`[data-active="true"] ${selector}`);
 };
+
+export const isFocusInInput = () =>
+  ['INPUT', 'TEXTAREA'].includes(document.activeElement?.tagName || '');


### PR DESCRIPTION
When pressing cmd + ArrowLeft/ArrowRight we navigate the user back/forward, but this is unwanted behavior in case the user is typing and wants to go to input start or end. Solution: check if user focus is inside some input or textarea before handling arrow navigation.