### PR TITLE
Fix long repo names exceed repo card

### DIFF
--- a/client/src/pages/HomeTab/ReposSection/RepoCard/index.tsx
+++ b/client/src/pages/HomeTab/ReposSection/RepoCard/index.tsx
@@ -18,6 +18,7 @@ import { cancelSync, deleteRepo, syncRepo } from '../../../../services/api';
 import { RepoSource } from '../../../../types';
 import { LocaleContext } from '../../../../context/localeContext';
 import { ContextMenuItem } from '../../../../components/ContextMenu';
+import Tooltip from '../../../../components/Tooltip';
 
 type Props = {
   name: string;
@@ -168,10 +169,18 @@ const RepoCard = ({
     >
       <div className="flex justify-between items-start">
         <div className="flex items-center gap-4">
-          <span className="h-11 w-11 rounded-md bg-bg-shade flex items-center justify-center mt-1 file-icon-lg">
+          <span className="h-11 w-11 rounded-md bg-bg-shade flex items-center justify-center mt-1 file-icon-lg flex-shrink-0">
             <FileIcon filename={getFileExtensionForLang(lang)} noMargin />
           </span>
-          <p className="break-all text-label-title pt-0.5">{repoName}</p>
+          {repoName.length > 40 ? (
+            <Tooltip text={repoName} placement={'top'}>
+              <p className="break-all text-label-title pt-0.5">
+                {repoName.slice(0, 37)}...
+              </p>
+            </Tooltip>
+          ) : (
+            <p className="break-all text-label-title pt-0.5">{repoName}</p>
+          )}
         </div>
         <div className="opacity-0 group-hover:opacity-100 focus-within:opacity-100 transition-all duration-150">
           <Dropdown


### PR DESCRIPTION
If the repo name is longer than 40 chars we cut it and show ... + a tooltip with full name