### PR TITLE
Path search edits

### DIFF
--- a/server/bleep/src/agent.rs
+++ b/server/bleep/src/agent.rs
@@ -462,9 +462,7 @@ impl Agent {
         &'a self,
         query: &str,
     ) -> impl Iterator<Item = FileDocument> + 'a {
-        
         let langs = self.last_exchange().query.langs.iter().map(Deref::deref);
-
         let user_id = self.user.username().expect("didn't have user ID");
 
         let (repos, branches): (Vec<_>, Vec<_>) = sqlx::query! {
@@ -490,7 +488,7 @@ impl Agent {
         self.app
             .indexes
             .file
-            .skim_fuzzy_path_match(repos.into_iter(),query, branch.as_deref(),  50)
+            .skim_fuzzy_path_match(repos.into_iter(), query, branch.as_deref(), langs, 50)
             .await
     }
 

--- a/server/bleep/src/agent.rs
+++ b/server/bleep/src/agent.rs
@@ -462,6 +462,7 @@ impl Agent {
         &'a self,
         query: &str,
     ) -> impl Iterator<Item = FileDocument> + 'a {
+        
         let langs = self.last_exchange().query.langs.iter().map(Deref::deref);
 
         let user_id = self.user.username().expect("didn't have user ID");
@@ -480,6 +481,7 @@ impl Agent {
             let repo_ref = RepoRef::from_str(&row.repo_ref).ok()?;
             Some((repo_ref, row.branch))
         })
+        .filter(|(repo_ref, _)| self.repo_refs.contains(repo_ref))
         .unzip();
 
         let branch = branches.first().cloned().flatten();
@@ -488,7 +490,7 @@ impl Agent {
         self.app
             .indexes
             .file
-            .fuzzy_path_match(repos.into_iter(), branch.as_deref(), query, langs, 50)
+            .skim_fuzzy_path_match(repos.into_iter(),query, branch.as_deref(),  50)
             .await
     }
 

--- a/server/bleep/src/agent/tools/path.rs
+++ b/server/bleep/src/agent/tools/path.rs
@@ -64,7 +64,7 @@ impl Agent {
 
         let mut paths = paths
             .iter()
-            .map(|repo_path| (self.get_path_alias(repo_path), repo_path.path.to_string()))
+            .map(|repo_path| (self.get_path_alias(repo_path), repo_path.to_string()))
             .collect::<Vec<_>>();
         paths.sort_by(|a: &(usize, String), b| a.0.cmp(&b.0)); // Sort by alias
 

--- a/server/bleep/src/webserver/search.rs
+++ b/server/bleep/src/webserver/search.rs
@@ -64,6 +64,7 @@ pub(super) async fn fuzzy_path(
             repo_refs,
             target,
             q.first_branch().as_deref(),
+            std::iter::empty(),
             args.page_size,
         )
         .await


### PR DESCRIPTION
Use `skim_fuzzy_path_match` rather than `fuzzy_path_match` in the agent. Remove the now unused path match implementation.