### PR TITLE
Log message with context for Quota/Answer API call failures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5847,9 +5847,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest-eventsource"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f03f570355882dd8d15acc3a313841e6e90eddbc76a93c748fd82cc13ba9f51"
+checksum = "f529a5ff327743addc322af460761dff5b50e0c826b9e6ac44c3195c50bb2026"
 dependencies = [
  "eventsource-stream",
  "futures-core",

--- a/server/bleep/Cargo.toml
+++ b/server/bleep/Cargo.toml
@@ -97,7 +97,7 @@ tower-http = { version = "0.4.4", features = ["auth", "cors", "catch-panic", "fs
 # api integrations
 octocrab = { version = "0.25.1", features = ["rustls", "rustls-webpki-tokio"] }
 reqwest = { version = "0.11.20", features = ["rustls-tls-webpki-roots", "cookies", "gzip"], default-features = false }
-reqwest-eventsource = "0.4.0"
+reqwest-eventsource = "0.5.0"
 secrecy = { version = "0.8.0", features = ["serde"] }
 
 # file processing


### PR DESCRIPTION
Now, we correctly propagate errors up when either:

- The LLM gateway fails to open a stream
- The quota API returns unexpected JSON content
  - In this case, the original body is forwarded in an error for further examination

Closes BLO-1599