### PR TITLE
Improve sync status reporting + cancellation

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -40,14 +40,3 @@ RUN mkdir -p $HOME/.config/direnv && printf '%s\n' "[whitelist]" 'prefix = [ "/w
         'create-overlay /nix "${dirs[@]}"' > $HOME/.runonce/100-nix \
     && . /home/gitpod/.nix-profile/etc/profile.d/nix.sh \
     && nix-env -iA nixpkgs.direnv
-
-# Cache nix compilation for saving time
-ARG onetime_cache_dir="/tmp/.workdir"
-RUN mkdir -p "${onetime_cache_dir}"
-COPY --chown=gitpod:gitpod . "${onetime_cache_dir}"
-
-WORKDIR "${onetime_cache_dir}"
-SHELL [ "/bin/bash", "-c" ]
-RUN source "$HOME/.nix-profile/etc/profile.d/nix.sh" \
-    && nix run nixpkgs#cachix use bloopai \
-    && nix develop

--- a/apps/desktop/src-tauri/build.rs
+++ b/apps/desktop/src-tauri/build.rs
@@ -67,6 +67,6 @@ fn wait_for(dylib_path: &Path) {
 
 fn is_apple_silicon() -> bool {
     let target = env::var("TARGET").unwrap();
-    let components: Vec<_> = target.split("-").map(|s| s.to_string()).collect();
+    let components: Vec<_> = target.split('-').map(|s| s.to_string()).collect();
     components[0] == "aarch64" && components[2] == "darwin"
 }

--- a/client/src/pages/HomeTab/ReposSection/RepoCard/index.tsx
+++ b/client/src/pages/HomeTab/ReposSection/RepoCard/index.tsx
@@ -27,7 +27,7 @@ type Props = {
   lang: string;
   repoRef: string;
   provider: 'local' | 'github';
-  syncStatus?: { percentage: number } | null;
+  syncPercentage?: number | null;
   onDelete: (ref: string) => void;
   indexedBranches?: string[];
 };
@@ -51,7 +51,7 @@ const RepoCard = ({
   last_index,
   lang,
   provider,
-  syncStatus,
+  syncPercentage,
   repoRef,
   onDelete,
   indexedBranches,
@@ -188,14 +188,18 @@ const RepoCard = ({
       </div>
       {(sync_status === SyncStatus.Indexing ||
         sync_status === SyncStatus.Syncing) &&
-      syncStatus ? (
+      syncPercentage !== null &&
+      syncPercentage !== undefined ? (
         <div className="flex flex-col gap-2">
           <p className="body-s text-label-title">
-            <Trans>{ (sync_status === SyncStatus.Indexing && "Indexing" || "Cloning") }...</Trans>
+            <Trans>
+              {sync_status === SyncStatus.Indexing ? 'Indexing' : 'Cloning'}
+            </Trans>
+            ...
           </p>
-          <BarLoader percentage={syncStatus.percentage} />
+          <BarLoader percentage={syncPercentage} />
           <p className="caption text-label-muted">
-            {syncStatus.percentage}% <Trans>complete</Trans>
+            {syncPercentage}% <Trans>complete</Trans>
           </p>
         </div>
       ) : (

--- a/client/src/pages/HomeTab/ReposSection/RepoCard/index.tsx
+++ b/client/src/pages/HomeTab/ReposSection/RepoCard/index.tsx
@@ -191,7 +191,7 @@ const RepoCard = ({
       syncStatus ? (
         <div className="flex flex-col gap-2">
           <p className="body-s text-label-title">
-            <Trans>Indexing...</Trans>
+            <Trans>{ (sync_status === SyncStatus.Indexing && "Indexing" || "Cloning") }...</Trans>
           </p>
           <BarLoader percentage={syncStatus.percentage} />
           <p className="caption text-label-muted">

--- a/client/src/pages/HomeTab/ReposSection/index.tsx
+++ b/client/src/pages/HomeTab/ReposSection/index.tsx
@@ -110,11 +110,7 @@ const ReposSection = ({
               lang={r.most_common_lang}
               key={ref + i}
               provider={r.provider}
-              syncPercentage={
-                currentlySyncingRepos?.[ref]
-                  ? currentlySyncingRepos?.[ref]
-                  : null
-              }
+              syncPercentage={currentlySyncingRepos?.[ref]}
               onDelete={onDelete}
               indexedBranches={r.branch_filter?.select}
             />

--- a/client/src/pages/HomeTab/ReposSection/index.tsx
+++ b/client/src/pages/HomeTab/ReposSection/index.tsx
@@ -38,10 +38,10 @@ const ReposSection = ({
 }: Props) => {
   const { apiUrl } = useContext(DeviceContext);
   const { setRepositories } = useContext(RepositoriesContext);
-  const [currentlySyncingRepo, setCurrentlySyncingRepo] = useState<{
-    repoRef: string;
-    percentage: number;
-  } | null>(null);
+  const [currentlySyncingRepos, setCurrentlySyncingRepos] = useState<Record<
+    string,
+    number
+  > | null>(null);
 
   useEffect(() => {
     eventSource?.close();
@@ -70,16 +70,16 @@ const ReposSection = ({
           });
         }
         if (Number.isInteger(data.ev?.index_percent)) {
-          setCurrentlySyncingRepo({
-            repoRef: data.ref,
-            percentage: data.ev.index_percent,
-          });
+          setCurrentlySyncingRepos((prev) => ({
+            ...prev,
+            [data.ref]: data.ev.index_percent,
+          }));
         }
       } catch {}
     };
     eventSource.onerror = (err) => {
       console.error('EventSource failed:', err);
-      setCurrentlySyncingRepo(null);
+      setCurrentlySyncingRepos(null);
     };
     return () => {
       eventSource?.close();
@@ -108,9 +108,9 @@ const ReposSection = ({
               lang={r.most_common_lang}
               key={ref + i}
               provider={r.provider}
-              syncStatus={
-                currentlySyncingRepo?.repoRef === ref
-                  ? currentlySyncingRepo
+              syncPercentage={
+                currentlySyncingRepos?.[ref]
+                  ? currentlySyncingRepos?.[ref]
                   : null
               }
               onDelete={onDelete}

--- a/client/src/pages/HomeTab/ReposSection/index.tsx
+++ b/client/src/pages/HomeTab/ReposSection/index.tsx
@@ -70,7 +70,10 @@ const ReposSection = ({
               return newRepos;
             });
           }
-          if (Number.isInteger(data.ev?.index_percent)) {
+          if (
+            Number.isInteger(data.ev?.index_percent) ||
+            data.ev?.index_percent === null
+          ) {
             setCurrentlySyncingRepos((prev) => ({
               ...prev,
               [data.ref]: data.ev.index_percent,

--- a/server/bleep/build.rs
+++ b/server/bleep/build.rs
@@ -109,6 +109,6 @@ fn determine_embedder_backend() {
 
 fn is_apple_silicon() -> bool {
     let target = env::var("TARGET").unwrap();
-    let components: Vec<_> = target.split("-").map(|s| s.to_string()).collect();
+    let components: Vec<_> = target.split('-').map(|s| s.to_string()).collect();
     components[0] == "aarch64" && components[2] == "darwin"
 }

--- a/server/bleep/src/background.rs
+++ b/server/bleep/src/background.rs
@@ -178,7 +178,7 @@ impl SyncQueue {
                                 if result.is_ok() {
                                     debug!(?result, "sync finished");
                                 } else {
-                                    error!(?result, "sync finished");
+                                    error!(?result, "sync failed");
                                 }
                             });
                         }

--- a/server/bleep/src/background.rs
+++ b/server/bleep/src/background.rs
@@ -2,7 +2,7 @@ use once_cell::sync::OnceCell;
 use rayon::ThreadPool;
 use thread_priority::ThreadBuilderExt;
 use tokio::sync::Semaphore;
-use tracing::{debug, info};
+use tracing::{debug, error, info};
 
 use crate::{
     repo::{BranchFilterConfig, RepoRef, SyncStatus},
@@ -175,7 +175,11 @@ impl SyncQueue {
                                 let result = next.run(permit).await;
                                 _ = active.remove(&next.reporef);
 
-                                debug!(?result, "sync finished");
+                                if result.is_ok() {
+                                    debug!(?result, "sync finished");
+                                } else {
+                                    error!(?result, "sync finished");
+                                }
                             });
                         }
                         Err((_, next)) => {

--- a/server/bleep/src/background.rs
+++ b/server/bleep/src/background.rs
@@ -44,7 +44,7 @@ pub struct Progress {
 #[derive(serde::Serialize, Clone)]
 #[serde(rename_all = "snake_case")]
 pub enum ProgressEvent {
-    IndexPercent(u8),
+    IndexPercent(Option<u8>),
     StatusChange(SyncStatus),
 }
 

--- a/server/bleep/src/background/control.rs
+++ b/server/bleep/src/background/control.rs
@@ -119,7 +119,7 @@ impl gix::progress::Progress for GitSync {
     }
 
     fn id(&self) -> gix::progress::Id {
-        self.id.clone()
+        self.id
     }
 
     fn message(&self, level: gix::progress::MessageLevel, message: String) {
@@ -157,7 +157,7 @@ impl gix::progress::Count for GitSync {
         _ = self.progress.send(Progress {
             reporef: self.reporef.clone(),
             branch_filter: self.filter_updates.branch_filter.clone(),
-            event: ProgressEvent::IndexPercent((current.min(100)) as u8),
+            event: ProgressEvent::IndexPercent(current.min(100)),
         });
     }
 
@@ -174,7 +174,7 @@ impl gix::progress::NestedProgress for GitSync {
             max: self.max.clone(),
             cnt: self.cnt.clone(),
             progress: self.progress.clone(),
-            id: self.id.clone(),
+            id: self.id,
             filter_updates: self.filter_updates.clone(),
             reporef: self.reporef.clone(),
             name: name.into(),

--- a/server/bleep/src/background/control.rs
+++ b/server/bleep/src/background/control.rs
@@ -23,10 +23,19 @@ enum ControlEvent {
 }
 
 pub struct SyncPipes {
+    /// Together with `filter_updates`, it uniquely identifies the sync process
     reporef: RepoRef,
+
+    /// Together with `reporef`, it uniquely identifies the sync process
     filter_updates: FilterUpdate,
+
+    /// Channel to stream updates to the frontend
     progress: super::ProgressStream,
+
+    /// Control event received from frontend
     event: RwLock<Option<ControlEvent>>,
+
+    /// Interrupt signal channel for `gix`
     git_interrupt: Arc<AtomicBool>,
 }
 

--- a/server/bleep/src/background/control.rs
+++ b/server/bleep/src/background/control.rs
@@ -12,7 +12,7 @@ use crate::repo::{FilterUpdate, RepoRef, SyncStatus};
 
 use super::{Progress, ProgressEvent};
 
-const GIT_REPORT_DELAY: Duration = Duration::from_secs(0);
+const GIT_REPORT_DELAY: Duration = Duration::from_secs(3);
 
 enum ControlEvent {
     /// Cancel whatever's happening, and return
@@ -64,7 +64,7 @@ impl SyncPipes {
 
         GitSync {
             created: Instant::now(),
-            max: Arc::new(0.into()),
+            max: Arc::new(usize::MAX.into()),
             cnt: Arc::new(0.into()),
             id: Default::default(),
             name: Default::default(),

--- a/server/bleep/src/background/control.rs
+++ b/server/bleep/src/background/control.rs
@@ -198,6 +198,18 @@ impl gix::progress::Count for GitSync {
             let max = self.max.load(Ordering::SeqCst);
             let current = self.cnt.load(Ordering::SeqCst);
 
+            // This logic is super arbitrary. If the `max` is larger
+            // than 10000, we assume that it's a meaningful value. At
+            // the beginning of the syncing process `gix` sometimes
+            // reports some smaller values that cause a false `0%`
+            // progress to make it to the frontend.
+            //
+            // The magic constant 4 * 1024 was experientially
+            // determined to roughly align with the scale of data git
+            // ends up receiving from the server.
+            //
+            // Feel free to change anything as long as it looks good
+            // on the frontend.
             let current = if max > 10000 {
                 ((current as f32 / (max * 4 * 1024) as f32) * 100f32) as u8
             } else {

--- a/server/bleep/src/background/control.rs
+++ b/server/bleep/src/background/control.rs
@@ -201,7 +201,7 @@ impl gix::progress::Count for GitSync {
             let current = if max > 10000 {
                 ((current as f32 / (max * 4 * 1024) as f32) * 100f32) as u8
             } else {
-                ((current as f32 / (max) as f32) * 100f32) as u8
+                0
             };
 
             _ = self.progress.send(Progress {

--- a/server/bleep/src/background/control.rs
+++ b/server/bleep/src/background/control.rs
@@ -236,24 +236,7 @@ impl gix::progress::NestedProgress for GitSync {
     type SubProgress = Self;
 
     fn add_child(&mut self, name: impl Into<String>) -> Self::SubProgress {
-        let name = name.into();
-        let progress = if name == "read pack" {
-            self.progress.clone()
-        } else {
-            let (sender, _) = tokio::sync::broadcast::channel(1000);
-            sender
-        };
-
-        GitSync {
-            created: self.created,
-            max: self.max.clone(),
-            cnt: self.cnt.clone(),
-            id: self.id,
-            filter_updates: self.filter_updates.clone(),
-            reporef: self.reporef.clone(),
-            progress,
-            name,
-        }
+        self.add_child_with_id(name, self.id)
     }
 
     fn add_child_with_id(

--- a/server/bleep/src/background/sync.rs
+++ b/server/bleep/src/background/sync.rs
@@ -178,8 +178,7 @@ impl SyncHandle {
                 Err(err) => {
                     self.set_status(|_| SyncStatus::Error {
                         message: err.to_string(),
-                    })
-                    .unwrap();
+                    });
                     return Err(err);
                 }
             }

--- a/server/bleep/src/background/sync.rs
+++ b/server/bleep/src/background/sync.rs
@@ -340,7 +340,10 @@ impl SyncHandle {
         let mut loop_counter = 0;
         let loop_max = 1;
         let git_err = loop {
-            match creds.git_sync(&self.reporef, repo.clone()).await {
+            match creds
+                .git_sync(&self.reporef, repo.clone(), &self.pipes)
+                .await
+            {
                 Err(
                     err @ RemoteError::GitCloneFetch(gix::clone::fetch::Error::PrepareFetch(
                         gix::remote::fetch::prepare::Error::RefMap(

--- a/server/bleep/src/background/sync.rs
+++ b/server/bleep/src/background/sync.rs
@@ -458,8 +458,7 @@ impl SyncHandle {
             let old_status = std::mem::replace(&mut repo.sync_status, new_status);
 
             if !matches!(repo.sync_status, SyncStatus::Queued)
-                || (matches!(old_status, SyncStatus::Syncing)
-                    && matches!(repo.sync_status, SyncStatus::Queued))
+                || matches!(old_status, SyncStatus::Syncing)
             {
                 repo.pub_sync_status = repo.sync_status.clone();
             }

--- a/server/bleep/src/periodic/remotes.rs
+++ b/server/bleep/src/periodic/remotes.rs
@@ -282,7 +282,9 @@ async fn periodic_repo_poll(app: Application, reporef: RepoRef) -> Option<()> {
         if (UNIX_EPOCH + Duration::from_secs(last_index)) > SystemTime::now() - poller.interval() {
             app.repo_pool
                 .update_async(&reporef, |_, repo| {
-                    repo.pub_sync_status = repo.sync_status.clone();
+                    if !matches!(repo.sync_status, Queued) {
+                        repo.pub_sync_status = repo.sync_status.clone();
+                    }
                 })
                 .await;
 

--- a/server/bleep/src/periodic/remotes.rs
+++ b/server/bleep/src/periodic/remotes.rs
@@ -279,9 +279,7 @@ async fn periodic_repo_poll(app: Application, reporef: RepoRef) -> Option<()> {
             return None;
         }
 
-        if (UNIX_EPOCH + Duration::from_secs(last_index as u64))
-            > SystemTime::now() - poller.interval()
-        {
+        if (UNIX_EPOCH + Duration::from_secs(last_index)) > SystemTime::now() - poller.interval() {
             app.repo_pool
                 .update_async(&reporef, |_, repo| {
                     repo.pub_sync_status = repo.sync_status.clone();

--- a/server/bleep/src/remotes.rs
+++ b/server/bleep/src/remotes.rs
@@ -143,7 +143,7 @@ async fn git_clone(
     let auth = auth.clone();
 
     let git_status = pipes.git_sync_progress();
-    let interrupt = pipes.interrupt();
+    let interrupt = pipes.is_interrupted();
 
     tokio::task::spawn_blocking(move || {
         let mut clone = {
@@ -169,7 +169,7 @@ async fn git_pull(auth: &Option<GitCreds>, repo: &Repository, pipes: &SyncPipes)
     let auth = auth.clone();
     let disk_path = repo.disk_path.to_owned();
 
-    let interrupt = pipes.interrupt();
+    let interrupt = pipes.is_interrupted();
 
     tokio::task::spawn_blocking(move || {
         let repo = gix::open(disk_path)?;

--- a/server/bleep/src/remotes/github.rs
+++ b/server/bleep/src/remotes/github.rs
@@ -95,14 +95,14 @@ impl From<Auth> for State {
 }
 
 impl Auth {
-    pub(crate) async fn clone_repo(&self, repo: &Repository) -> Result<()> {
+    pub(crate) async fn clone_repo(&self, repo: &Repository, pipes: &SyncPipes) -> Result<()> {
         let creds = self.creds_for_private_repos(repo).await?;
-        git_clone(creds, &repo.remote.to_string(), &repo.disk_path).await
+        git_clone(creds, &repo.remote.to_string(), &repo.disk_path, pipes).await
     }
 
-    pub(crate) async fn pull_repo(&self, repo: &Repository) -> Result<()> {
+    pub(crate) async fn pull_repo(&self, repo: &Repository, pipes: &SyncPipes) -> Result<()> {
         let creds = self.creds_for_private_repos(repo).await?;
-        git_pull(creds, repo).await
+        git_pull(creds, repo, pipes).await
     }
 
     async fn creds_for_private_repos(&self, repo: &Repository) -> Result<Option<GitCreds>> {

--- a/server/bleep/src/remotes/github.rs
+++ b/server/bleep/src/remotes/github.rs
@@ -95,17 +95,8 @@ impl From<Auth> for State {
 }
 
 impl Auth {
-    pub(crate) async fn clone_repo(&self, repo: &Repository, pipes: &SyncPipes) -> Result<()> {
-        let creds = self.creds_for_private_repos(repo).await?;
-        git_clone(creds, &repo.remote.to_string(), &repo.disk_path, pipes).await
-    }
-
-    pub(crate) async fn pull_repo(&self, repo: &Repository, pipes: &SyncPipes) -> Result<()> {
-        let creds = self.creds_for_private_repos(repo).await?;
-        git_pull(creds, repo, pipes).await
-    }
-
-    async fn creds_for_private_repos(&self, repo: &Repository) -> Result<Option<GitCreds>> {
+    /// Return credentials for private repositories, and no credentials for public ones.
+    pub(crate) async fn creds(&self, repo: &Repository) -> Result<Option<GitCreds>> {
         let RepoRemote::Git(GitRemote { ref address, .. }) = repo.remote else {
             return Err(RemoteError::NotSupported("github without git backend"));
         };

--- a/server/bleep/src/repo.rs
+++ b/server/bleep/src/repo.rs
@@ -347,7 +347,7 @@ pub struct RepoMetadata {
     pub langs: language::LanguageInfo,
 }
 
-#[derive(Serialize, Deserialize, PartialEq, Eq, Clone, Debug, Hash)]
+#[derive(Serialize, Deserialize, PartialEq, Eq, Clone, Debug, Hash, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum SyncStatus {
     /// There was an error during last sync & index
@@ -366,9 +366,10 @@ pub enum SyncStatus {
     Cancelled,
 
     /// Queued for sync & index
+    #[default]
     Queued,
 
-    /// Active VCS operation in progress
+    /// Active Git clone in progress (we don't report fetch/pull)
     Syncing,
 
     /// Active indexing in progress
@@ -379,12 +380,6 @@ pub enum SyncStatus {
 
     /// Successfully indexed
     Done,
-}
-
-impl Default for SyncStatus {
-    fn default() -> Self {
-        SyncStatus::Queued
-    }
 }
 
 impl SyncStatus {

--- a/server/bleep/src/repo.rs
+++ b/server/bleep/src/repo.rs
@@ -217,6 +217,7 @@ pub struct Repository {
     #[serde(default)]
     pub file_filter: FileFilterConfig,
 
+    /// Sync lock
     #[serde(skip)]
     pub locked: bool,
 

--- a/server/bleep/src/repo.rs
+++ b/server/bleep/src/repo.rs
@@ -268,6 +268,15 @@ impl Repository {
         }
     }
 
+    /// Delete the on-disk data for this repository asynchronously.
+    pub async fn remove_all(&self) -> Result<(), std::io::Error> {
+        if self.disk_path.exists() {
+            tokio::fs::remove_dir_all(&self.disk_path).await
+        } else {
+            Ok(())
+        }
+    }
+
     /// Pre-scan the repository to provide supporting metadata for a
     /// new indexing operation
     pub async fn get_repo_metadata(&self) -> Arc<RepoMetadata> {

--- a/server/bleep/src/repo.rs
+++ b/server/bleep/src/repo.rs
@@ -289,6 +289,7 @@ impl Repository {
     /// Does not initiate a new sync.
     pub(crate) fn mark_removed(&mut self) {
         self.sync_status = SyncStatus::Removed;
+        self.pub_sync_status = SyncStatus::Removed;
     }
 
     /// Marks the repository for indexing on the next sync

--- a/server/bleep/src/semantic/embedder.rs
+++ b/server/bleep/src/semantic/embedder.rs
@@ -186,8 +186,10 @@ mod gpu {
 
     impl LocalEmbedder {
         pub fn new(model_dir: &Path) -> anyhow::Result<Self> {
-            let mut model_params = llm::ModelParameters::default();
-            model_params.use_gpu = true;
+            let model_params = llm::ModelParameters {
+                use_gpu: true,
+                ..Default::default()
+            };
 
             let model = llm::load_dynamic(
                 Some(llm::ModelArchitecture::Bert),
@@ -281,7 +283,7 @@ mod gpu {
                 .iter()
                 .map(|sequence| {
                     vocab
-                        .tokenize(&sequence, beginning_of_sentence)
+                        .tokenize(sequence, beginning_of_sentence)
                         .unwrap()
                         .iter()
                         .map(|(_, tok)| *tok)

--- a/server/bleep/src/webserver/repos.rs
+++ b/server/bleep/src/webserver/repos.rs
@@ -494,9 +494,11 @@ mod test {
                     sync_status: SyncStatus::Done,
                     last_commit_unix_secs: 123456,
                     last_index_unix_secs: 123456,
-                    most_common_lang: None,
+                    most_common_lang: Default::default(),
                     branch_filter: Default::default(),
                     file_filter: Default::default(),
+                    pub_sync_status: Default::default(),
+                    locked: Default::default(),
                 },
             )
             .unwrap();
@@ -513,9 +515,11 @@ mod test {
                     sync_status: SyncStatus::Done,
                     last_commit_unix_secs: 123456,
                     last_index_unix_secs: 123456,
-                    most_common_lang: None,
+                    most_common_lang: Default::default(),
                     branch_filter: Default::default(),
                     file_filter: Default::default(),
+                    pub_sync_status: Default::default(),
+                    locked: Default::default(),
                 },
             )
             .unwrap();
@@ -534,9 +538,11 @@ mod test {
                     sync_status: SyncStatus::Uninitialized,
                     last_commit_unix_secs: 123456,
                     last_index_unix_secs: 0,
-                    most_common_lang: None,
+                    most_common_lang: Default::default(),
                     branch_filter: Default::default(),
                     file_filter: Default::default(),
+                    pub_sync_status: Default::default(),
+                    locked: Default::default(),
                 },
             )
                 .into(),
@@ -554,9 +560,11 @@ mod test {
                 sync_status: SyncStatus::Uninitialized,
                 last_commit_unix_secs: 123456,
                 last_index_unix_secs: 0,
-                most_common_lang: None,
+                most_common_lang: Default::default(),
                 branch_filter: Default::default(),
                 file_filter: Default::default(),
+                pub_sync_status: Default::default(),
+                locked: Default::default(),
             },
         )
             .into();

--- a/server/bleep/src/webserver/repos.rs
+++ b/server/bleep/src/webserver/repos.rs
@@ -232,10 +232,8 @@ pub(super) async fn index_status(Extension(app): Extension<Application>) -> impl
     Sse::new(async_stream::stream! {
         loop {
             if let Ok(event) = receiver.recv().await {
-                yield sse::Event::default().json_data(event).map_err(|err| {
-                    <_ as Into<Box<dyn std::error::Error + Send + Sync>>>::into(err)
-                });
-        }
+                yield sse::Event::default().json_data(event).map_err(Box::new);
+            }
         }
     })
     .keep_alive(


### PR DESCRIPTION
The improvements come out when you leave bloop around. The syncing process doesn't report `Queued` and `Syncing` anymore, these happen only in the background.

The default sync delay is also bumped to 10 minutes.

After 5 seconds Bloop now also displays a progress bar for Git clone operations, and allows interrupting the Git clone of a large repository.

<a href="https://gitpod.io/#https://github.com/BloopAI/bloop/pull/1107"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

