### PR TITLE
add repo sync analytics

### DIFF
--- a/server/bleep/src/background/sync.rs
+++ b/server/bleep/src/background/sync.rs
@@ -19,7 +19,7 @@ pub struct SyncHandle {
     pub(crate) filter_updates: FilterUpdate,
     pub(crate) pipes: SyncPipes,
     pub(crate) file_cache: FileCache,
-    app: Application,
+    pub(crate) app: Application,
     exited: flume::Sender<SyncStatus>,
     exit_signal: flume::Receiver<SyncStatus>,
 }

--- a/server/bleep/src/indexes.rs
+++ b/server/bleep/src/indexes.rs
@@ -79,6 +79,7 @@ pub struct Indexes {
     pub repo: Indexer<Repo>,
     pub file: Indexer<File>,
     pub doc: Doc,
+    was_index_reset: bool,
     write_mutex: tokio::sync::Mutex<()>,
 }
 
@@ -104,7 +105,13 @@ impl Indexes {
                 config.max_threads,
             )?,
             write_mutex: Default::default(),
+            was_index_reset: false,
         })
+    }
+
+    pub fn was_index_reset(mut self, was_index_reset: bool) -> Self {
+        self.was_index_reset = was_index_reset;
+        self
     }
 
     pub fn reset_databases(config: &Configuration) -> Result<()> {

--- a/server/bleep/src/indexes.rs
+++ b/server/bleep/src/indexes.rs
@@ -10,6 +10,7 @@ use tantivy::{
     DocAddress, Document, IndexReader, IndexWriter, Score,
 };
 
+mod analytics;
 pub mod doc;
 pub mod file;
 pub mod reader;
@@ -84,7 +85,11 @@ pub struct Indexes {
 }
 
 impl Indexes {
-    pub async fn new(config: &Configuration, sql: crate::SqlDb) -> Result<Self> {
+    pub async fn new(
+        config: &Configuration,
+        sql: crate::SqlDb,
+        was_index_reset: bool,
+    ) -> Result<Self> {
         Ok(Self {
             repo: Indexer::create(
                 Repo::new(),
@@ -105,13 +110,8 @@ impl Indexes {
                 config.max_threads,
             )?,
             write_mutex: Default::default(),
-            was_index_reset: false,
+            was_index_reset,
         })
-    }
-
-    pub fn was_index_reset(mut self, was_index_reset: bool) -> Self {
-        self.was_index_reset = was_index_reset;
-        self
     }
 
     pub fn reset_databases(config: &Configuration) -> Result<()> {

--- a/server/bleep/src/indexes/analytics.rs
+++ b/server/bleep/src/indexes/analytics.rs
@@ -1,0 +1,120 @@
+use crate::{analytics::RepoEvent, repo::RepoRef};
+use tokio::{sync::mpsc, time::Instant};
+
+#[derive(Default)]
+pub struct WorkerStats {
+    // size in bytes
+    pub size: usize,
+    // number of qdrant chunkc
+    pub chunks: usize,
+    // number of dir-entries reindexed by this worker
+    pub reindex_count: usize,
+}
+
+impl std::ops::AddAssign for WorkerStats {
+    fn add_assign(&mut self, rhs: Self) {
+        self.size += rhs.size;
+        self.chunks += rhs.chunks;
+        self.reindex_count += rhs.reindex_count;
+    }
+}
+
+#[derive(serde::Serialize, Clone, Copy, PartialEq, Eq)]
+enum IndexJobKind {
+    Index,
+    PeriodicSync { reindex_file_count: usize },
+    SchemaUpgrade { reindex_file_count: usize },
+}
+
+// the main entrypoint into gathering analytics for an index job
+pub struct StatsGatherer {
+    // reciever of stats from worker threads
+    stats_rx: mpsc::UnboundedReceiver<WorkerStats>,
+    // pass this along to each worker thread
+    stats_tx: mpsc::UnboundedSender<WorkerStats>,
+    // the reporef of the target index job
+    reporef: RepoRef,
+    // the moment this job began
+    start_time: Instant,
+    // set to true if this is the first index of this reporef
+    pub is_first_index: bool,
+    // set to true if the index was reset on startup
+    pub was_index_reset: bool,
+    // gather analytics events into this `event` field
+    pub event: RepoEvent,
+    // combine stats from each worker thread into `repo_stats`
+    pub repo_stats: WorkerStats,
+}
+
+impl StatsGatherer {
+    pub fn for_repo(reporef: RepoRef) -> Self {
+        let (stats_tx, stats_rx) = mpsc::unbounded_channel();
+        Self {
+            stats_rx,
+            stats_tx,
+            event: RepoEvent::new("index"),
+            reporef,
+            is_first_index: false,
+            was_index_reset: false,
+            start_time: Instant::now(),
+            repo_stats: WorkerStats::default(),
+        }
+    }
+
+    pub fn sender(&self) -> mpsc::UnboundedSender<WorkerStats> {
+        self.stats_tx.clone()
+    }
+
+    #[rustfmt::skip]
+    pub async fn finish(mut self) -> RepoEvent {
+        // aggregate stats
+        self.stats_rx.close();
+        while let Some(stats) = self.stats_rx.recv().await {
+            self.repo_stats += stats;
+        }
+
+        // determine the type of index job run
+        //
+        let job_kind = if self.was_index_reset {
+            IndexJobKind::SchemaUpgrade {
+                reindex_file_count: self.repo_stats.reindex_count,
+            }
+        } else if self.is_first_index {
+            IndexJobKind::Index
+        } else {
+            IndexJobKind::PeriodicSync {
+                reindex_file_count: self.repo_stats.reindex_count,
+            }
+        };
+
+        self.event.add_payload("reporef", &self.reporef.name());
+        self.event.add_payload("provider", &self.reporef.backend());
+        self.event.add_payload("index_job_kind", &job_kind);
+        self.event.add_payload("chunk_count", &self.repo_stats.chunks);
+        self.event.add_payload("bytes", &human_readable(self.repo_stats.size));
+        self.event.add_payload("sync_time", &format!("{:?}", self.start_time.elapsed()));
+        self.event
+    }
+}
+
+fn human_readable(size: usize) -> String {
+    let suffixes = ["B", "KB", "MB", "GB"];
+    let s = suffixes
+        .iter()
+        .zip(0..10)
+        .rev()
+        .map(|(suf, exp)| (suf, size as f64 / (1024_f64.powi(exp))))
+        .find(|(_, t)| t >= &1.0);
+    s.map(|(suffix, value)| format!("{value:.2}{suffix}"))
+        .unwrap_or_else(|| size.to_string())
+}
+
+#[cfg(test)]
+mod test {
+    #[test]
+    fn human_readable() {
+        assert_eq!(super::human_readable(15), "15.00B");
+        assert_eq!(super::human_readable(1024), "1.00KB");
+        assert_eq!(super::human_readable(7616597515), "7.09GB");
+    }
+}

--- a/server/bleep/src/indexes/file.rs
+++ b/server/bleep/src/indexes/file.rs
@@ -199,9 +199,11 @@ impl Indexable for File {
 
         // aggregate stats
         drop(worker_stats_tx);
-        let mut repo_stats = WorkerStats::default();
-        repo_stats.is_first_index = is_first_index;
-        repo_stats.was_index_reset = app.indexes.was_index_reset;
+        let mut repo_stats = WorkerStats {
+            is_first_index,
+            was_index_reset: app.indexes.was_index_reset,
+            ..Default::default()
+        };
         while let Ok(Some(stats)) =
             tokio::time::timeout(Duration::from_millis(10), worker_stats_rx.recv()).await
         {

--- a/server/bleep/src/lib.rs
+++ b/server/bleep/src/lib.rs
@@ -154,9 +154,10 @@ impl Application {
                 .context("qdrant initialization failed")?;
 
         // Wipe existing dbs & caches if the schema has changed
+        let mut was_index_reset = false;
         if config.source.index_version_mismatch() {
             debug!("schema version mismatch, resetting state");
-
+            was_index_reset = true;
             Indexes::reset_databases(&config)?;
             debug!("tantivy indexes deleted");
 
@@ -173,7 +174,10 @@ impl Application {
         config.source.save_index_version()?;
         debug!("index version saved");
 
-        let indexes = Indexes::new(&config, sql.clone()).await?.into();
+        let indexes = Indexes::new(&config, sql.clone())
+            .await?
+            .was_index_reset(dbg!(was_index_reset))
+            .into();
         debug!("indexes initialized");
 
         // Enforce capabilies and features depending on environment

--- a/server/bleep/src/lib.rs
+++ b/server/bleep/src/lib.rs
@@ -174,9 +174,8 @@ impl Application {
         config.source.save_index_version()?;
         debug!("index version saved");
 
-        let indexes = Indexes::new(&config, sql.clone())
+        let indexes = Indexes::new(&config, sql.clone(), was_index_reset)
             .await?
-            .was_index_reset(dbg!(was_index_reset))
             .into();
         debug!("indexes initialized");
 

--- a/server/bleep/src/repo/iterator.rs
+++ b/server/bleep/src/repo/iterator.rs
@@ -83,6 +83,13 @@ pub struct RepoDir {
     pub branches: Vec<String>,
 }
 
+impl RepoDir {
+    pub fn size(&self) -> usize {
+        use std::io::{Cursor, Seek, SeekFrom};
+        Cursor::new(&self.path).seek(SeekFrom::End(0)).unwrap_or(0) as usize
+    }
+}
+
 pub struct RepoFile {
     /// Path to file
     pub path: String,
@@ -101,6 +108,10 @@ impl RepoFile {
 
     pub fn buffer(&self) -> std::io::Result<String> {
         (self.buffer)()
+    }
+
+    pub fn size(&self) -> usize {
+        self.len as usize
     }
 }
 


### PR DESCRIPTION
tracks repo metadata on first index, or on full reindex (when the tantivy index hash is updated, for example), includes the following info:

- repo ref
- repo provider
- size in bytes
- number of qdrant chunks
- time taken to index

sample event:

    RepoEvent {
        name: "index",
        payload: [
            ("repo_ref", String("nerdypepper/dijo")),
            ("provider", String("github")),
            ("file_count", Number(35)),
            ("chunk_count", Number(236)),
            ("bytes", String("116.59KB")),
            ("sync_time", String("4.957807429s")),
        ],
    }

---

to test this changeset, set the following values in `local_config.json`:

    {
        "analytics_key": "..",
        "analytics_data_plane": ".."
    }

run rudderstack in "live event stream" mode, and index a repository.