### PR TITLE
Qdrant keyword path filter in proc

### DIFF
--- a/server/bleep/src/agent.rs
+++ b/server/bleep/src/agent.rs
@@ -340,7 +340,6 @@ impl Agent {
         Ok(history)
     }
 
-    #[allow(clippy::too_many_arguments)]
     async fn semantic_search(
         &self,
         query: parser::Literal<'_>,

--- a/server/bleep/src/agent.rs
+++ b/server/bleep/src/agent.rs
@@ -345,11 +345,7 @@ impl Agent {
         &self,
         query: parser::Literal<'_>,
         paths: Vec<String>,
-        limit: u64,
-        offset: u64,
-        threshold: f32,
-        retrieve_more: bool,
-        exact: bool,
+        params: semantic::SemanticSearchParams,
     ) -> Result<Vec<semantic::Payload>> {
         let paths_set = paths
             .into_iter()
@@ -394,21 +390,14 @@ impl Agent {
         };
 
         debug!(?query, %self.thread_id, "executing semantic query");
-        self.app
-            .semantic
-            .search(&query, limit, offset, threshold, retrieve_more, exact)
-            .await
+        self.app.semantic.search(&query, params).await
     }
 
     #[allow(dead_code)]
     async fn batch_semantic_search(
         &self,
         queries: Vec<parser::Literal<'_>>,
-        limit: u64,
-        offset: u64,
-        threshold: f32,
-        retrieve_more: bool,
-        exact: bool,
+        params: semantic::SemanticSearchParams,
     ) -> Result<Vec<semantic::Payload>> {
         let queries = queries
             .iter()
@@ -424,14 +413,7 @@ impl Agent {
         debug!(?queries, %self.thread_id, "executing semantic query");
         self.app
             .semantic
-            .batch_search(
-                queries.as_slice(),
-                limit,
-                offset,
-                threshold,
-                retrieve_more,
-                exact,
-            )
+            .batch_search(queries.as_slice(), params)
             .await
     }
 

--- a/server/bleep/src/agent.rs
+++ b/server/bleep/src/agent.rs
@@ -340,6 +340,7 @@ impl Agent {
         Ok(history)
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn semantic_search(
         &self,
         query: parser::Literal<'_>,
@@ -348,6 +349,7 @@ impl Agent {
         offset: u64,
         threshold: f32,
         retrieve_more: bool,
+        exact: bool,
     ) -> Result<Vec<semantic::Payload>> {
         let paths_set = paths
             .into_iter()
@@ -394,7 +396,7 @@ impl Agent {
         debug!(?query, %self.thread_id, "executing semantic query");
         self.app
             .semantic
-            .search(&query, limit, offset, threshold, retrieve_more)
+            .search(&query, limit, offset, threshold, retrieve_more, exact)
             .await
     }
 
@@ -406,6 +408,7 @@ impl Agent {
         offset: u64,
         threshold: f32,
         retrieve_more: bool,
+        exact: bool,
     ) -> Result<Vec<semantic::Payload>> {
         let queries = queries
             .iter()
@@ -421,7 +424,14 @@ impl Agent {
         debug!(?queries, %self.thread_id, "executing semantic query");
         self.app
             .semantic
-            .batch_search(queries.as_slice(), limit, offset, threshold, retrieve_more)
+            .batch_search(
+                queries.as_slice(),
+                limit,
+                offset,
+                threshold,
+                retrieve_more,
+                exact,
+            )
             .await
     }
 

--- a/server/bleep/src/agent/tools/code.rs
+++ b/server/bleep/src/agent/tools/code.rs
@@ -31,7 +31,7 @@ impl Agent {
                     limit: CODE_SEARCH_LIMIT,
                     offset: 0,
                     threshold: 0.3,
-                    exact_match: true,
+                    exact_match: false,
                 },
             )
             .await?;
@@ -52,7 +52,7 @@ impl Agent {
                             limit: CODE_SEARCH_LIMIT,
                             offset: 0,
                             threshold: 0.3,
-                            exact_match: true,
+                            exact_match: false,
                         },
                     )
                     .await?;

--- a/server/bleep/src/agent/tools/code.rs
+++ b/server/bleep/src/agent/tools/code.rs
@@ -23,7 +23,7 @@ impl Agent {
         .await?;
 
         let mut results = self
-            .semantic_search(query.into(), vec![], CODE_SEARCH_LIMIT, 0, 0.3, true)
+            .semantic_search(query.into(), vec![], CODE_SEARCH_LIMIT, 0, 0.3, true, false)
             .await?;
 
         debug!("returned {} results", results.len());
@@ -35,7 +35,7 @@ impl Agent {
             if !hyde_docs.is_empty() {
                 let hyde_doc = hyde_docs.first().unwrap().into();
                 let hyde_results = self
-                    .semantic_search(hyde_doc, vec![], CODE_SEARCH_LIMIT, 0, 0.3, true)
+                    .semantic_search(hyde_doc, vec![], CODE_SEARCH_LIMIT, 0, 0.3, true, false)
                     .await?;
 
                 debug!("returned {} HyDE results", results.len());

--- a/server/bleep/src/agent/tools/code.rs
+++ b/server/bleep/src/agent/tools/code.rs
@@ -8,6 +8,7 @@ use crate::{
     },
     analytics::EventData,
     llm_gateway,
+    semantic::SemanticSearchParams,
 };
 
 impl Agent {
@@ -23,7 +24,16 @@ impl Agent {
         .await?;
 
         let mut results = self
-            .semantic_search(query.into(), vec![], CODE_SEARCH_LIMIT, 0, 0.3, true, false)
+            .semantic_search(
+                query.into(),
+                vec![],
+                SemanticSearchParams {
+                    limit: CODE_SEARCH_LIMIT,
+                    offset: 0,
+                    threshold: 0.3,
+                    exact_match: true,
+                },
+            )
             .await?;
 
         debug!("returned {} results", results.len());
@@ -35,7 +45,16 @@ impl Agent {
             if !hyde_docs.is_empty() {
                 let hyde_doc = hyde_docs.first().unwrap().into();
                 let hyde_results = self
-                    .semantic_search(hyde_doc, vec![], CODE_SEARCH_LIMIT, 0, 0.3, true, false)
+                    .semantic_search(
+                        hyde_doc,
+                        vec![],
+                        SemanticSearchParams {
+                            limit: CODE_SEARCH_LIMIT,
+                            offset: 0,
+                            threshold: 0.3,
+                            exact_match: true,
+                        },
+                    )
                     .await?;
 
                 debug!("returned {} HyDE results", results.len());

--- a/server/bleep/src/agent/tools/path.rs
+++ b/server/bleep/src/agent/tools/path.rs
@@ -9,6 +9,7 @@ use crate::{
         Agent,
     },
     analytics::EventData,
+    semantic::SemanticSearchParams,
 };
 
 impl Agent {
@@ -34,7 +35,16 @@ impl Agent {
         // If there are no lexical results, perform a semantic search.
         if paths.is_empty() {
             let semantic_paths = self
-                .semantic_search(query.into(), vec![], 30, 0, 0.0, true, false)
+                .semantic_search(
+                    query.into(),
+                    vec![],
+                    SemanticSearchParams {
+                        limit: 30,
+                        offset: 0,
+                        threshold: 0.0,
+                        exact_match: false,
+                    },
+                )
                 .await?
                 .into_iter()
                 .map(|chunk| chunk.relative_path)

--- a/server/bleep/src/agent/tools/path.rs
+++ b/server/bleep/src/agent/tools/path.rs
@@ -34,7 +34,7 @@ impl Agent {
         // If there are no lexical results, perform a semantic search.
         if paths.is_empty() {
             let semantic_paths = self
-                .semantic_search(query.into(), vec![], 30, 0, 0.0, true)
+                .semantic_search(query.into(), vec![], 30, 0, 0.0, true, false)
                 .await?
                 .into_iter()
                 .map(|chunk| chunk.relative_path)

--- a/server/bleep/src/agent/tools/proc.rs
+++ b/server/bleep/src/agent/tools/proc.rs
@@ -7,6 +7,7 @@ use crate::{
         Agent,
     },
     analytics::EventData,
+    semantic::SemanticSearchParams,
 };
 
 impl Agent {
@@ -31,7 +32,16 @@ impl Agent {
         .await?;
 
         let results = self
-            .semantic_search(query.into(), paths.clone(), 10, 0, 0.0, true, true)
+            .semantic_search(
+                query.into(),
+                paths.clone(),
+                SemanticSearchParams {
+                    limit: 10,
+                    offset: 0,
+                    threshold: 0.0,
+                    exact_match: true,
+                },
+            )
             .await?;
 
         let mut chunks = results

--- a/server/bleep/src/agent/tools/proc.rs
+++ b/server/bleep/src/agent/tools/proc.rs
@@ -31,7 +31,7 @@ impl Agent {
         .await?;
 
         let results = self
-            .semantic_search(query.into(), paths.clone(), 10, 0, 0.0, true)
+            .semantic_search(query.into(), paths.clone(), 10, 0, 0.0, true, true)
             .await?;
 
         let mut chunks = results

--- a/server/bleep/src/semantic/execute.rs
+++ b/server/bleep/src/semantic/execute.rs
@@ -24,6 +24,7 @@ pub async fn execute(
             ((params.page + 1) * params.page_size) as u64,
             0.0,
             false,
+            false,
         )
         .await?;
 

--- a/server/bleep/src/semantic/execute.rs
+++ b/server/bleep/src/semantic/execute.rs
@@ -5,6 +5,7 @@ use crate::{
         execute::{ApiQuery, PagingMetadata, QueryResponse, QueryResult, ResultStats},
         parser::SemanticQuery,
     },
+    semantic::SemanticSearchParams,
     snippet::Snippet,
 };
 
@@ -20,11 +21,12 @@ pub async fn execute(
     let results = semantic
         .search(
             &query,
-            params.page_size as u64,
-            ((params.page + 1) * params.page_size) as u64,
-            0.0,
-            false,
-            false,
+            SemanticSearchParams {
+                limit: params.page_size as u64,
+                offset: ((params.page + 1) * params.page_size) as u64,
+                threshold: 0.0,
+                exact_match: false,
+            },
         )
         .await?;
 


### PR DESCRIPTION
We want to use a Qdrant `keyword` filter on `paths` when running `proc` to ensure that we only receive code snippets from the specified files. In all other cases, we want to use a `text` filter so that we can partially match path filters (e.g. so we can search within the directory `server/`)