### PR TITLE
Null values, rate limit fix and gpt-4o

### DIFF
--- a/server/bleep/src/llm/call.rs
+++ b/server/bleep/src/llm/call.rs
@@ -123,6 +123,7 @@ pub async fn llm_call(
         Some(Err(reqwest_eventsource::Error::InvalidStatusCode(status, _))) => {
             error!("{}", &status);
             if status == 429 {
+                response.close();
                 println!("Rate limit exceeded, try again after 5s");
                 tokio::time::sleep(Duration::from_secs(5)).await;
                 let openai_key = req.openai_key.clone();

--- a/server/bleep/src/llm/call.rs
+++ b/server/bleep/src/llm/call.rs
@@ -87,7 +87,7 @@ pub async fn llm_call(
 
     let model = match req.model.as_deref() {
         Some(model) => model.to_owned(),
-        None => "gpt-4-turbo".into(),
+        None => "gpt-4o".into(),
     };
     //filter out Null values from messages
 

--- a/server/bleep/src/llm/client.rs
+++ b/server/bleep/src/llm/client.rs
@@ -73,7 +73,7 @@ pub mod api {
         pub functions: Vec<Function>,
     }
 
-    #[derive(Debug, serde::Serialize, serde::Deserialize)]
+    #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
     pub struct LLMRequest {
         pub openai_key: String,
         pub messages: Messages,


### PR DESCRIPTION
I had problem with running the built executable (since it is necessary to build, see #1286) so I made some changes in the source code that may fix issues for those who want to continue using this awesome application.

Small changes but includes:
- fixing openai requests ended up in `400 Bad Request`
- trying again requests failed with `429 Rate Limitation` after 5 seconds delay
- default model changed to `gpt-4o` instead of `gpt-4-Turbo` which is [2 times faster on half price](https://platform.openai.com/docs/models/gpt-4o)
- logging sent messages to see how Bleep communicates with OpenAI : )