### PR TITLE
Indexing status reporting improvements

### DIFF
--- a/server/bleep/src/background.rs
+++ b/server/bleep/src/background.rs
@@ -35,6 +35,8 @@ pub fn rayon_pool() -> &'static ThreadPool {
 pub struct Progress {
     #[serde(rename = "ref")]
     reporef: RepoRef,
+    #[serde(rename = "rsync")]
+    resync: bool,
     #[serde(rename = "b")]
     branch_filter: Option<BranchFilterConfig>,
     #[serde(rename = "ev")]

--- a/server/bleep/src/background/sync.rs
+++ b/server/bleep/src/background/sync.rs
@@ -164,7 +164,6 @@ impl SyncHandle {
         };
 
         let (exited, exit_signal) = flume::bounded(1);
-        let pipes = SyncPipes::new(reporef.clone(), filter_updates.clone(), status);
         let current = app
             .repo_pool
             .entry_async(reporef.clone())
@@ -195,6 +194,13 @@ impl SyncHandle {
                     }
                 }
             });
+
+        let pipes = SyncPipes::new(
+            reporef.clone(),
+            current.get().last_index_unix_secs != 0,
+            filter_updates.clone(),
+            status,
+        );
 
         // if we're not upgrading from shallow to full checkout
         // this seems to be a speed optimization for git operations

--- a/server/bleep/src/repo.rs
+++ b/server/bleep/src/repo.rs
@@ -354,12 +354,8 @@ impl Repository {
 
         if shallow {
             self.sync_status = SyncStatus::Shallow
-        } else {
-            if let Some(ref ff) = filter_update.file_filter {
-                self.file_filter = ff.patch_into(&self.file_filter);
-            }
-
-            self.sync_status = SyncStatus::Done
+        } else if let Some(ref ff) = filter_update.file_filter {
+            self.file_filter = ff.patch_into(&self.file_filter);
         };
     }
 }


### PR DESCRIPTION
This PR avoids sending duplicate index status updates to the frontend. In `set_status` we only send an event if the `new_status != old_status`.

It also adds a new `re-sync (rsync)` field to `Progress` events so that the FE can distinguish initial indexing and display toasts.