### PR TITLE
permit all docs to contribute metadata

### DIFF
--- a/server/bleep/src/indexes/doc.rs
+++ b/server/bleep/src/indexes/doc.rs
@@ -210,7 +210,7 @@ impl Doc {
         // set favicon
         if let Some(favicon) = &metadata.icon {
             let resolved_url = url::Url::parse(favicon)
-                .unwrap_or_else(|_| normalize_absolute_url(&doc_source, favicon));
+                .unwrap_or_else(|_| normalize_absolute_url(doc_source, favicon));
             if let Err(e) = self.set_favicon(resolved_url.as_str(), id, executor).await {
                 error!(%e, %favicon, %id, "failed to set doc icon");
             } else {


### PR DESCRIPTION
documents that failed to parse into markdown were typically ejected from the stream, and were therefore unable to contribute metadata in the form of page titles & document count. now, they contribute metadata and are subsequently ejected from the stream.

this scenario previously had strange side-effects with https://stripe.com/docs, where the metadata was scraped from the next available page, and setting random page titles instead of "Stripe Documentation.

<a href="https://gitpod.io/#https://github.com/BloopAI/bloop/pull/1124"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

