### PR TITLE
Build binaries if building for cloud

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ COPY server server
 COPY apps/desktop/src-tauri apps/desktop/src-tauri
 COPY Cargo.lock Cargo.toml .
 RUN --mount=target=/root/.cache/sccache,type=cache --mount=target=/build/target,type=cache \
-    cargo --locked build -p bleep --release --features=ee-cloud && \
+    cargo --locked build --bin bleep --release --features=ee-cloud && \
     cp /build/target/release/bleep / && \
     sccache --show-stats && \
     mkdir /dylib && \

--- a/server/bleep/Cargo.toml
+++ b/server/bleep/Cargo.toml
@@ -10,7 +10,7 @@ default = ["dynamic-ort", "ee-pro"]
 debug = ["console-subscriber", "histogram"]
 dynamic-ort = ["ort/load-dynamic"]
 ee-pro = []
-ee-cloud = ["ee-pro"]
+ee-cloud = ["ee-pro", "color-eyre"]
 
 [[bin]]
 name = "bleep"

--- a/server/bleep/src/lib.rs
+++ b/server/bleep/src/lib.rs
@@ -10,6 +10,10 @@
 #![warn(unused_crate_dependencies)]
 #![allow(elided_lifetimes_in_paths)]
 
+// only used in the binary
+#[cfg(feature = "color-eyre")]
+use color_eyre as _;
+
 #[cfg(any(bench, test))]
 use criterion as _;
 


### PR DESCRIPTION
Mixing around dependencies created some warnings, and skips building the binary unnecessarily.