### PR TITLE
update action-set-json-field to v2.1

### DIFF
--- a/.github/workflows/tauri-release.yml
+++ b/.github/workflows/tauri-release.yml
@@ -99,14 +99,14 @@ jobs:
         run: du -h apps/desktop/src-tauri/config/config.json
 
       - name: Set providerShortName in tauri.conf.json
-        uses: jossef/action-set-json-field@v2
+        uses: jossef/action-set-json-field@v2.1
         with:
           file: apps/desktop/src-tauri/tauri.conf.json
           field: tauri.bundle.macOS.providerShortName
           value: ${{ secrets.MAC_PROVIDER_SHORT_NAME }}
 
       - name: Set signingIdentity in tauri.conf.json
-        uses: jossef/action-set-json-field@v2
+        uses: jossef/action-set-json-field@v2.1
         with:
           file: apps/desktop/src-tauri/tauri.conf.json
           field: tauri.bundle.macOS.signingIdentity
@@ -114,7 +114,7 @@ jobs:
 
       - name: Remove onnxruntime from aarch64-apple-darwin builds
         if: matrix.target == 'aarch64-apple-darwin'
-        uses: jossef/action-set-json-field@v2
+        uses: jossef/action-set-json-field@v2.1
         with:
           file: apps/desktop/src-tauri/tauri.conf.json
           field: tauri.bundle.macOS.frameworks


### PR DESCRIPTION
this should supress the warning on github action runs:

    The following actions uses node12 which is deprecated and will be forced
    to run on node16: jossef/action-set-json-field@v2. For more info:
    https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/