### PR TITLE
Update Tantivy minimum buffer size per thread

### DIFF
--- a/server/bleep/src/lib.rs
+++ b/server/bleep/src/lib.rs
@@ -133,9 +133,9 @@ impl Application {
         config.max_threads = config.max_threads.max(minimum_parallelism());
         let threads = config.max_threads;
 
-        // 3MiB buffer size is minimum for Tantivy
-        config.buffer_size = config.buffer_size.max(threads * 3_000_000);
-        config.repo_buffer_size = config.repo_buffer_size.max(threads * 3_000_000);
+        // 15MiB buffer size is minimum for Tantivy
+        config.buffer_size = config.buffer_size.max(threads * 15_000_000);
+        config.repo_buffer_size = config.repo_buffer_size.max(threads * 15_000_000);
         config.source.set_default_dir(&config.index_dir);
 
         // Finalize config


### PR DESCRIPTION
Tantivy's minimum buffer size per thread seems to have risen to 15Mb