### PR TITLE
Fix .deb path in release action

### DIFF
--- a/.github/workflows/tauri-release.yml
+++ b/.github/workflows/tauri-release.yml
@@ -152,7 +152,7 @@ jobs:
         run: |
           sentry-cli releases new "${{ steps.release-version.outputs.RELEASE_VERSION }}"
           sentry-cli releases set-commits "${{ steps.release-version.outputs.RELEASE_VERSION }}" --auto
-      
+
       - name: (MacOS) Upload source maps to Sentry
         if: matrix.name == 'macos-11'
         run: |
@@ -181,7 +181,7 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/v')
         with:
           files: |
-            target/${{ matrix.target }}/release/bundle/dev/*.deb
+            target/${{ matrix.target }}/release/bundle/deb/*.deb
             target/${{ matrix.target }}/release/bundle/appimage/*.AppImage
             target/${{ matrix.target }}/release/bundle/appimage/*.tar.gz
             target/${{ matrix.target }}/release/bundle/dmg/*.dmg


### PR DESCRIPTION
There was a typo in the glob for uploading the .deb file to release assets.