### PR TITLE
Automatically open bloop app after authentication with GitHub

### DIFF
--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -42,10 +42,28 @@ fn main() {
         .setup(backend::initialize)
         .invoke_handler(tauri::generate_handler![
             show_folder_in_finder,
+            show_main_window,
             backend::get_last_log_file,
         ])
         .run(tauri::generate_context!())
         .expect("error running tauri application");
+}
+
+#[tauri::command]
+fn show_main_window(app_handle: tauri::AppHandle) {
+    match app_handle.get_window("main") {
+        Some(window) => {
+            if !cfg!(target_os = "macos") {
+                window.unminimize().unwrap();
+            }
+            window.unminimize().unwrap();
+            window.set_focus().unwrap();
+            window.show().unwrap();
+        }
+        None => {
+
+        }
+    }
 }
 
 #[tauri::command]

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -60,9 +60,7 @@ fn show_main_window(app_handle: tauri::AppHandle) {
             window.set_focus().unwrap();
             window.show().unwrap();
         }
-        None => {
-
-        }
+        None => {}
     }
 }
 

--- a/client/src/pages/Onboarding/Desktop/UserForm/Step2.tsx
+++ b/client/src/pages/Onboarding/Desktop/UserForm/Step2.tsx
@@ -24,7 +24,8 @@ const UserFormStep2 = ({ onContinue }: Props) => {
   const { isGithubConnected, setGithubConnected } = useContext(
     UIContext.GitHubConnected,
   );
-  const { envConfig, openLink, setEnvConfig } = useContext(DeviceContext);
+  const { envConfig, openLink, setEnvConfig, invokeTauriCommand } =
+    useContext(DeviceContext);
   const [isTimedOut, setIsTimedOut] = useState(false);
   const [isBtnClicked, setBtnClicked] = useState(false);
   const [loginUrl, setLoginUrl] = useState('');
@@ -84,6 +85,7 @@ const UserFormStep2 = ({ onContinue }: Props) => {
         () =>
           checkGHAuth().then((d) => {
             if (!!d.user_login) {
+              invokeTauriCommand('show_main_window');
               onContinue();
             }
           }),


### PR DESCRIPTION
To improve the user experience when signing in with GitHub we now will re-open and focus bloop app once the user is authenticated on the FE. Tried using a couple of JS APIs from Tauri - all working unreliably or not working at all. The only solution that seems to work is focusing the window from the Rust side. For it to work there is now a new Tauri command that can be invoked from the FE when onboarding is closed.