### PR TITLE
Fix code studio UI bugs

### DIFF
--- a/client/src/components/CodeBlock/CodeFullSelectable/CodeContainer.tsx
+++ b/client/src/components/CodeBlock/CodeFullSelectable/CodeContainer.tsx
@@ -241,18 +241,20 @@ const CodeContainerSelectable = ({
           />
         </Fragment>
       ))}
-      {!!currentlySelectingRange && (
-        <SelectionRect range={currentlySelectingRange} isTemporary />
-      )}
-      <LinesContainer
-        items={tokens}
-        pathHash={pathHash}
-        handleAddRange={handleAddRange}
-        searchTerm={searchTerm}
-        setCurrentlySelectingRange={setCurrentlySelectingRange}
-        modifyingRange={modifyingRange}
-        scrollToIndex={scrollToIndex}
-      />
+      <div className="overflow-x-auto relative">
+        {!!currentlySelectingRange && (
+          <SelectionRect range={currentlySelectingRange} isTemporary />
+        )}
+        <LinesContainer
+          items={tokens}
+          pathHash={pathHash}
+          handleAddRange={handleAddRange}
+          searchTerm={searchTerm}
+          setCurrentlySelectingRange={setCurrentlySelectingRange}
+          modifyingRange={modifyingRange}
+          scrollToIndex={scrollToIndex}
+        />
+      </div>
     </div>
   );
 };

--- a/client/src/components/CodeBlock/CodeFullSelectable/SelectionHandler.tsx
+++ b/client/src/components/CodeBlock/CodeFullSelectable/SelectionHandler.tsx
@@ -154,17 +154,20 @@ const SelectionHandler = ({
     <>
       <div
         ref={startHandlerRef}
-        className={`absolute -left-0.5 w-5 h-1 bg-bg-main rounded-tl rounded-tr cursor-row-resize z-10`}
+        className={`absolute -left-0.5 w-5 h-1 bg-bg-main rounded-tl rounded-tr cursor-row-resize z-20`}
         style={{
-          top: `${range[0] * CODE_LINE_HEIGHT - 2}px`,
+          top: `${Math.max(range[0] * CODE_LINE_HEIGHT - 2, 0)}px`,
         }}
         onMouseDown={handleMouseDownStart}
       />
       <div
         ref={endHandlerRef}
-        className={`absolute -left-0.5 w-5 h-1 bg-bg-main rounded-bl rounded-br cursor-row-resize z-10`}
+        className={`absolute -left-0.5 w-5 h-1 bg-bg-main rounded-bl rounded-br cursor-row-resize z-20`}
         style={{
-          top: `${range[1] * CODE_LINE_HEIGHT + CODE_LINE_HEIGHT}px`,
+          top: `${Math.min(
+            range[1] * CODE_LINE_HEIGHT + CODE_LINE_HEIGHT,
+            fileLinesNum * 20 - 4,
+          )}px`,
         }}
         onMouseDown={handleMouseDownEnd}
       />

--- a/client/src/components/CodeBlock/CodeFullSelectable/SelectionRect.tsx
+++ b/client/src/components/CodeBlock/CodeFullSelectable/SelectionRect.tsx
@@ -36,10 +36,13 @@ const SelectionRect = ({
     };
   }, [range]);
   return (
-    <div className="absolute left-0 right-0 z-10 group" style={style}>
+    <div
+      className="absolute left-0 right-0 z-10 group pointer-events-none"
+      style={style}
+    >
       <div className="w-full h-full bg-bg-main opacity-20 hover:opacity-30 z-10" />
       {!isTemporary && (
-        <div className="absolute top-2 right-2 z-20 opacity-0 group-hover:opacity-100 flex gap-1 items-center">
+        <div className="absolute top-2 right-2 z-20 flex gap-1 items-center pointer-events-auto">
           <Button size="tiny" variant="secondary" onClick={invertRanges}>
             <Trans>Invert</Trans>
           </Button>


### PR DESCRIPTION
Issues fixed in this PR:
- drag handler is not usable if the selection starts at the first line or ends on the last line
- when scrolling file horizontally selection rectangle does not stretch the full width. This is fixed, **however**, due to some limitations (the use of pointer-events none) we have to always show action buttons instead of on hover.