### PR TITLE
Fix breadcrumbs in doc search modal

### DIFF
--- a/client/src/pages/StudioTab/AddDocsModal/PagesWithPreview/index.tsx
+++ b/client/src/pages/StudioTab/AddDocsModal/PagesWithPreview/index.tsx
@@ -134,25 +134,27 @@ const PagesWithPreview = ({
                   setHighlightedIndex={setHighlightedIndex}
                   handleDocSubmit={handleSelectSection}
                   displayTitle={
-                    <Tooltip
-                      placement="top-start"
-                      text={constructSectionTitle(
-                        s.doc_title,
-                        s.ancestry,
-                        s.header,
-                      )}
-                    >
-                      <BreadcrumbsPath
-                        path={constructSectionTitle(
+                    <div className="w-full overflow-hidden">
+                      <Tooltip
+                        placement="top-start"
+                        text={constructSectionTitle(
                           s.doc_title,
                           s.ancestry,
                           s.header,
                         )}
-                        repo={''}
-                        limitSectionWidth
-                        nonInteractive
-                      />
-                    </Tooltip>
+                      >
+                        <BreadcrumbsPath
+                          path={constructSectionTitle(
+                            s.doc_title,
+                            s.ancestry,
+                            s.header,
+                          )}
+                          repo={''}
+                          limitSectionWidth
+                          nonInteractive
+                        />
+                      </Tooltip>
+                    </div>
                   }
                   doc_title={s.doc_title}
                   i={i}


### PR DESCRIPTION
Currently, the breadcrumbs when searching for a doc section can overflow its container and make it hard to read. Fix: enclose breadcrumbs in a container with overflow: hidden so that breadcrumbs can correctly calculate how many sections can fit. The space is still a bit limited but hiding middle sections should improve the UX