### PR TITLE
Save tutorial state on user profile

### DIFF
--- a/server/bleep/src/user.rs
+++ b/server/bleep/src/user.rs
@@ -14,6 +14,8 @@ pub struct UserProfile {
     prompt_guide: PromptGuideState,
     #[serde(default = "default_allow_session_recordings")]
     allow_session_recordings: bool,
+    #[serde(default = "default_is_tutorial_finished")]
+    is_tutorial_finished: bool,
 }
 
 impl Default for UserProfile {
@@ -22,10 +24,14 @@ impl Default for UserProfile {
             username: None,
             prompt_guide: PromptGuideState::Active,
             allow_session_recordings: default_allow_session_recordings(),
+            is_tutorial_finished: default_is_tutorial_finished(),
         }
     }
 }
 
 fn default_allow_session_recordings() -> bool {
     true
+}
+fn default_is_tutorial_finished() -> bool {
+    false
 }


### PR DESCRIPTION
when the user first launches bloop for the first time they get tutorial tips, if they finish or skip the tutorial we mark `is_tutorial_finished` as true and don't show the tutorial again.

<a href="https://gitpod.io/#https://github.com/BloopAI/bloop/pull/1210"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

