### PR TITLE
Hybrid search (lexical + semantic) merged with RRF

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -510,6 +510,7 @@ dependencies = [
  "histogram",
  "hyperpolyglot",
  "ignore",
+ "itertools 0.10.5",
  "jsonwebtoken",
  "jwt-authorizer",
  "lazy-regex",

--- a/server/bleep/Cargo.toml
+++ b/server/bleep/Cargo.toml
@@ -114,6 +114,8 @@ gix = { git = "https://github.com/BloopAI/gitoxide", version="0.55.2", features 
 qdrant-client = { version = "1.5.0", default-features = false }
 tiktoken-rs = "0.4.5"
 tokenizers = { version = "0.14.0", default-features = false, features = ["progressbar", "cli", "onig", "esaxx_fast"] }
+itertools = "0.10.0"
+
 
 # answer parsing
 # We use the git version here, so that we can pull in recent changes that make footnotes work. The

--- a/server/bleep/src/semantic/schema.rs
+++ b/server/bleep/src/semantic/schema.rs
@@ -81,11 +81,11 @@ pub(super) async fn create_lexical_index(
     qdrant
         .create_field_index(
             name.to_string(),
-            "text",
+            "snippet",
             FieldType::Text,
             Some(&PayloadIndexParams {
                 index_params: Some(IndexParams::TextIndexParams(TextIndexParams {
-                    tokenizer: 0,
+                    tokenizer: 3,
                     lowercase: Some(true),
                     min_token_len: Some(2),
                     max_token_len: Some(20),

--- a/server/bleep/src/semantic/schema.rs
+++ b/server/bleep/src/semantic/schema.rs
@@ -3,11 +3,11 @@
 //!
 use qdrant_client::{
     prelude::QdrantClient,
+    qdrant::payload_index_params::IndexParams,
     qdrant::{
-        vectors_config, CollectionOperationResponse, CreateCollection, Distance, VectorParams,
-        VectorsConfig, FieldType, TextIndexParams, PointsOperationResponse, PayloadIndexParams, 
+        vectors_config, CollectionOperationResponse, CreateCollection, Distance, FieldType,
+        PayloadIndexParams, PointsOperationResponse, TextIndexParams, VectorParams, VectorsConfig,
     },
-    qdrant::payload_index_params::IndexParams
 };
 
 pub(super) const EMBEDDING_DIM: usize = 384;
@@ -74,20 +74,24 @@ pub(super) async fn create_collection(
         .await
 }
 
-
 pub(super) async fn create_lexical_index(
     name: &str,
     qdrant: &QdrantClient,
 ) -> anyhow::Result<PointsOperationResponse> {
-    qdrant.create_field_index(name.to_string(),
-     "text", 
-     FieldType::Text,
-     Some(&PayloadIndexParams{index_params: 
-        Some(IndexParams::TextIndexParams(TextIndexParams{
-            tokenizer: 0,
-            lowercase: Some(true),
-            min_token_len: Some(2),
-            max_token_len: Some(20)}))}),
-    None).await
-        
+    qdrant
+        .create_field_index(
+            name.to_string(),
+            "text",
+            FieldType::Text,
+            Some(&PayloadIndexParams {
+                index_params: Some(IndexParams::TextIndexParams(TextIndexParams {
+                    tokenizer: 0,
+                    lowercase: Some(true),
+                    min_token_len: Some(2),
+                    max_token_len: Some(20),
+                })),
+            }),
+            None,
+        )
+        .await
 }

--- a/server/bleep/src/semantic/schema.rs
+++ b/server/bleep/src/semantic/schema.rs
@@ -85,7 +85,7 @@ pub(super) async fn create_lexical_index(
             FieldType::Text,
             Some(&PayloadIndexParams {
                 index_params: Some(IndexParams::TextIndexParams(TextIndexParams {
-                    tokenizer: 3, // word tokenizer 
+                    tokenizer: 3, // word tokenizer
                     lowercase: Some(true),
                     min_token_len: Some(2),
                     max_token_len: Some(20),

--- a/server/bleep/src/semantic/schema.rs
+++ b/server/bleep/src/semantic/schema.rs
@@ -85,7 +85,7 @@ pub(super) async fn create_lexical_index(
             FieldType::Text,
             Some(&PayloadIndexParams {
                 index_params: Some(IndexParams::TextIndexParams(TextIndexParams {
-                    tokenizer: 3,
+                    tokenizer: 3, // word tokenizer 
                     lowercase: Some(true),
                     min_token_len: Some(2),
                     max_token_len: Some(20),

--- a/server/bleep/src/semantic/schema.rs
+++ b/server/bleep/src/semantic/schema.rs
@@ -75,7 +75,7 @@ pub(super) async fn create_collection(
 }
 
 
-pub(super) async fn create_lexixal_index(
+pub(super) async fn create_lexical_index(
     name: &str,
     qdrant: &QdrantClient,
 ) -> anyhow::Result<PointsOperationResponse> {

--- a/server/bleep/src/semantic/schema.rs
+++ b/server/bleep/src/semantic/schema.rs
@@ -5,8 +5,9 @@ use qdrant_client::{
     prelude::QdrantClient,
     qdrant::{
         vectors_config, CollectionOperationResponse, CreateCollection, Distance, VectorParams,
-        VectorsConfig,
+        VectorsConfig, FieldType, TextIndexParams, PointsOperationResponse, PayloadIndexParams, 
     },
+    qdrant::payload_index_params::IndexParams
 };
 
 pub(super) const EMBEDDING_DIM: usize = 384;
@@ -71,4 +72,22 @@ pub(super) async fn create_collection(
             ..Default::default()
         })
         .await
+}
+
+
+pub(super) async fn create_lexixal_index(
+    name: &str,
+    qdrant: &QdrantClient,
+) -> anyhow::Result<PointsOperationResponse> {
+    qdrant.create_field_index(name.to_string(),
+     "text", 
+     FieldType::Text,
+     Some(&PayloadIndexParams{index_params: 
+        Some(IndexParams::TextIndexParams(TextIndexParams{
+            tokenizer: 0,
+            lowercase: Some(true),
+            min_token_len: Some(2),
+            max_token_len: Some(20)}))}),
+    None).await
+        
 }


### PR DESCRIPTION
Hybrid search replaces semantic search with a mix between semantic search results and lexical search results Results are merged using reciprocal rank fusion (RRF).

To be able to merge results, each search (semantic and lexical) have to operate on the same documents. Here the documents are code snippets and to makes things easier, we use Qdrant as vector and snippet DB/index manager.

Wdrant lexical search does not rank lexical results based on known algorithms (tf-idf, bm25). So we rerank lexical results using word counts and number of query unique words matched.

This PR:

- Creates Qdrant snippet index (https://qdrant.tech/documentation/concepts/indexing/#full-text-index) using a word tokenizer
- creates a Qdrant lexical search function
- creates a rerank lexical results function
- creates a "merge semantic and lexical results with RRF" function
- changes search to perform hybrid search