### PR TITLE
Save user preferred font size in local storage

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -25,6 +25,7 @@ import {
   getPlainFromStorage,
   LANGUAGE_KEY,
   savePlainToStorage,
+  USER_FONT_SIZE_KEY,
 } from '../../../client/src/services/storage';
 import { LocaleType } from '../../../client/src/types/general';
 import { polling } from '../../../client/src/utils/requestUtils';
@@ -165,11 +166,24 @@ function App() {
         .getPropertyValue('font-size');
       const fontSize = parseFloat(style);
 
-      (root as HTMLElement).style.fontSize =
-        (e.key === '0' ? 16 : fontSize + (e.key === '=' ? 1 : -1)) + 'px';
+      const newFontSize =
+        e.key === '0' ? 16 : fontSize + (e.key === '=' ? 1 : -1);
+      (root as HTMLElement).style.fontSize = newFontSize + 'px';
+      savePlainToStorage(USER_FONT_SIZE_KEY, newFontSize);
     }
   }, []);
   useKeyboardNavigation(handleKeyEvent);
+
+  useEffect(() => {
+    const root = document.querySelector(':root');
+    if (!root) {
+      return;
+    }
+    const newFontSize = getPlainFromStorage(USER_FONT_SIZE_KEY);
+    if (newFontSize) {
+      (root as HTMLElement).style.fontSize = newFontSize + 'px';
+    }
+  }, []);
 
   useEffect(() => {
     let intervalId: number;

--- a/client/src/services/storage.ts
+++ b/client/src/services/storage.ts
@@ -37,3 +37,4 @@ export const ANSWER_SPEED_KEY = 'answer_speed_key';
 export const HIDE_TUTORIALS_KEY = 'hide_tutorials';
 export const ACCESS_TOKEN_KEY = 'access_token';
 export const REFRESH_TOKEN_KEY = 'refresh_token';
+export const USER_FONT_SIZE_KEY = 'user_font_size';


### PR DESCRIPTION
To persist font size across sessions we now save font size in local storage (can be changed by pressing ctrl/cmd +/-/0)