### PR TITLE
Remove interactive cred checks

### DIFF
--- a/server/bleep/src/lib.rs
+++ b/server/bleep/src/lib.rs
@@ -315,8 +315,6 @@ impl Application {
     }
 
     pub(crate) async fn user(&self) -> User {
-        crate::periodic::update_credentials(self).await;
-
         self.credentials
             .user()
             .zip(self.credentials.github())


### PR DESCRIPTION
Seems like putting this on the request path will intermittently cause network-related hangs, and blocks requests. It's better to solely rely on some mechanism to fire early if we detect there's a hang.