### PR TITLE
Update to non-symlinky git

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2276,7 +2276,7 @@ dependencies = [
 [[package]]
 name = "gix"
 version = "0.55.2"
-source = "git+https://github.com/BloopAI/gitoxide#ea8cd0e45793c374cfc6ebbacd09b09ebfbecfe4"
+source = "git+https://github.com/BloopAI/gitoxide#307b30afff2dad314bff97c640095f42401ea22f"
 dependencies = [
  "gix-actor",
  "gix-archive",
@@ -2336,7 +2336,7 @@ dependencies = [
 [[package]]
 name = "gix-actor"
 version = "0.28.0"
-source = "git+https://github.com/BloopAI/gitoxide#ea8cd0e45793c374cfc6ebbacd09b09ebfbecfe4"
+source = "git+https://github.com/BloopAI/gitoxide#307b30afff2dad314bff97c640095f42401ea22f"
 dependencies = [
  "bstr",
  "btoi",
@@ -2349,7 +2349,7 @@ dependencies = [
 [[package]]
 name = "gix-archive"
 version = "0.6.0"
-source = "git+https://github.com/BloopAI/gitoxide#ea8cd0e45793c374cfc6ebbacd09b09ebfbecfe4"
+source = "git+https://github.com/BloopAI/gitoxide#307b30afff2dad314bff97c640095f42401ea22f"
 dependencies = [
  "bstr",
  "gix-date",
@@ -2361,7 +2361,7 @@ dependencies = [
 [[package]]
 name = "gix-attributes"
 version = "0.20.0"
-source = "git+https://github.com/BloopAI/gitoxide#ea8cd0e45793c374cfc6ebbacd09b09ebfbecfe4"
+source = "git+https://github.com/BloopAI/gitoxide#307b30afff2dad314bff97c640095f42401ea22f"
 dependencies = [
  "bstr",
  "gix-glob",
@@ -2377,7 +2377,7 @@ dependencies = [
 [[package]]
 name = "gix-bitmap"
 version = "0.2.7"
-source = "git+https://github.com/BloopAI/gitoxide#ea8cd0e45793c374cfc6ebbacd09b09ebfbecfe4"
+source = "git+https://github.com/BloopAI/gitoxide#307b30afff2dad314bff97c640095f42401ea22f"
 dependencies = [
  "thiserror",
 ]
@@ -2385,7 +2385,7 @@ dependencies = [
 [[package]]
 name = "gix-chunk"
 version = "0.4.4"
-source = "git+https://github.com/BloopAI/gitoxide#ea8cd0e45793c374cfc6ebbacd09b09ebfbecfe4"
+source = "git+https://github.com/BloopAI/gitoxide#307b30afff2dad314bff97c640095f42401ea22f"
 dependencies = [
  "thiserror",
 ]
@@ -2393,7 +2393,7 @@ dependencies = [
 [[package]]
 name = "gix-command"
 version = "0.2.10"
-source = "git+https://github.com/BloopAI/gitoxide#ea8cd0e45793c374cfc6ebbacd09b09ebfbecfe4"
+source = "git+https://github.com/BloopAI/gitoxide#307b30afff2dad314bff97c640095f42401ea22f"
 dependencies = [
  "bstr",
 ]
@@ -2401,7 +2401,7 @@ dependencies = [
 [[package]]
 name = "gix-commitgraph"
 version = "0.22.0"
-source = "git+https://github.com/BloopAI/gitoxide#ea8cd0e45793c374cfc6ebbacd09b09ebfbecfe4"
+source = "git+https://github.com/BloopAI/gitoxide#307b30afff2dad314bff97c640095f42401ea22f"
 dependencies = [
  "bstr",
  "gix-chunk",
@@ -2414,7 +2414,7 @@ dependencies = [
 [[package]]
 name = "gix-config"
 version = "0.31.0"
-source = "git+https://github.com/BloopAI/gitoxide#ea8cd0e45793c374cfc6ebbacd09b09ebfbecfe4"
+source = "git+https://github.com/BloopAI/gitoxide#307b30afff2dad314bff97c640095f42401ea22f"
 dependencies = [
  "bstr",
  "gix-config-value",
@@ -2434,7 +2434,7 @@ dependencies = [
 [[package]]
 name = "gix-config-value"
 version = "0.14.0"
-source = "git+https://github.com/BloopAI/gitoxide#ea8cd0e45793c374cfc6ebbacd09b09ebfbecfe4"
+source = "git+https://github.com/BloopAI/gitoxide#307b30afff2dad314bff97c640095f42401ea22f"
 dependencies = [
  "bitflags 2.4.0",
  "bstr",
@@ -2446,7 +2446,7 @@ dependencies = [
 [[package]]
 name = "gix-credentials"
 version = "0.21.0"
-source = "git+https://github.com/BloopAI/gitoxide#ea8cd0e45793c374cfc6ebbacd09b09ebfbecfe4"
+source = "git+https://github.com/BloopAI/gitoxide#307b30afff2dad314bff97c640095f42401ea22f"
 dependencies = [
  "bstr",
  "gix-command",
@@ -2461,7 +2461,7 @@ dependencies = [
 [[package]]
 name = "gix-date"
 version = "0.8.0"
-source = "git+https://github.com/BloopAI/gitoxide#ea8cd0e45793c374cfc6ebbacd09b09ebfbecfe4"
+source = "git+https://github.com/BloopAI/gitoxide#307b30afff2dad314bff97c640095f42401ea22f"
 dependencies = [
  "bstr",
  "itoa 1.0.9",
@@ -2472,7 +2472,7 @@ dependencies = [
 [[package]]
 name = "gix-diff"
 version = "0.37.0"
-source = "git+https://github.com/BloopAI/gitoxide#ea8cd0e45793c374cfc6ebbacd09b09ebfbecfe4"
+source = "git+https://github.com/BloopAI/gitoxide#307b30afff2dad314bff97c640095f42401ea22f"
 dependencies = [
  "gix-hash",
  "gix-object",
@@ -2483,7 +2483,7 @@ dependencies = [
 [[package]]
 name = "gix-discover"
 version = "0.26.0"
-source = "git+https://github.com/BloopAI/gitoxide#ea8cd0e45793c374cfc6ebbacd09b09ebfbecfe4"
+source = "git+https://github.com/BloopAI/gitoxide#307b30afff2dad314bff97c640095f42401ea22f"
 dependencies = [
  "bstr",
  "dunce",
@@ -2497,7 +2497,7 @@ dependencies = [
 [[package]]
 name = "gix-features"
 version = "0.36.0"
-source = "git+https://github.com/BloopAI/gitoxide#ea8cd0e45793c374cfc6ebbacd09b09ebfbecfe4"
+source = "git+https://github.com/BloopAI/gitoxide#307b30afff2dad314bff97c640095f42401ea22f"
 dependencies = [
  "bytes",
  "bytesize",
@@ -2519,7 +2519,7 @@ dependencies = [
 [[package]]
 name = "gix-filter"
 version = "0.6.0"
-source = "git+https://github.com/BloopAI/gitoxide#ea8cd0e45793c374cfc6ebbacd09b09ebfbecfe4"
+source = "git+https://github.com/BloopAI/gitoxide#307b30afff2dad314bff97c640095f42401ea22f"
 dependencies = [
  "bstr",
  "encoding_rs",
@@ -2538,7 +2538,7 @@ dependencies = [
 [[package]]
 name = "gix-fs"
 version = "0.8.0"
-source = "git+https://github.com/BloopAI/gitoxide#ea8cd0e45793c374cfc6ebbacd09b09ebfbecfe4"
+source = "git+https://github.com/BloopAI/gitoxide#307b30afff2dad314bff97c640095f42401ea22f"
 dependencies = [
  "gix-features",
 ]
@@ -2546,7 +2546,7 @@ dependencies = [
 [[package]]
 name = "gix-glob"
 version = "0.14.0"
-source = "git+https://github.com/BloopAI/gitoxide#ea8cd0e45793c374cfc6ebbacd09b09ebfbecfe4"
+source = "git+https://github.com/BloopAI/gitoxide#307b30afff2dad314bff97c640095f42401ea22f"
 dependencies = [
  "bitflags 2.4.0",
  "bstr",
@@ -2557,7 +2557,7 @@ dependencies = [
 [[package]]
 name = "gix-hash"
 version = "0.13.1"
-source = "git+https://github.com/BloopAI/gitoxide#ea8cd0e45793c374cfc6ebbacd09b09ebfbecfe4"
+source = "git+https://github.com/BloopAI/gitoxide#307b30afff2dad314bff97c640095f42401ea22f"
 dependencies = [
  "faster-hex",
  "thiserror",
@@ -2566,7 +2566,7 @@ dependencies = [
 [[package]]
 name = "gix-hashtable"
 version = "0.4.0"
-source = "git+https://github.com/BloopAI/gitoxide#ea8cd0e45793c374cfc6ebbacd09b09ebfbecfe4"
+source = "git+https://github.com/BloopAI/gitoxide#307b30afff2dad314bff97c640095f42401ea22f"
 dependencies = [
  "gix-hash",
  "hashbrown 0.14.0",
@@ -2576,7 +2576,7 @@ dependencies = [
 [[package]]
 name = "gix-ignore"
 version = "0.9.0"
-source = "git+https://github.com/BloopAI/gitoxide#ea8cd0e45793c374cfc6ebbacd09b09ebfbecfe4"
+source = "git+https://github.com/BloopAI/gitoxide#307b30afff2dad314bff97c640095f42401ea22f"
 dependencies = [
  "bstr",
  "gix-glob",
@@ -2587,7 +2587,7 @@ dependencies = [
 [[package]]
 name = "gix-index"
 version = "0.26.0"
-source = "git+https://github.com/BloopAI/gitoxide#ea8cd0e45793c374cfc6ebbacd09b09ebfbecfe4"
+source = "git+https://github.com/BloopAI/gitoxide#307b30afff2dad314bff97c640095f42401ea22f"
 dependencies = [
  "bitflags 2.4.0",
  "bstr",
@@ -2609,7 +2609,7 @@ dependencies = [
 [[package]]
 name = "gix-lock"
 version = "11.0.0"
-source = "git+https://github.com/BloopAI/gitoxide#ea8cd0e45793c374cfc6ebbacd09b09ebfbecfe4"
+source = "git+https://github.com/BloopAI/gitoxide#307b30afff2dad314bff97c640095f42401ea22f"
 dependencies = [
  "gix-tempfile",
  "gix-utils",
@@ -2619,7 +2619,7 @@ dependencies = [
 [[package]]
 name = "gix-macros"
 version = "0.1.0"
-source = "git+https://github.com/BloopAI/gitoxide#ea8cd0e45793c374cfc6ebbacd09b09ebfbecfe4"
+source = "git+https://github.com/BloopAI/gitoxide#307b30afff2dad314bff97c640095f42401ea22f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2629,7 +2629,7 @@ dependencies = [
 [[package]]
 name = "gix-mailmap"
 version = "0.20.0"
-source = "git+https://github.com/BloopAI/gitoxide#ea8cd0e45793c374cfc6ebbacd09b09ebfbecfe4"
+source = "git+https://github.com/BloopAI/gitoxide#307b30afff2dad314bff97c640095f42401ea22f"
 dependencies = [
  "bstr",
  "gix-actor",
@@ -2640,7 +2640,7 @@ dependencies = [
 [[package]]
 name = "gix-negotiate"
 version = "0.9.0"
-source = "git+https://github.com/BloopAI/gitoxide#ea8cd0e45793c374cfc6ebbacd09b09ebfbecfe4"
+source = "git+https://github.com/BloopAI/gitoxide#307b30afff2dad314bff97c640095f42401ea22f"
 dependencies = [
  "bitflags 2.4.0",
  "gix-commitgraph",
@@ -2655,7 +2655,7 @@ dependencies = [
 [[package]]
 name = "gix-object"
 version = "0.38.0"
-source = "git+https://github.com/BloopAI/gitoxide#ea8cd0e45793c374cfc6ebbacd09b09ebfbecfe4"
+source = "git+https://github.com/BloopAI/gitoxide#307b30afff2dad314bff97c640095f42401ea22f"
 dependencies = [
  "bstr",
  "btoi",
@@ -2673,7 +2673,7 @@ dependencies = [
 [[package]]
 name = "gix-odb"
 version = "0.54.0"
-source = "git+https://github.com/BloopAI/gitoxide#ea8cd0e45793c374cfc6ebbacd09b09ebfbecfe4"
+source = "git+https://github.com/BloopAI/gitoxide#307b30afff2dad314bff97c640095f42401ea22f"
 dependencies = [
  "arc-swap",
  "gix-date",
@@ -2691,7 +2691,7 @@ dependencies = [
 [[package]]
 name = "gix-pack"
 version = "0.44.0"
-source = "git+https://github.com/BloopAI/gitoxide#ea8cd0e45793c374cfc6ebbacd09b09ebfbecfe4"
+source = "git+https://github.com/BloopAI/gitoxide#307b30afff2dad314bff97c640095f42401ea22f"
 dependencies = [
  "clru",
  "gix-chunk",
@@ -2711,7 +2711,7 @@ dependencies = [
 [[package]]
 name = "gix-packetline"
 version = "0.16.7"
-source = "git+https://github.com/BloopAI/gitoxide#ea8cd0e45793c374cfc6ebbacd09b09ebfbecfe4"
+source = "git+https://github.com/BloopAI/gitoxide#307b30afff2dad314bff97c640095f42401ea22f"
 dependencies = [
  "bstr",
  "faster-hex",
@@ -2722,7 +2722,7 @@ dependencies = [
 [[package]]
 name = "gix-packetline-blocking"
 version = "0.16.6"
-source = "git+https://github.com/BloopAI/gitoxide#ea8cd0e45793c374cfc6ebbacd09b09ebfbecfe4"
+source = "git+https://github.com/BloopAI/gitoxide#307b30afff2dad314bff97c640095f42401ea22f"
 dependencies = [
  "bstr",
  "faster-hex",
@@ -2733,7 +2733,7 @@ dependencies = [
 [[package]]
 name = "gix-path"
 version = "0.10.0"
-source = "git+https://github.com/BloopAI/gitoxide#ea8cd0e45793c374cfc6ebbacd09b09ebfbecfe4"
+source = "git+https://github.com/BloopAI/gitoxide#307b30afff2dad314bff97c640095f42401ea22f"
 dependencies = [
  "bstr",
  "gix-trace",
@@ -2745,7 +2745,7 @@ dependencies = [
 [[package]]
 name = "gix-pathspec"
 version = "0.4.0"
-source = "git+https://github.com/BloopAI/gitoxide#ea8cd0e45793c374cfc6ebbacd09b09ebfbecfe4"
+source = "git+https://github.com/BloopAI/gitoxide#307b30afff2dad314bff97c640095f42401ea22f"
 dependencies = [
  "bitflags 2.4.0",
  "bstr",
@@ -2759,7 +2759,7 @@ dependencies = [
 [[package]]
 name = "gix-prompt"
 version = "0.7.0"
-source = "git+https://github.com/BloopAI/gitoxide#ea8cd0e45793c374cfc6ebbacd09b09ebfbecfe4"
+source = "git+https://github.com/BloopAI/gitoxide#307b30afff2dad314bff97c640095f42401ea22f"
 dependencies = [
  "gix-command",
  "gix-config-value",
@@ -2771,7 +2771,7 @@ dependencies = [
 [[package]]
 name = "gix-protocol"
 version = "0.41.1"
-source = "git+https://github.com/BloopAI/gitoxide#ea8cd0e45793c374cfc6ebbacd09b09ebfbecfe4"
+source = "git+https://github.com/BloopAI/gitoxide#307b30afff2dad314bff97c640095f42401ea22f"
 dependencies = [
  "bstr",
  "btoi",
@@ -2788,7 +2788,7 @@ dependencies = [
 [[package]]
 name = "gix-quote"
 version = "0.4.7"
-source = "git+https://github.com/BloopAI/gitoxide#ea8cd0e45793c374cfc6ebbacd09b09ebfbecfe4"
+source = "git+https://github.com/BloopAI/gitoxide#307b30afff2dad314bff97c640095f42401ea22f"
 dependencies = [
  "bstr",
  "btoi",
@@ -2798,7 +2798,7 @@ dependencies = [
 [[package]]
 name = "gix-ref"
 version = "0.38.0"
-source = "git+https://github.com/BloopAI/gitoxide#ea8cd0e45793c374cfc6ebbacd09b09ebfbecfe4"
+source = "git+https://github.com/BloopAI/gitoxide#307b30afff2dad314bff97c640095f42401ea22f"
 dependencies = [
  "gix-actor",
  "gix-date",
@@ -2818,7 +2818,7 @@ dependencies = [
 [[package]]
 name = "gix-refspec"
 version = "0.19.0"
-source = "git+https://github.com/BloopAI/gitoxide#ea8cd0e45793c374cfc6ebbacd09b09ebfbecfe4"
+source = "git+https://github.com/BloopAI/gitoxide#307b30afff2dad314bff97c640095f42401ea22f"
 dependencies = [
  "bstr",
  "gix-hash",
@@ -2831,7 +2831,7 @@ dependencies = [
 [[package]]
 name = "gix-revision"
 version = "0.23.0"
-source = "git+https://github.com/BloopAI/gitoxide#ea8cd0e45793c374cfc6ebbacd09b09ebfbecfe4"
+source = "git+https://github.com/BloopAI/gitoxide#307b30afff2dad314bff97c640095f42401ea22f"
 dependencies = [
  "bstr",
  "gix-date",
@@ -2846,7 +2846,7 @@ dependencies = [
 [[package]]
 name = "gix-revwalk"
 version = "0.9.0"
-source = "git+https://github.com/BloopAI/gitoxide#ea8cd0e45793c374cfc6ebbacd09b09ebfbecfe4"
+source = "git+https://github.com/BloopAI/gitoxide#307b30afff2dad314bff97c640095f42401ea22f"
 dependencies = [
  "gix-commitgraph",
  "gix-date",
@@ -2860,7 +2860,7 @@ dependencies = [
 [[package]]
 name = "gix-sec"
 version = "0.10.0"
-source = "git+https://github.com/BloopAI/gitoxide#ea8cd0e45793c374cfc6ebbacd09b09ebfbecfe4"
+source = "git+https://github.com/BloopAI/gitoxide#307b30afff2dad314bff97c640095f42401ea22f"
 dependencies = [
  "bitflags 2.4.0",
  "gix-path",
@@ -2871,7 +2871,7 @@ dependencies = [
 [[package]]
 name = "gix-status"
 version = "0.2.0"
-source = "git+https://github.com/BloopAI/gitoxide#ea8cd0e45793c374cfc6ebbacd09b09ebfbecfe4"
+source = "git+https://github.com/BloopAI/gitoxide#307b30afff2dad314bff97c640095f42401ea22f"
 dependencies = [
  "bstr",
  "filetime",
@@ -2890,7 +2890,7 @@ dependencies = [
 [[package]]
 name = "gix-submodule"
 version = "0.5.0"
-source = "git+https://github.com/BloopAI/gitoxide#ea8cd0e45793c374cfc6ebbacd09b09ebfbecfe4"
+source = "git+https://github.com/BloopAI/gitoxide#307b30afff2dad314bff97c640095f42401ea22f"
 dependencies = [
  "bstr",
  "gix-config",
@@ -2904,7 +2904,7 @@ dependencies = [
 [[package]]
 name = "gix-tempfile"
 version = "11.0.0"
-source = "git+https://github.com/BloopAI/gitoxide#ea8cd0e45793c374cfc6ebbacd09b09ebfbecfe4"
+source = "git+https://github.com/BloopAI/gitoxide#307b30afff2dad314bff97c640095f42401ea22f"
 dependencies = [
  "gix-fs",
  "libc",
@@ -2918,12 +2918,12 @@ dependencies = [
 [[package]]
 name = "gix-trace"
 version = "0.1.3"
-source = "git+https://github.com/BloopAI/gitoxide#ea8cd0e45793c374cfc6ebbacd09b09ebfbecfe4"
+source = "git+https://github.com/BloopAI/gitoxide#307b30afff2dad314bff97c640095f42401ea22f"
 
 [[package]]
 name = "gix-transport"
 version = "0.38.0"
-source = "git+https://github.com/BloopAI/gitoxide#ea8cd0e45793c374cfc6ebbacd09b09ebfbecfe4"
+source = "git+https://github.com/BloopAI/gitoxide#307b30afff2dad314bff97c640095f42401ea22f"
 dependencies = [
  "base64 0.21.4",
  "bstr",
@@ -2941,7 +2941,7 @@ dependencies = [
 [[package]]
 name = "gix-traverse"
 version = "0.34.0"
-source = "git+https://github.com/BloopAI/gitoxide#ea8cd0e45793c374cfc6ebbacd09b09ebfbecfe4"
+source = "git+https://github.com/BloopAI/gitoxide#307b30afff2dad314bff97c640095f42401ea22f"
 dependencies = [
  "gix-commitgraph",
  "gix-date",
@@ -2956,7 +2956,7 @@ dependencies = [
 [[package]]
 name = "gix-url"
 version = "0.25.1"
-source = "git+https://github.com/BloopAI/gitoxide#ea8cd0e45793c374cfc6ebbacd09b09ebfbecfe4"
+source = "git+https://github.com/BloopAI/gitoxide#307b30afff2dad314bff97c640095f42401ea22f"
 dependencies = [
  "bstr",
  "gix-features",
@@ -2969,7 +2969,7 @@ dependencies = [
 [[package]]
 name = "gix-utils"
 version = "0.1.5"
-source = "git+https://github.com/BloopAI/gitoxide#ea8cd0e45793c374cfc6ebbacd09b09ebfbecfe4"
+source = "git+https://github.com/BloopAI/gitoxide#307b30afff2dad314bff97c640095f42401ea22f"
 dependencies = [
  "fastrand",
 ]
@@ -2977,7 +2977,7 @@ dependencies = [
 [[package]]
 name = "gix-validate"
 version = "0.8.0"
-source = "git+https://github.com/BloopAI/gitoxide#ea8cd0e45793c374cfc6ebbacd09b09ebfbecfe4"
+source = "git+https://github.com/BloopAI/gitoxide#307b30afff2dad314bff97c640095f42401ea22f"
 dependencies = [
  "bstr",
  "thiserror",
@@ -2986,7 +2986,7 @@ dependencies = [
 [[package]]
 name = "gix-worktree"
 version = "0.27.0"
-source = "git+https://github.com/BloopAI/gitoxide#ea8cd0e45793c374cfc6ebbacd09b09ebfbecfe4"
+source = "git+https://github.com/BloopAI/gitoxide#307b30afff2dad314bff97c640095f42401ea22f"
 dependencies = [
  "bstr",
  "gix-attributes",
@@ -3003,7 +3003,7 @@ dependencies = [
 [[package]]
 name = "gix-worktree-state"
 version = "0.4.0"
-source = "git+https://github.com/BloopAI/gitoxide#ea8cd0e45793c374cfc6ebbacd09b09ebfbecfe4"
+source = "git+https://github.com/BloopAI/gitoxide#307b30afff2dad314bff97c640095f42401ea22f"
 dependencies = [
  "bstr",
  "gix-features",
@@ -3022,7 +3022,7 @@ dependencies = [
 [[package]]
 name = "gix-worktree-stream"
 version = "0.6.0"
-source = "git+https://github.com/BloopAI/gitoxide#ea8cd0e45793c374cfc6ebbacd09b09ebfbecfe4"
+source = "git+https://github.com/BloopAI/gitoxide#307b30afff2dad314bff97c640095f42401ea22f"
 dependencies = [
  "gix-attributes",
  "gix-features",


### PR DESCRIPTION
On windows Git doesn't handle symlinks gracefully. Fix our fork until the official `gix` package comes out.