### PR TITLE
Fix code search on local repos

### DIFF
--- a/server/bleep/src/agent.rs
+++ b/server/bleep/src/agent.rs
@@ -432,7 +432,7 @@ impl Agent {
             target: Some(query),
             repos: repos
                 .iter()
-                .map(RepoRef::display_name)
+                .map(RepoRef::indexed_name)
                 .map(|r| parser::Literal::Plain(r.into()))
                 .collect(),
             paths,

--- a/server/bleep/src/agent.rs
+++ b/server/bleep/src/agent.rs
@@ -432,7 +432,7 @@ impl Agent {
             target: Some(query),
             repos: repos
                 .iter()
-                .map(RepoRef::to_string)
+                .map(RepoRef::display_name)
                 .map(|r| parser::Literal::Plain(r.into()))
                 .collect(),
             paths,

--- a/server/bleep/src/semantic.rs
+++ b/server/bleep/src/semantic.rs
@@ -808,14 +808,7 @@ fn build_conditions(
     let repo_filter = {
         let conditions = query
             .repos()
-            .map(|r| {
-                if r.contains('/') && !r.starts_with("github.com/") {
-                    format!("github.com/{r}")
-                } else {
-                    r.to_string()
-                }
-            })
-            .map(|r| make_kv_keyword_filter("repo_name", r.as_ref()).into())
+            .map(|r| make_kv_keyword_filter("repo_name", &r).into())
             .collect::<Vec<_>>();
         // one of the above repos should match
         if conditions.is_empty() {


### PR DESCRIPTION
We were making semantic queries with the full stringified repo ref. Instead, we should have been constructing a semantic query using the repository display name.

It seems that this was fixed coincidentally in #1190 via a condition (which might now be possible to remove).