### PR TITLE
reindex events are not sent unless stats are collected

### DIFF
--- a/server/bleep/src/indexes/file.rs
+++ b/server/bleep/src/indexes/file.rs
@@ -202,9 +202,10 @@ impl Indexable for File {
 
         info!(?repo.disk_path, "repo file indexing finished, took {:?}", start.elapsed());
 
+        stats_gatherer.finish().await;
         if stats_gatherer.repo_stats.reindex_count > 0 {
             let user = app.user().await;
-            let event = stats_gatherer.finish().await;
+            let event = stats_gatherer.event();
             app.with_analytics(|hub| hub.track_repo(event, &user));
         }
 


### PR DESCRIPTION
index-stats must be consolidated before making a check for whether or not the analytics event must be sent.