### PR TITLE
Remove updater (OSS)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4065,12 +4065,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
-name = "minisign-verify"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "933dca44d65cdd53b355d0b73d380a2ff5da71f87f036053188bf1eab6a19881"
-
-[[package]]
 name = "miniz_oxide"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6806,7 +6800,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9bfe673cf125ef364d6f56b15e8ce7537d9ca7e4dae1cf6fbbdeed2e024db3d9"
 dependencies = [
  "anyhow",
- "base64 0.21.5",
  "bytes",
  "cocoa",
  "dirs-next",
@@ -6820,7 +6813,6 @@ dependencies = [
  "heck 0.4.1",
  "http",
  "ignore",
- "minisign-verify",
  "objc",
  "once_cell",
  "open",
@@ -6847,14 +6839,12 @@ dependencies = [
  "tauri-utils",
  "tempfile",
  "thiserror",
- "time",
  "tokio",
  "url",
  "uuid",
  "webkit2gtk",
  "webview2-com",
  "windows 0.39.0",
- "zip",
 ]
 
 [[package]]

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -17,7 +17,7 @@ tauri-build = { version = "1.4.1", features = [] }
 [dependencies]
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
-tauri = { version = "1.5.0", features = ["dialog-open", "fs-all", "http-all", "native-tls-vendored", "os-all", "path-all", "process-all", "shell-all", "updater", "window-all"] }
+tauri = { version = "1.5.0", features = ["dialog-open", "fs-all", "http-all", "native-tls-vendored", "os-all", "path-all", "process-all", "shell-all", "window-all"] }
 bleep = { path = "../../../server/bleep", package = "bleep" }
 anyhow = "1.0.75"
 tokio = { version = "1.32.0", features = ["rt-multi-thread"] }

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -85,14 +85,6 @@
     "security": {
       "csp": null
     },
-    "updater": {
-      "active": true,
-      "endpoints": [
-        "https://api.bloop.ai/releases/{{target}}/{{current_version}}"
-      ],
-      "dialog": true,
-      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDNGQkQ2RjRBNEM3OURFQ0IKUldUTDNubE1TbSs5UDVIMms5dTU2cVk4cGt4Zzl3bkRXU2UvSzliZktUQTQ5TXFWcmpwb1RvYXMK"
-    },
     "windows": [
       {
         "fullscreen": false,


### PR DESCRIPTION
To fix local builds for our users and contributors the updater section should be removed from tauri.config.json, otherwise it requires having a private key in the environment, as mentioned in #1263 