### PR TITLE
Better notifications on startup failure

### DIFF
--- a/apps/desktop/src-tauri/src/backend.rs
+++ b/apps/desktop/src-tauri/src/backend.rs
@@ -2,6 +2,8 @@ use bleep::{analytics, Application, Configuration, Environment};
 use tracing::error;
 
 use super::{config::get_device_id, Manager, Payload, Runtime};
+use std::thread;
+use std::time::Duration;
 
 #[tauri::command]
 pub fn get_last_log_file(config: tauri::State<Configuration>) -> Option<String> {
@@ -72,6 +74,7 @@ async fn start_backend<R: Runtime>(configuration: Configuration, app: tauri::App
     if let Err(err) = wait_for_qdrant().await {
         error!(?err, "bad bad qdrant not running now");
         sentry_anyhow::capture_anyhow(&err);
+        thread::sleep(Duration::from_secs(4));
         app.emit_all(
             "server-crashed",
             Payload {

--- a/apps/desktop/src-tauri/src/backend.rs
+++ b/apps/desktop/src-tauri/src/backend.rs
@@ -57,7 +57,7 @@ async fn wait_for_qdrant() -> anyhow::Result<()> {
     let qdrant =
         QdrantClient::new(Some(QdrantClientConfig::from_url("http://127.0.0.1:6334"))).unwrap();
 
-    for _ in 0..3 {
+    for _ in 0..35 {
         if qdrant.health_check().await.is_ok() {
             return Ok(());
         }
@@ -72,13 +72,13 @@ async fn start_backend<R: Runtime>(configuration: Configuration, app: tauri::App
     tracing::info!("booting bleep back-end");
 
     if let Err(err) = wait_for_qdrant().await {
-        error!(?err, "bad bad qdrant not running now");
+        error!(?err, "qdrant failed to come up");
         sentry_anyhow::capture_anyhow(&err);
         thread::sleep(Duration::from_secs(4));
         app.emit_all(
             "server-crashed",
             Payload {
-                message: "Something bad happened".into(),
+                message: "Failed to start qdrant".into(),
             },
         )
         .unwrap();

--- a/apps/desktop/src-tauri/src/qdrant.rs
+++ b/apps/desktop/src-tauri/src/qdrant.rs
@@ -55,16 +55,16 @@ where
         )
         .unwrap();
 
-        let command = relative_command_path("qdrant").expect("bad bundle");
+        // let command = relative_command_path("qdrant").expect("bad bundle");
 
-        self.stdout_file = Some(stdout_file.clone());
-        self.stderr_file = Some(stderr_file.clone());
-        self.child = Some(run_command(
-            &command,
-            &qdrant_dir,
-            &stdout_file,
-            &stderr_file,
-        ));
+        // self.stdout_file = Some(stdout_file.clone());
+        // self.stderr_file = Some(stderr_file.clone());
+        // self.child = Some(run_command(
+        //     &command,
+        //     &qdrant_dir,
+        //     &stdout_file,
+        //     &stderr_file,
+        // ));
 
         Ok(())
     }

--- a/apps/desktop/src-tauri/src/qdrant.rs
+++ b/apps/desktop/src-tauri/src/qdrant.rs
@@ -55,16 +55,16 @@ where
         )
         .unwrap();
 
-        // let command = relative_command_path("qdrant").expect("bad bundle");
+        let command = relative_command_path("qdrant").expect("bad bundle");
 
-        // self.stdout_file = Some(stdout_file.clone());
-        // self.stderr_file = Some(stderr_file.clone());
-        // self.child = Some(run_command(
-        //     &command,
-        //     &qdrant_dir,
-        //     &stdout_file,
-        //     &stderr_file,
-        // ));
+        self.stdout_file = Some(stdout_file.clone());
+        self.stderr_file = Some(stderr_file.clone());
+        self.child = Some(run_command(
+            &command,
+            &qdrant_dir,
+            &stdout_file,
+            &stderr_file,
+        ));
 
         Ok(())
     }

--- a/apps/desktop/src/SplashScreen.tsx
+++ b/apps/desktop/src/SplashScreen.tsx
@@ -12,7 +12,7 @@ const SplashScreen = ({}: Props) => {
       animate={{ opacity: 1 }}
       exit={{ opacity: 0 }}
       key="splash"
-      className="w-screen h-screen flex items-center justify-center bg-bg-sub fixed top-0 left-0 z-[1000]"
+      className="w-screen h-screen flex items-center justify-center bg-bg-sub fixed top-0 left-0 z-10"
     >
       <div className="w-99 rounded-xl border border-bg-border bg-bg-base px-12 py-20 relative animate-pulse-shadow-slow z-0">
         <div


### PR DESCRIPTION
Reduce qdrant wait times to 35s, and fix the frontend handling of messages coming through early in the startup process.