### PR TITLE
rework sync logic for docs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7690,6 +7690,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]

--- a/server/bleep/Cargo.toml
+++ b/server/bleep/Cargo.toml
@@ -42,7 +42,7 @@ harness = false
 tantivy = { version = "0.21.0", features = ["mmap"] }
 tantivy-columnar = "0.2.0"
 tokio = { version = "1.32.0", features = ["macros", "process", "rt", "rt-multi-thread", "io-std", "io-util", "sync", "fs"] }
-tokio-stream = "0.1.14"
+tokio-stream = { version = "0.1.14", features = ["sync"]}
 async-trait = "0.1.73"
 async-stream = "0.3.5"
 flume = "0.10.14"

--- a/server/bleep/src/webserver.rs
+++ b/server/bleep/src/webserver.rs
@@ -62,11 +62,13 @@ pub async fn start(app: Application) -> anyhow::Result<()> {
             Router::new()
                 .route("/", get(docs::list)) // list all doc providers
                 .route("/search", get(docs::search)) // text search over doc providers
-                .route("/sync", get(docs::sync)) // index a new doc provider
+                .route("/enqueue", get(docs::enqueue)) // enqueue a new url to begin syncing
                 .route("/verify", get(docs::verify)) // verify if a doc url is valid
                 .route("/:id", get(docs::list_one)) // list a doc provider by id
                 .route("/:id", delete(docs::delete)) // delete a doc provider by id
                 .route("/:id/resync", get(docs::resync)) // resync a doc provider by id
+                .route("/:id/status", get(docs::status)) // query sync status of an existing doc source
+                .route("/:id/cancel", get(docs::cancel)) // cancel an index job
                 .route("/:id/search", get(docs::search_with_id)) // search/list sections of a doc provider
                 .route("/:id/list", get(docs::list_with_id)) // list pages of a doc provider
                 .route("/:id/fetch", get(docs::fetch)), // fetch all sections of a page of a doc provider


### PR DESCRIPTION
- replace `/sync` with `/enqueue`; a non-streaming replacement to add items to the doc-sync queue
- introduce `/status` and `/cancel`; to stream updates for a syncing document or to cancel a sync job
- convert `/resync` to http from sse
- internal updates to `/list` to work with the new queue system

--- 

i have dropped `TODO` comments in a few locations that require error handling; i will add these in a follow up PR:
- if a sync job fails (e.g.: zero docs were scraped); the join handle should be deleted and the progress should report that
- if a progress updated failed for some reason, we should be able to know so in sentry 

<a href="https://gitpod.io/#https://github.com/BloopAI/bloop/pull/1186"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

