### PR TITLE
Tweak rlimits

### DIFF
--- a/apps/desktop/src-tauri/src/qdrant.rs
+++ b/apps/desktop/src-tauri/src/qdrant.rs
@@ -135,7 +135,7 @@ fn run_command(command: &Path, qdrant_dir: &Path, stdout: &Path, stderr: &Path) 
     let stderr_logs_file = File::create(stderr).unwrap();
 
     match getrlimit(Resource::RLIMIT_NOFILE) {
-        Ok((current_soft, current_hard)) if current_hard < 2048 => {
+        Ok((current_soft, current_hard)) if current_hard < 10000 => {
             if let Err(err) = setrlimit(Resource::RLIMIT_NOFILE, 10000, 10000) {
                 error!(
                     ?err,


### PR DESCRIPTION
Qdrant still crashes on startup with
```
Result::unwrap()` on an `Err` value: Os { code: 24, kind: Uncategorized, message: "Too many open files" }`
```
for some users. We currently raise the `rlimit` if we detect that it is below 2048. This PR relaxes this, raising the `rlimit` if we detect that it's lower than 10,000.

<a href="https://gitpod.io/#https://github.com/BloopAI/bloop/pull/1181"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

