### PR TITLE
fix blocking status endpoint

### DIFF
--- a/server/bleep/src/indexes/doc.rs
+++ b/server/bleep/src/indexes/doc.rs
@@ -395,6 +395,7 @@ impl Doc {
             match handle {
                 Some(h) => {
                     let s = tokio_stream::wrappers::WatchStream::from_changes(h.progress_stream.clone());
+                    drop(lock);
                     for await progress in s {
                         yield progress;
                     }


### PR DESCRIPTION
the status reporting endpoint can drop the lock over the tantivy index once it has a handle to the progress stream.

<a href="https://gitpod.io/#https://github.com/BloopAI/bloop/pull/1217"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

