### PR TITLE
Explain file in the user-set language

### DIFF
--- a/client/src/Project/CurrentTabContent/ChatTab/ChatPersistentState.tsx
+++ b/client/src/Project/CurrentTabContent/ChatTab/ChatPersistentState.tsx
@@ -249,6 +249,7 @@ const ChatPersistentState = ({
         }
         queryParams.line_start = options.lines[0].toString();
         queryParams.line_end = options.lines[1].toString();
+        queryParams.q = query;
       } else {
         queryParams.q = query;
       }
@@ -480,7 +481,7 @@ const ChatPersistentState = ({
       const [lineStart, lineEnd] = ending.split('-');
       const filePath = prefix.slice(9);
       userQuery = t(
-        `Explain the purpose of the file {{filePath}}, from lines {{lineStart}} - {{lineEnd}}`,
+        `Explain lines {{lineStart}} - {{lineEnd}} in {{filePath}}`,
         {
           lineStart: Number(lineStart) + 1,
           lineEnd: Number(lineEnd) + 1,

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -537,5 +537,6 @@
 	"Simplified": "Simplified",
 	"Recommended: The classic input": "Recommended: The classic input",
 	"Fallback: Use if experiencing problems with the default one": "Fallback: Use if experiencing problems with the default one",
-	"Add multiple files": "Add multiple files"
+	"Add multiple files": "Add multiple files",
+	"Explain lines {{lineStart}} - {{lineEnd}} in {{filePath}}": "Explain lines {{lineStart}} - {{lineEnd}} in {{filePath}}"
 }

--- a/client/src/locales/es.json
+++ b/client/src/locales/es.json
@@ -536,5 +536,7 @@
 	"Select the input type to use in conversations": "Seleccione el tipo de entrada a usar en conversaciones",
 	"Default": "Por defecto",
 	"Recommended: The classic input": "Recomendado: la entrada clásica",
-	"Add multiple files": "Agregar varios archivos"
+	"Add multiple files": "Agregar varios archivos",
+	"Simplified": "Simplificada",
+	"Explain lines {{lineStart}} - {{lineEnd}} in {{filePath}}": "Explique las líneas {{lineStart}} - {{lineEnd}} en {{filePath}}"
 }

--- a/client/src/locales/it.json
+++ b/client/src/locales/it.json
@@ -518,5 +518,6 @@
 	"Select the input type to use in conversations": "Seleziona il tipo di input da utilizzare nelle conversazioni",
 	"Recommended: The classic input": "Consigliato: l'ingresso classico",
 	"Conversation input": "Input di conversazione",
-	"Add multiple files": "Aggiungi più file"
+	"Add multiple files": "Aggiungi più file",
+	"Explain lines {{lineStart}} - {{lineEnd}} in {{filePath}}": "Spiega le righe {{lineStart}} - {{lineEnd}} in {{filePath}}"
 }

--- a/client/src/locales/ja.json
+++ b/client/src/locales/ja.json
@@ -523,5 +523,7 @@
 	"Default": "デフォルト",
 	"Recommended: The classic input": "推奨：クラシック入力",
 	"Conversation input": "会話の入力",
-	"Add multiple files": "複数のファイルを追加します"
+	"Add multiple files": "複数のファイルを追加します",
+	"Explain lines {{lineStart}} - {{lineEnd}} in {{filePath}}": "{{filePath}} の行 {{lineStart}} - {{lineEnd}} について説明します",
+	"Add to studio": "スタジオに追加します"
 }

--- a/client/src/locales/zh-CN.json
+++ b/client/src/locales/zh-CN.json
@@ -533,5 +533,6 @@
 	"Select the input type to use in conversations": "选择要在对话中使用的输入类型",
 	"Default": "默认",
 	"Recommended: The classic input": "推荐：经典输入",
-	"Add multiple files": "添加多个文件"
+	"Add multiple files": "添加多个文件",
+	"Explain lines {{lineStart}} - {{lineEnd}} in {{filePath}}": "解释 {{filePath}} 中的 {{lineStart}} - {{lineEnd}} 行"
 }

--- a/server/bleep/src/webserver/answer.rs
+++ b/server/bleep/src/webserver/answer.rs
@@ -387,6 +387,7 @@ pub struct Explain {
     pub branch: Option<String>,
     pub repo_ref: RepoRef,
     pub conversation_id: Option<i64>,
+    pub q: String,
 }
 
 pub async fn explain(
@@ -403,12 +404,7 @@ pub async fn explain(
 
     // We synthesize a virtual `/answer` request.
     let virtual_req = Answer {
-        q: format!(
-            "Explain lines {} - {} in {}",
-            params.line_start + 1,
-            params.line_end + 1,
-            params.relative_path
-        ),
+        q: params.q,
         conversation_id: params.conversation_id,
         parent_exchange_id: None,
         answer_model: agent::model::GPT_4_TURBO_24K,


### PR DESCRIPTION
Explain file endpoint now accepts a q param which is the same query as we constructed before but localized to user language. This way it shows correctly in conversation history and the response is in the same language.