### PR TITLE
Assorted search fixes

### DIFF
--- a/server/bleep/src/agent/prompts.rs
+++ b/server/bleep/src/agent/prompts.rs
@@ -108,7 +108,7 @@ pub fn system<'a>(paths: impl IntoIterator<Item = &'a str>) -> String {
 - When calling functions.path your query should be a single term (no whitespace). E.g. if the user says 'Where is the query parser?', your query should be 'parser'. If the users says 'What's in the auth dir?', your query should be 'auth'
 - If the output of a function is empty, try calling the function again with DIFFERENT arguments OR try calling a different function
 - Only call functions.proc with path indices that are under the PATHS heading above
-- Call functions.proc with paths that might contain relevant information. Either because of the path name, or to expand on code that's been returned by functions.code
+- Call functions.proc with paths that might contain relevant information. Either because of the path name or to expand on a chunk returned by functions.code. For example, if a chunk contains a reference to a term in the query, you might want to call functions.proc with the path of the chunk
 - ALWAYS call a function. DO NOT answer the question directly"#);
     s
 }

--- a/server/bleep/src/agent/tools/proc.rs
+++ b/server/bleep/src/agent/tools/proc.rs
@@ -31,7 +31,7 @@ impl Agent {
         .await?;
 
         let results = self
-            .semantic_search(query.into(), paths.clone(), 20, 0, 0.0, true)
+            .semantic_search(query.into(), paths.clone(), 10, 0, 0.0, true)
             .await?;
 
         let mut chunks = results

--- a/server/bleep/src/semantic.rs
+++ b/server/bleep/src/semantic.rs
@@ -900,11 +900,11 @@ pub fn deduplicate_with_mmr(
             let mut equation_score = lambda * first_part - (1. - lambda) * second_part;
 
             // MMR + (1/2)^n where n is the number of times a language has been selected
-            let lang_count = lang_counts.get(languages[i]).unwrap_or(&0);
+            let lang_count = lang_counts.get(languages[i]).unwrap_or(&1);
             equation_score += 0.5_f32.powi(*lang_count);
 
             // MMR + (3/4)^n where n is the number of times a path has been selected
-            let path_count = path_counts.get(paths[i]).unwrap_or(&0);
+            let path_count = path_counts.get(paths[i]).unwrap_or(&1);
             equation_score += 0.75_f32.powi(*path_count);
 
             if equation_score > best_score {


### PR DESCRIPTION
- Tweak agent prompt
- Reduce the number of code chunks returned by `proc`. Returning `20` would sometimes lead `proc` results to immediately be `[HIDDEN]`
- Fix default values for MMR factors