### PR TITLE
Update `semantic` log levels

### DIFF
--- a/server/bleep/src/lib.rs
+++ b/server/bleep/src/lib.rs
@@ -425,7 +425,7 @@ fn tracing_subscribe(config: &Configuration) -> bool {
                 Targets::new()
                     .with_target("bleep", LevelFilter::DEBUG)
                     .with_target("bleep::indexes::file", LevelFilter::WARN)
-                    .with_target("bleep::semantic", LevelFilter::WARN),
+                    .with_target("bleep::semantic", LevelFilter::DEBUG),
             )
     });
 

--- a/server/bleep/src/semantic.rs
+++ b/server/bleep/src/semantic.rs
@@ -16,7 +16,7 @@ use qdrant_client::{
 use futures::{stream, StreamExt, TryStreamExt};
 use rayon::prelude::*;
 use thiserror::Error;
-use tracing::{debug, error, info, warn};
+use tracing::{debug, error, info, trace, warn};
 
 pub mod chunk;
 pub mod embedder;
@@ -593,7 +593,7 @@ impl Semantic {
         .into_iter()
         .collect::<anyhow::Result<Vec<_>>>()?;
 
-        tracing::trace!(?parsed_queries, "performing qdrant batch search");
+        trace!(?parsed_queries, "performing qdrant batch search");
 
         let result = self
             .batch_search_with(
@@ -605,7 +605,7 @@ impl Semantic {
             )
             .await;
 
-        tracing::trace!(?result, "qdrant batch search returned");
+        trace!(?result, "qdrant batch search returned");
 
         let results = result?
             .into_iter()
@@ -640,7 +640,7 @@ impl Semantic {
             MIN_CHUNK_TOKENS..self.config.max_chunk_tokens,
             chunk::OverlapStrategy::default(),
         );
-        debug!(chunk_count = chunks.len(), "found chunks");
+        trace!(chunk_count = chunks.len(), "found chunks");
 
         chunks.into_par_iter().map(move |chunk| {
             let data = format!("{repo_name}\t{relative_path}\n{}", chunk.data);

--- a/server/bleep/src/semantic/chunk.rs
+++ b/server/bleep/src/semantic/chunk.rs
@@ -8,7 +8,7 @@ use crate::text_range::{Point, TextRange};
 use clap::{builder::PossibleValue, ValueEnum};
 use serde::{Deserialize, Serialize};
 use tokenizers::Tokenizer;
-use tracing::{debug, error, warn};
+use tracing::{error, trace, warn};
 
 #[derive(Debug)]
 pub enum ChunkError {
@@ -192,7 +192,7 @@ fn add_token_range<'s>(
     }
 
     if is_noisy(&src[start_byte..end_byte]) {
-        debug!("skipping noisy chunk");
+        trace!("skipping noisy chunk");
         return;
     }
 
@@ -260,7 +260,7 @@ pub fn by_tokens<'s>(
     let max_tokens = token_bounds.end - DEDUCT_SPECIAL_TOKENS - repo_tokens;
     let max_newline_tokens = max_tokens * 3 / 4; //TODO: make this configurable
     let max_boundary_tokens = max_tokens * 7 / 8; //TODO: make this configurable
-    debug!("max tokens reduced to {max_tokens}");
+    trace!("max tokens reduced to {max_tokens}");
 
     let offsets_len = offsets.len() - 1;
     // remove the SEP token which has (0, 0) offsets for some reason


### PR DESCRIPTION
Write `DEBUG` level logs to file and lower noisy semantic operations to `trace`.