### PR TITLE
Recover from network errors in `poll_for_oauth_token`

### DIFF
--- a/server/bleep/src/webserver/github.rs
+++ b/server/bleep/src/webserver/github.rs
@@ -133,8 +133,9 @@ async fn poll_for_oauth_token(code: String, app: Application) {
         let response = match reqwest::get(&query_url).await {
             Ok(res) => res.json().await,
             Err(err) => {
-                warn!(?err, "github authorization failed");
-                return;
+                warn!(?err, "github authorization query failed");
+                clock.tick().await;
+                continue;
             }
         };
 


### PR DESCRIPTION
This allows bloop to recover from any network errors that we hit when fetching the OAuth token. Previously we would exit the loop and authorisation would fail.